### PR TITLE
Fixes the xcb/X11-error of the EventRecorder script playback on Ubuntu

### DIFF
--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -1,11 +1,12 @@
 import os
+import platform 
 
 #make the program quit on Ctrl+C
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 from PyQt4.QtGui import QApplication, QSplashScreen, QPixmap
-from PyQt4.QtCore import QTimer
+from PyQt4.QtCore import Qt, QTimer
 from ilastik.shell.gui.ilastikShell import IlastikShell, SideSplitterSizePolicy
 
 # Logging configuration
@@ -22,7 +23,19 @@ def startShellGui(workflowClass=None,*testFuncs):
     """
     Create an application and launch the shell in it.
     """
+
+    """
+    The next two lines fix the following xcb error on Ubuntu by calling X11InitThreads before loading the QApplication:
+       [xcb] Unknown request in queue while dequeuing 
+       [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called 
+       [xcb] Aborting, sorry about that.
+       python: ../../src/xcb_io.c:178: dequeue_pending_request: Assertion !xcb_xlib_unknown_req_in_deq failed.
+    """
+    if 'Ubuntu' in platform.platform():
+        QApplication.setAttribute(Qt.AA_X11InitThreads,True)
+    
     app = QApplication([])
+
     QTimer.singleShot( 0, functools.partial(launchShell, workflowClass, *testFuncs ) )
     
     _applyStyleSheet(app)

--- a/ilastik/utility/gui/eventRecorder/eventRecorder.py
+++ b/ilastik/utility/gui/eventRecorder/eventRecorder.py
@@ -67,6 +67,11 @@ class EventPlayer(object):
         """
         _globals = {}
         _locals = {}
+        """ 
+        Calls to events in the playback script like: player.post_event(obj,PyQt4.QtGui.QMouseEvent(...),t)
+        are/were responsible for the xcb-error on Ubuntu, because you may not use
+        a Gui-object from a thread other than the MainThread running the Gui
+        """
         execfile(path, _globals, _locals)
         def run():
             _locals['playback_events'](player=self)
@@ -79,10 +84,8 @@ class EventPlayer(object):
     def post_event(self, obj, event, timestamp_in_seconds):
         if self._playback_speed is not None:
             self._timer.sleep_until(timestamp_in_seconds / self._playback_speed)
-
         assert threading.current_thread().name != "MainThread"
         QApplication.postEvent(obj, event)
-        
         assert QApplication.instance().thread() == obj.thread()
         
         flusher = EventFlusher()


### PR DESCRIPTION
Now the playback of prerecorded scripts works fine on Ubuntu as well (there was some xcb-error before due to conflicts with different threads probably accessing the same Gui-elements).

I hope it also fixes the sporadic segfaults within the same action - I didn't notice any after fixing this xcb stuff.
