### PR TITLE
[Thresholding] use the correct axes in OpGauss vigra call

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/opThresholdTwoLevels.py
+++ b/ilastik/applets/thresholdTwoLevels/opThresholdTwoLevels.py
@@ -202,8 +202,8 @@ class OpThresholdTwoLevels(Operator):
         self._cache.Input.setDirty(slice(None))
 
     def checkConstraints(self, *args):
-        if self.InputImage.ready():
-            numChannels = self.InputImage.meta.getTaggedShape()['c']
+        if self._opReorder1.Output.ready():
+            numChannels = self._opReorder1.Output.meta.getTaggedShape()['c']
             if self.Channel.value >= numChannels:
                 raise DatasetConstraintError(
                     "Two-Level Thresholding",


### PR DESCRIPTION
fixes #945
