### PR TITLE
Provide serialization support for masked arrays

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -448,7 +448,12 @@ class SerialBlockSlot(SerialSlot):
                     block_group = subgroup.create_group(blockName)
 
                     block_group.create_dataset("data", data=block.data)
-                    block_group.create_dataset("mask", data=block.mask)
+                    block_group.create_dataset(
+                        "mask",
+                        data=block.mask,
+                        compression="gzip",
+                        compression_opts=2
+                    )
                     block_group.create_dataset("fill_value", data=block.fill_value)
 
                     block_group.attrs['blockSlice'] = slicingToString(slicing)

--- a/tests/test_applets/base/testSerializer.py
+++ b/tests/test_applets/base/testSerializer.py
@@ -486,5 +486,6 @@ class TestSerialBlockSlot(unittest.TestCase):
         os.remove(h5_filepath)
         shutil.rmtree(tmp_dir)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is related to ( https://github.com/ilastik/ilastik/issues/1076 ). It relies on features from this PR to function correctly ( https://github.com/ilastik/lazyflow/pull/164 ).

Provides support for serializing masked arrays from caches using SerialBlockSlot. Has tests to make sure serialization is working correctly.