### PR TITLE
Fixing ilastik/ilastik-#1107

### DIFF
--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -28,6 +28,7 @@ def flatten_tracking_table(table, extra_table, obj_counts, max_tracks, t_range):
 
 
 def flatten_ilastik_feature_table(table, selection, signal):
+    selection = list(selection)
     frames = table.meta.shape[0]
 
     signal(0)


### PR DESCRIPTION
This fixes the issue ilastik#1107.

Apparently ``if x in iterable: ...`` advances the iterator, which was not intended here.