### PR TITLE
Cleanup convenience methods applet serializer

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -52,8 +52,11 @@ def getOrCreateGroup(parentGroup, groupName):
 
 def deleteIfPresent(parentGroup, name):
     """Deletes parentGroup[name], if it exists."""
-    if name in parentGroup:
+
+    try:
         del parentGroup[name]
+    except KeyError:
+        pass
 
 def slicingToString(slicing):
     """Convert the given slicing into a string of the form

--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -47,9 +47,8 @@ def getOrCreateGroup(parentGroup, groupName):
     necessary.
 
     """
-    if groupName in parentGroup:
-        return parentGroup[groupName]
-    return parentGroup.create_group(groupName)
+
+    return parentGroup.require_group(groupName)
 
 def deleteIfPresent(parentGroup, name):
     """Deletes parentGroup[name], if it exists."""

--- a/tests/test_applets/base/testSerializer.py
+++ b/tests/test_applets/base/testSerializer.py
@@ -29,6 +29,7 @@ from lazyflow.graph import Graph, Operator, InputSlot, Slot, OperatorWrapper
 from lazyflow.operators import OpCompressedUserLabelArray
 
 from ilastik.applets.base.appletSerializer import \
+    getOrCreateGroup, deleteIfPresent, \
     SerialSlot, SerialListSlot, AppletSerializer, SerialDictSlot, SerialBlockSlot
 
 class OpMock(Operator):
@@ -60,6 +61,60 @@ class OpMockSerializer(AppletSerializer):
 
 def randArray():
     return numpy.random.randn(10, 10)
+
+
+class TestHDF5HelperFunctions(unittest.TestCase):
+    def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
+        self.tmpFile = h5py.File(os.path.join(self.tmpDir, "test.h5"), "a")
+        self.tmpFile.create_group("a")
+        self.tmpFile.create_dataset("c", (2,2), dtype=numpy.int)
+
+    def test_getOrCreateGroup_1(self):
+        self.assertTrue("a" in self.tmpFile)
+        self.assertTrue(isinstance(self.tmpFile["a"], h5py.Group))
+
+        group = getOrCreateGroup(self.tmpFile, "a")
+
+        self.assertEqual(group.name, "/a")
+        self.assertTrue("a" in self.tmpFile)
+        self.assertTrue(isinstance(self.tmpFile["a"], h5py.Group))
+
+    def test_getOrCreateGroup_2(self):
+        self.assertTrue("b" not in self.tmpFile)
+
+        group = getOrCreateGroup(self.tmpFile, "b")
+
+        self.assertEqual(group.name, "/b")
+        self.assertTrue("b" in self.tmpFile)
+        self.assertTrue(isinstance(self.tmpFile["b"], h5py.Group))
+
+    def test_getOrCreateGroup_3(self):
+        self.assertTrue("c" in self.tmpFile)
+        self.assertTrue(isinstance(self.tmpFile["c"], h5py.Dataset))
+
+        self.assertRaises(TypeError, lambda : getOrCreateGroup(self.tmpFile, "c"))
+
+        self.assertTrue("c" in self.tmpFile)
+        self.assertTrue(isinstance(self.tmpFile["c"], h5py.Dataset))
+
+    def test_deleteIfPresent_1(self):
+        self.assertTrue("a" in self.tmpFile)
+
+        deleteIfPresent(self.tmpFile, "a")
+
+        self.assertTrue("a" not in self.tmpFile)
+
+    def test_deleteIfPresent_2(self):
+        self.assertTrue("b" not in self.tmpFile)
+
+        deleteIfPresent(self.tmpFile, "b")
+
+        self.assertTrue("b" not in self.tmpFile)
+
+    def tearDown(self):
+        self.tmpFile.close()
+        shutil.rmtree(self.tmpDir)
 
 
 class TestSerializer(unittest.TestCase):


### PR DESCRIPTION
Changed the convenience methods so that `getOrCreateGroup` takes advantage of the method `require_group` from h5py, which does the same thing. Also, this ensures that an existing dataset might not be returned instead of a group. Now, an error will be raised. Changed `deleteIfPresent` to simply attempt deleting and handle an exception in the case that the item does not exist as opposed to performing the search twice.