### PR TITLE
Quote escaping for Event Recorder

### DIFF
--- a/ilastik/utility/gui/eventRecorder/eventRecorder.py
+++ b/ilastik/utility/gui/eventRecorder/eventRecorder.py
@@ -217,6 +217,8 @@ def playback_events(player):
 
         # Write all events and comments
         for eventstr, objname, timestamp_in_seconds in self._captured_events:
+            eventstr = eventstr.replace('\\', '\\\\')
+            eventstr = eventstr.replace('"', r'\"')
             if objname == "comment":
                 fileobj.write(
 """


### PR DESCRIPTION
This should be fixing #246, but there might be some special cases that aren't met.
