### PR TITLE
Counting workflow title "Data Selection" -> "Input Data"

### DIFF
--- a/ilastik/workflows/counting/countingWorkflow.py
+++ b/ilastik/workflows/counting/countingWorkflow.py
@@ -30,8 +30,8 @@ class CountingWorkflow(Workflow):
         self.projectMetadataApplet = ProjectMetadataApplet()
 
         self.dataSelectionApplet = DataSelectionApplet(self,
-                                                       "Data Selection",
-                                                       "DataSelection",
+                                                       "Input Data",
+                                                       "Input Data",
                                                        batchDataGui=False,
                                                        force5d=False
                                                       )


### PR DESCRIPTION
All work flows use the title "Input Data" to refer to the DataSelectionApplet,
apart from counting. This patch changes counting to use "Input Data" as the
title for consistency.

We could also consider changing all other workflows to use "Data Selection" of course.
