### PR TITLE
rewrite of ThresholdTwoLevels (squashed)

### DIFF
--- a/tests/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
+++ b/tests/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
@@ -471,12 +471,6 @@ class TestThresholdTwoLevels(Generator2):
         out5d = vigra.taggedView(out5d[0:1, ...], axistags=oper5d.Output.meta.axistags)
 
         self.checkResult(out5d)
-
-        vigra.writeHDF5(self.data, "/tmp/input_inner_operator.h5", "/volume/data")
-        vigra.writeHDF5(self.data5d, "/tmp/input.h5", "/volume/data")
-        vigra.writeHDF5(output, "/tmp/TTL_inner_operator.h5", "/volume/data")
-        vigra.writeHDF5(out5d, "/tmp/TTL.h5", "/volume/data")
-
         numpy.testing.assert_array_equal(out5d[0:1, ...], output)
 
     def thresholdTwoLevels(self, data):


### PR DESCRIPTION
I squashed the bugfixes.

commit e93dff0bb3fac67e9ff2d847f3eab8a18734a9de
Author: Markus Döring webmaster@burgerdev.de
Date:   Thu Feb 20 15:20:23 2014 +0100

```
OpFilterLabels5d.propagateDirty now handles input slots correctly
```

commit 2e5e9a7489329b6f3e5a39fc38f45b62968262a7
Author: Markus Döring webmaster@burgerdev.de
Date:   Wed Feb 19 17:07:33 2014 +0100

```
fixed endless loop bug
```

commit 1afbca5225d1b4f306b0891665421c0da2947787
Author: Markus Döring webmaster@burgerdev.de
Date:   Tue Feb 18 16:55:06 2014 +0100

```
rewrite of ThresholdTwoLevels for 'large-t' data
```
