### PR TITLE
Include opengm before everything else to enable graph cut thresholding

### DIFF
--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -33,7 +33,7 @@ import splashScreen
 import ilastik.config
 shell = None
 
-def startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, *testFuncs):
+def startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, preinit_funcs, postinit_funcs):
     """
     Create an application and launch the shell in it.
     """
@@ -63,7 +63,7 @@ def startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, *test
 
     splashScreen.showSplashScreen()
     app.processEvents()
-    QTimer.singleShot( 0, functools.partial(launchShell, workflow_cmdline_args, *testFuncs ) )
+    QTimer.singleShot( 0, functools.partial(launchShell, workflow_cmdline_args, preinit_funcs, postinit_funcs ) )
     QTimer.singleShot( 0, splashScreen.hideSplashScreen)
 
     return app.exec_()
@@ -78,11 +78,14 @@ def _applyStyleSheet(app):
         app.setStyleSheet(styleSheetText)
 
 
-def launchShell(workflow_cmdline_args, *testFuncs):
+def launchShell(workflow_cmdline_args, preinit_funcs, postinit_funcs):
     """
     Start the ilastik shell GUI with the given workflow type.
     Note: A QApplication must already exist, and you must call this function from its event loop.
     """
+    for f in preinit_funcs:
+        f()
+
     # This will import a lot of stuff (essentially the entire program).
     # We use a late import here so the splash screen is shown while this lengthy import happens.
     from ilastik.shell.gui.ilastikShell import IlastikShell
@@ -109,9 +112,9 @@ def launchShell(workflow_cmdline_args, *testFuncs):
         workflow_cmdline_args.remove('--fullscreen')
         shell.showMaximized()
     
-    # Run a test (if given)
-    for testFunc in testFuncs:
-        QTimer.singleShot(0, functools.partial(testFunc, shell) )
+    # Run post-init funcs
+    for f in postinit_funcs:
+        QTimer.singleShot(0, functools.partial(f, shell) )
     
     # On Mac, the main window needs to be explicitly raised
     shell.raise_()

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -1,13 +1,6 @@
 import sys
 import os
 
-# Import opengm first if possible, to make sure it is included before vigra.
-# Otherwise the import fails and we will not get access to GraphCut thresholding
-try:
-    import opengm
-except:
-    pass
-
 import ilastik.config
 from ilastik.config import cfg as ilastik_config
 
@@ -56,6 +49,11 @@ def main( parsed_args, workflow_cmdline_args=[] ):
     # Extra initialization functions.
     # Called during app startup.
     init_funcs = []
+
+    # Import opengm first if possible, to make sure it is included before vigra.
+    # Otherwise the import fails and we will not get access to GraphCut thresholding
+    init_funcs.append( _import_opengm )
+    
     lazyflow_config_fn = _prepare_lazyflow_config( parsed_args )
     if lazyflow_config_fn:
         init_funcs.append( lazyflow_config_fn )    
@@ -185,6 +183,14 @@ def _validate_arg_compatibility( parsed_args ):
          parsed_args.exit_on_success ):
         sys.stderr.write("Some of the command-line options you provided are not supported in headless mode.  Exiting.")
         sys.exit(1)
+
+def _import_opengm( parsed_args ):
+    # Import opengm first if possible, to make sure it is included before vigra.
+    # Otherwise the import fails and we will not get access to GraphCut thresholding
+    try:
+        import opengm
+    except:
+        pass
 
 def _prepare_lazyflow_config( parsed_args ):
     # Check environment variable settings.

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -47,26 +47,27 @@ def main( parsed_args, workflow_cmdline_args=[] ):
     _validate_arg_compatibility( parsed_args )
 
     # Extra initialization functions.
-    # Called during app startup.
-    init_funcs = []
-
-    # Import opengm first if possible, to make sure it is included before vigra.
-    # Otherwise the import fails and we will not get access to GraphCut thresholding
-    init_funcs.append( _import_opengm )
+    # These are called during app startup, but before the shell is created.
+    preinit_funcs = []
+    preinit_funcs.append( _import_opengm ) # Must be first (or at least before vigra).
+    preinit_funcs.append( _monkey_patch_h5py )
     
     lazyflow_config_fn = _prepare_lazyflow_config( parsed_args )
     if lazyflow_config_fn:
