### PR TITLE
Replace counting label operator

### DIFF
--- a/ilastik/applets/counting/countingGui.py
+++ b/ilastik/applets/counting/countingGui.py
@@ -129,8 +129,8 @@ class CountingGui(LabelingGui):
         labelSlots = LabelingGui.LabelingSlots()
         labelSlots.labelInput = topLevelOperatorView.LabelInputs
         labelSlots.labelOutput = topLevelOperatorView.LabelImages
-        labelSlots.labelEraserValue = topLevelOperatorView.opLabelPipeline.opLabelArray.eraser
-        labelSlots.labelDelete = topLevelOperatorView.opLabelPipeline.opLabelArray.deleteLabel
+        labelSlots.labelEraserValue = topLevelOperatorView.opLabelPipeline.opLabelArray.EraserLabelValue
+        labelSlots.labelDelete = topLevelOperatorView.opLabelPipeline.opLabelArray.DeleteLabel
         labelSlots.maxLabelValue = topLevelOperatorView.MaxLabelValue
         labelSlots.labelsAllowed = topLevelOperatorView.LabelsAllowedFlags
         labelSlots.labelNames = topLevelOperatorView.LabelNames


### PR DESCRIPTION
@buotex, I am working to eliminate `OpBlockedSparseLabelArray` and `OpSparseLabelArray` from the ilastik code base, since they can be replaced with faster alternatives.  (Eventually we will probably use something from the `blockedarray` repo for labeling, but for now I'm using pure-python alternatives.)  

Anyway, I hacked a bit on the counting top-level operator to replace the labeling operator.  Instead of `OpBlockedSparseLabelArray`, it now uses `OpDenseLabelArray` (which was originally written for the Carving workflow.  It is faster because it doesn't store a sparse representation of the labels -- it just stores the raw array data.

These changes seem to work just fine in my testing (and all counting unit/regression tests still pass...).  Still, I'd like it if you could just give it a quick try and hit "merge" on this PR if you don't see any issues.  Thanks!
