### PR TITLE
Removed the empty QWidget which covered the z-spinbox (fixes #115)

### DIFF
--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -147,7 +147,7 @@ class LayerViewerGui(QWidget):
         self.__viewerControlWidget = None
         if not centralWidgetOnly:
             self.initViewerControlUi() # Might be overridden in a subclass. Default implementation loads a standard layer widget.
-            self._drawer = QWidget( self )
+            #self._drawer = QWidget( self )
             self.initAppletDrawerUi() # Default implementation loads a blank drawer from drawer.ui.
         
     def _after_init(self):


### PR DESCRIPTION
Now the z-spinbox is usable again - if this bugfix raises any new errors, please report them.