-        init_funcs.append( lazyflow_config_fn )    
+        preinit_funcs.append( lazyflow_config_fn )
 
-    init_funcs.append( _monkey_patch_h5py )
+    # More initialization functions.
+    # These will be called AFTER the shell is created.
+    # The shell is provided as a parameter to the function.
+    postinit_funcs = []
 
     load_fn = _prepare_auto_open_project( parsed_args )
     if load_fn:
-        init_funcs.append( load_fn )    
+        postinit_funcs.append( load_fn )
     
     create_fn = _prepare_auto_create_new_project( parsed_args )
     if create_fn:
-        init_funcs.append( create_fn )
+        postinit_funcs.append( create_fn )
 
     _enable_faulthandler()
     _init_excepthooks( parsed_args )
@@ -88,16 +89,22 @@ def main( parsed_args, workflow_cmdline_args=[] ):
         import ilastik
         dummy_module_dir = os.path.join( os.path.split(ilastik.__file__)[0], "headless_dummy_modules" )
         sys.path.insert(0, dummy_module_dir)
+
+        # Run pre-init
+        for f in preinit_funcs:
+            f()
         
         from ilastik.shell.headless.headlessShell import HeadlessShell
         shell = HeadlessShell( workflow_cmdline_args )
-        for f in init_funcs:
+
+        # Run post-init
+        for f in postinit_funcs:
             f(shell)
         return shell
     # Normal launch
     else:
         from ilastik.shell.gui.startShellGui import startShellGui
-        sys.exit(startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, *init_funcs))
+        sys.exit(startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, preinit_funcs, postinit_funcs))
 
 def _init_configfile( parsed_args ):
     # If the user provided a custom config path to use instead of the default .ilastikrc,
@@ -184,7 +191,7 @@ def _validate_arg_compatibility( parsed_args ):
         sys.stderr.write("Some of the command-line options you provided are not supported in headless mode.  Exiting.")
         sys.exit(1)
 
-def _import_opengm( parsed_args ):
+def _import_opengm():
     # Import opengm first if possible, to make sure it is included before vigra.
     # Otherwise the import fails and we will not get access to GraphCut thresholding
     try:
@@ -211,7 +218,7 @@ def _prepare_lazyflow_config( parsed_args ):
     
     # Note that n_threads == 0 is valid and useful for debugging.
     if (n_threads is not None) or total_ram_mb:
-        def _configure_lazyflow_settings(shell):
+        def _configure_lazyflow_settings():
             import lazyflow
             import lazyflow.request
             if n_threads is not None:
@@ -227,7 +234,7 @@ def _prepare_lazyflow_config( parsed_args ):
         return _configure_lazyflow_settings
     return None
 
-def _monkey_patch_h5py(shell):
+def _monkey_patch_h5py():
     """
     This workaround avoids error messages from HDF5 when accessing non-existing
     files, datasets, and dataset attributes from non-main threads.

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -1,6 +1,13 @@
 import sys
 import os
 
+# Import opengm first if possible, to make sure it is included before vigra.
+# Otherwise the import fails and we will not get access to GraphCut thresholding
+try:
+    import opengm
+except:
+    pass
+
 import ilastik.config
 from ilastik.config import cfg as ilastik_config
 

--- a/tests/helpers/shellGuiTestCaseBase.py
+++ b/tests/helpers/shellGuiTestCaseBase.py
@@ -122,7 +122,7 @@ class ShellGuiTestCaseBase(object):
             QApplication.setAttribute(Qt.AA_DontUseNativeMenuBar, True)
 
         # Use the thread router to launch the shell in the app thread
-        ShellGuiTestCaseBase.threadRouter.routeToParent.emit( partial(launchShell, None, initTest ) )
+        ShellGuiTestCaseBase.threadRouter.routeToParent.emit( partial(launchShell, None, [], [initTest] ) )
         init_complete.wait()
 
     @classmethod


### PR DESCRIPTION
See #1061. (Including vigra before opengm yields ImportError: cannot import name IndexVector)

This only has an affect if OpenGM is built with the python wrapper, but that should be the case in our binaries.