### PR TITLE
Add 4 channel support for RGBA layers in the LayerViewerGui

### DIFF
--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -266,7 +266,7 @@ class LayerViewerGui(QWidget):
                     "Your image has {} channels.".format(numChannels)
 
             # Automatically select Grayscale or RGBA based on number of channels
-            if numChannels == 2 or numChannels == 3:
+            if numChannels == 2 or numChannels == 3 or numChannels == 4:
                 display_mode = "rgba"
             else:
                 display_mode = "grayscale"


### PR DESCRIPTION
For some reason, only 2 or 3 channels were considered to be an RGBA, but 4 was excluded. As a result, supplying 4 channels made one's layer behave as if it were grayscale. As it turns out, the rest of the function correctly handles the alpha channel with this change in place. As it is helpful to set the alpha layer in some cases (transparent background) and it behave properly, it doesn't make sense to exclude the case of 4 channels. Thus, this PR is offered to enable 4 channel/alpha support.
