### PR TITLE
added h5 clean-up for failed loadProject() calls

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1031,7 +1031,10 @@ class IlastikShell( QMainWindow ):
 
         except Exception, e:
             traceback.print_exc()
-            QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + e.message)
+            QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + str(e))
+
+            # no project will be loaded, free the file resource
+            hdf5File.close()
         else:
 
             try:
@@ -1050,7 +1053,16 @@ class IlastikShell( QMainWindow ):
             except Exception as ex:
                 traceback.print_exc()
                 self.closeCurrentProject()
-                QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + ex.message)
+
+                # _loadProject failed, so we cannot expect it to clean up
+                # the hdf5 file (but it might have cleaned it up, so we catch 
+                # the error)
+                try:
+                    hdf5File.close()
+                except:
+                    pass
+                QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + str(ex))
+
             else:
                 stop = time.time()
                 print "Loading the project took %f sec." % (stop-start,)


### PR DESCRIPTION
The _loadProject function (at projectManager.py:381) raises an error, and the caller catches a general Exception (at ilastikShell.py:1053) and can therefore not rely on anything being cleaned up, even if he calls `_closeCurrentProject()`.

Addition:
`Exception.message` seems to be deprecated, replaced it with `str(Exception)`.

Steps to reproduce:
1. start new workflow (e.g. pixel classification)
2. add an image 
3. save and close ilastik
4. move the image
5. restart ilastik 
6. try to open the project
7. in the dialog box, click on cancel
8. start new workflow
9. try to save as the same file
10. h5py throws an error because it cannot open the same file twice
