### PR TITLE
Label Import: Rebased from #1119

### DIFF
--- a/ilastik/applets/labeling/dataImportOptionsDlg.ui
+++ b/ilastik/applets/labeling/dataImportOptionsDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>692</width>
-    <height>410</height>
+    <width>658</width>
+    <height>421</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Image Export Options</string>
+   <string>Label Import Options</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -44,6 +44,26 @@
       <property name="bottomMargin">
        <number>6</number>
       </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="filenameLabel1">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Files:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="inputFilesComboBox"/>
+        </item>
+       </layout>
+      </item>
       <item>
        <widget class="SlotMetaInfoDisplayWidget" name="inputMetaInfoWidget" native="true"/>
       </item>
@@ -89,7 +109,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Insertion Point</string>
+      <string>Insertion Point and Mapping</string>
      </property>
      <property name="checkable">
       <bool>false</bool>
@@ -98,7 +118,7 @@
       <item>
        <widget class="QTableWidget" name="positionWidget">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -195,20 +215,48 @@
        </widget>
       </item>
       <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="QTableWidget" name="mappingWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
+        <property name="rowCount">
+         <number>1</number>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
+        <property name="columnCount">
+         <number>3</number>
         </property>
-       </spacer>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>100</number>
+        </attribute>
+        <row>
+         <property name="text">
+          <string>#</string>
+         </property>
+        </row>
+        <column>
+         <property name="text">
+          <string>map</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>to</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>pixels</string>
+         </property>
+        </column>
+        <item row="0" column="0">
+         <property name="text">
+          <string/>
+         </property>
+        </item>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/ilastik/applets/labeling/dataImportOptionsDlg.ui
+++ b/ilastik/applets/labeling/dataImportOptionsDlg.ui
@@ -271,14 +271,25 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="warningLabel">
+       <property name="text">
+        <string>Warning: Imported X/Y dimensions do not match your original dataset.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/ilastik/applets/labeling/dataImportOptionsDlg.ui
+++ b/ilastik/applets/labeling/dataImportOptionsDlg.ui
@@ -32,16 +32,7 @@
       <string>Source Image Description</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>6</number>
       </property>
       <item>
@@ -67,6 +58,33 @@
       <item>
        <widget class="SlotMetaInfoDisplayWidget" name="inputMetaInfoWidget" native="true"/>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>File Axes:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="axesEdit"/>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -82,16 +100,7 @@
       <string>Destination Labels Description</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_6">
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>6</number>
       </property>
       <item>

--- a/ilastik/applets/labeling/dataImportOptionsDlg.ui
+++ b/ilastik/applets/labeling/dataImportOptionsDlg.ui
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>692</width>
+    <height>410</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Image Export Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox_7">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Source Image Description</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_7">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="SlotMetaInfoDisplayWidget" name="inputMetaInfoWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Destination Labels Description</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
+      <item>
+       <widget class="SlotMetaInfoDisplayWidget" name="labelMetaInfoWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Insertion Point</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QTableWidget" name="positionWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="rowCount">
+         <number>5</number>
+        </property>
+        <property name="columnCount">
+         <number>2</number>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>100</number>
+        </attribute>
+        <row>
+         <property name="text">
+          <string>t</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>y</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>z</string>
+         </property>
+        </row>
+        <row>
+         <property name="text">
+          <string>c</string>
+         </property>
+        </row>
+        <column>
+         <property name="text">
+          <string>insert at</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>max</string>
+         </property>
+        </column>
+        <item row="0" column="0">
+         <property name="text">
+          <string/>
+         </property>
+        </item>
+        <item row="0" column="1">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="flags">
+          <set>ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="1" column="1">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="flags">
+          <set>ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="2" column="1">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="flags">
+          <set>ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="3" column="1">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="flags">
+          <set>ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="4" column="1">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="flags">
+          <set>ItemIsEnabled</set>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SlotMetaInfoDisplayWidget</class>
+   <extends>QWidget</extends>
+   <header>volumina.widgets.slotMetaInfoDisplayWidget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>254</x>
+     <y>341</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>322</x>
+     <y>341</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -805,7 +805,8 @@ class LabelingGui(LayerViewerGui):
             labellayer.name = "Labels"
             labellayer.ref_object = None
 
-            labellayer.contexts.append(("Import...", partial( import_labeling_layer, labellayer, self )))
+            labellayer.contexts.append(("Import...",
+                                        partial( import_labeling_layer, labellayer, self._labelingSlots.labelInput, self )))
 
             return labellayer, labelsrc
 

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -43,16 +43,8 @@ from ilastik.utility import bind, log_exception
 from ilastik.utility.gui import ThunkEventHandler, threadRouted
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
-from volumina.widgets.importHelper import get_settings_and_import_layer
+from ilastik.applets.labeling.labelingImport import import_labeling_layer
 
-###
-### lazyflow input
-###
-try:
-    import lazyflow
-    _has_lazyflow = True
-except ImportError as e:
-    _has_lazyflow = False
 
 # Loggers
 logger = logging.getLogger(__name__)
@@ -813,10 +805,7 @@ class LabelingGui(LayerViewerGui):
             labellayer.name = "Labels"
             labellayer.ref_object = None
 
-            global _has_lazyflow
-            if _has_lazyflow:
-                labellayer.contexts.append(("Import...", partial( get_settings_and_import_layer, labellayer, self )))
-
+            labellayer.contexts.append(("Import...", partial( import_labeling_layer, labellayer, self )))
 
             return labellayer, labelsrc
 

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -806,7 +806,7 @@ class LabelingGui(LayerViewerGui):
             labellayer.ref_object = None
 
             labellayer.contexts.append(("Import...",
-                                        partial( import_labeling_layer, labellayer, self._labelingSlots.labelInput, self )))
+                                        partial( import_labeling_layer, labellayer, self._labelingSlots, self )))
 
             return labellayer, labelsrc
 

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -43,6 +43,17 @@ from ilastik.utility import bind, log_exception
 from ilastik.utility.gui import ThunkEventHandler, threadRouted
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
+from volumina.widgets.importHelper import get_settings_and_import_layer
+
+###
+### lazyflow input
+###
+try:
+    import lazyflow
+    _has_lazyflow = True
+except ImportError as e:
+    _has_lazyflow = False
+
 # Loggers
 logger = logging.getLogger(__name__)
 
@@ -801,6 +812,11 @@ class LabelingGui(LayerViewerGui):
             labellayer = ColortableLayer(labelsrc, colorTable = self._colorTable16, direct=direct )
             labellayer.name = "Labels"
             labellayer.ref_object = None
+
+            global _has_lazyflow
+            if _has_lazyflow:
+                labellayer.contexts.append(("Import...", partial( get_settings_and_import_layer, labellayer, self )))
+
 
             return labellayer, labelsrc
 

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -1,0 +1,436 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2015, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#		   http://ilastik.org/license.html
+###############################################################################
+
+#Python
+from functools import partial
+import collections
+import operator
+import time
+import os
+import numpy
+import vigra
+
+#Qt
+from PyQt4 import uic
+from PyQt4.QtCore import pyqtSignal, Qt, QEvent, QObject
+from PyQt4.QtGui import QDialog, QFileDialog, QMessageBox
+
+#volumina
+from volumina.widgets.multiStepProgressDialog import MultiStepProgressDialog
+from volumina.widgets.subregionRoiWidget import RoiSpinBox
+
+import logging
+logger = logging.getLogger(__name__)
+from volumina.utility import log_exception, PreferencesManager
+
+from ilastik.widgets.stackFileSelectionWidget import StackFileSelectionWidget
+from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui
+
+#lazyflow
+import lazyflow
+from lazyflow.graph import Graph
+from lazyflow.request import Request
+from lazyflow.roi import TinyVector, roiToSlice, roiFromShape
+from lazyflow.operators.ioOperators import OpInputDataReader, OpStackLoader
+from lazyflow.operators.opReorderAxes import OpReorderAxes
+
+
+def import_labeling_layer(layer, parent_widget=None):
+    """
+    Prompt the user for layer import settings, and perform the layer import.
+    """
+    sourceTags = [True for l in layer.datasources]
+    for i, source in enumerate(layer.datasources):
+        if not hasattr(source, "dataSlot"):
+             sourceTags[i] = False
+    if not any(sourceTags):
+        raise RuntimeError("can not import to a non-lazyflow data source (layer=%r, datasource=%r)" % (type(layer), type(layer.datasources[0])) )
+
+    dataSlots = [slot.dataSlot for (slot, isSlot) in
+                 zip(layer.datasources, sourceTags) if isSlot is True]
+    for slot in dataSlots:
+        assert isinstance(slot, lazyflow.graph.Slot), "slot is of type %r" % (type(slot))
+        assert isinstance(slot.getRealOperator(), lazyflow.graph.Operator), "slot's operator is of type %r" % (type(slot.getRealOperator()))
+
+    # TODO: *Finish* make generic, not carving specific, if possible?
+    opLabels = parent_widget._labelingSlots.labelInput.getRealOperator() #dataSlots[0].getRealOperator().parent
+    writeSeeds = parent_widget._labelingSlots.labelInput
+
+    # TODO: use ilastik.shell.projectManager to get project related path?
+    # Find the directory of the most recently opened image file
+    mostRecentImageFile = PreferencesManager().get( 'DataSelection', 'recent image' )
+    if mostRecentImageFile is not None:
+        defaultDirectory = os.path.split(mostRecentImageFile)[0]
+    else:
+        defaultDirectory = os.path.expanduser('~')
+
+    fileNames = DataSelectionGui.getImageFileNamesToOpen(parent_widget, defaultDirectory)
+    fileNames = map(str, fileNames)
+
+    if not fileNames:
+        return
+
+    # Create an operator to do the work
+    opImport = OpInputDataReader( parent=opLabels )
+
+    opImport.WorkingDirectory.setValue(defaultDirectory)
+    opImport.FilePath.setValue(fileNames[0] if len(fileNames) == 1 else
+                               os.path.pathsep.join(fileNames))
+
+    # The reader assumes xyzc order, so we must transpose the data.
+    opReorderAxes = OpReorderAxes( parent=opImport )
+    opReorderAxes.Input.connect( opImport.Output )
+
+    try:
+
+        readData = opReorderAxes.Output[:].wait()
+
+        img_shape_diff = TinyVector(writeSeeds.meta.shape) - TinyVector(readData.shape)
+        is_img_subset = not any(map(lambda x: x < 0, img_shape_diff))
+
+        #expect import is subset
+        if not is_img_subset:
+            QMessageBox.critical(parent_widget, "Import shape too large",
+                                             "Import shape is not a subset of original input stack.")
+            return
+
+        # expect x, y shape to match original shape
+        if any(img_shape_diff[:3]) or any(img_shape_diff[-1:]):
+            QMessageBox.critical(parent_widget, "Shape does not match",
+                                             "X,Y shape must match original input stack.")
+            return
+
+        if any(img_shape_diff):
+            # User has choices: Use this dialog to collect settings
+            settingsDlg = LabelImportOptionsDlg( parent_widget, img_shape_diff, opReorderAxes.Output, writeSeeds )
+            # If user didn't accept, exit now.
+            if ( settingsDlg.exec_() == LabelImportOptionsDlg.Accepted ):
+                img_offset = settingsDlg.img_offset
+            else:
+                return
+        else:
+            img_offset = img_shape_diff
+
+        img_shape = roiFromShape(readData.shape)
+        img_start = TinyVector(img_shape[0]) + img_offset
+        img_end = TinyVector(img_shape[1]) + img_offset
+        img_slice = roiToSlice(img_start, img_end)
+
+        # TODO: ensure that labels are cleared (optional setting)
+        #opCarving.clearCurrentLabeling()
+
+        writeSeeds[img_slice] = readData[:]
+
+        #opCarving.Segmentation.setDirty()
+        #opCarving.Trigger.setDirty()
+
+    finally:
+        # Clean up our temporary operators
+        opReorderAxes.cleanUp()
+        opImport.cleanUp()
+
+
+"""
+    '''
+    # Alternate input UI (for image stacks)
+    stackDlg = StackFileSelectionWidget(parent_widget)
+    stackDlg.exec_()
+    if stackDlg.result() != QDialog.Accepted :
+        return
+    fileNames = stackDlg.selectedFiles
+    '''
+
+    '''
+    # For now, we require a single file
+    if len(fileNames) > 1:
+        QMessageBox.critical(parent_widget, "Too many files",
+                                         "Labels must be contained in a single hdf5 volume.")
+        return
+    '''
+
+    if len(fileNames) == 1:
+        '''
+        # Create an operator to do the work
+        opImport = OpInputDataReader( parent=opCarving )
+
+        opImport.WorkingDirectory.setValue(defaultDirectory)
+        opImport.FilePath.setValue(fileNames[0])
+
+        # The reader assumes xyzc order, so we must transpose the data.
+        opReorderAxes = OpReorderAxes( parent=opImport )
+        opReorderAxes.Input.connect( opImport.Output )
+        '''
+        '''
+        # Another Per-slice image import method
+        filename = fileNames[0]
+
+        imgs_count = vigra.impex.numberImages(filename)
+        for img_idx in range(imgs_count):
+            img = vigra.readImage(filename, dtype=dtype, index=img_idx)
+
+            img_shape = roiFromShape(img.shape)
+            img_slice = roiToSlice(img_shape[0], img_shape[1])
+
+            z = numpy.zeros(img_shape[1], dtype=dtype)
+            z[img_slice] = img[img_slice]
+
+            seedsSlice = (slice(0,1),) + (img_slice[0], img_slice[1], slice(img_idx, img_idx+1)) + (slice(0,1),)
+            opCarving.WriteSeeds[seedsSlice] = z[(numpy.newaxis,) + img_slice + (numpy.newaxis,)]
+
+        # Volume image import method
+        imgs_count = vigra.impex.numberImages(filename)
+        img = vigra.readVolume(filename, dtype=dtype)
+
+        img_shape = roiFromShape(img.shape)
+        img_slice = roiToSlice(img_shape[0], img_shape[1])
+
+        z = numpy.zeros(img_shape[1], dtype=dtype)
+        z[img_slice] = img[img_slice]
+
+        opCarving.WriteSeeds[(slice(0,1),) + img_slice] = z[(numpy.newaxis,) + img_slice]
+
+        '''
+    elif len(fileNames) > 1:
+        '''
+        # Create an operator to do the work
+        opImport = OpStackLoader( parent=opCarving )
+
+        opImport.globstring.setValue(os.path.pathsep.join(fileNames))
+
+        # The reader assumes xyzc order, so we must transpose the data.
+        opReorderAxes = OpReorderAxes( parent=opImport )
+        opReorderAxes.Input.connect( opImport.stack )
+        '''
+
+        '''
+        # Another Per-slice image import method
+        dtype = opCarving.WriteSeeds.meta.dtype
+        img_idx = 0
+
+        for filename in fileNames:
+            img = vigra.readImage(filename, dtype=dtype, index=0)
+
+            img_shape = roiFromShape(img.shape)
+            img_slice = roiToSlice(img_shape[0], img_shape[1])
+
+            z = numpy.zeros(img_shape[1], dtype=dtype)
+            z[img_slice] = img[img_slice]
+
+            seedSlice = (slice(0,1),) + (img_slice[0], img_slice[1], slice(img_idx, img_idx+1)) + (slice(0,1),)
+            opCarving.WriteSeeds[seedSlice] = z[(numpy.newaxis,) + img_slice + (numpy.newaxis,)]
+            img_idx += 1
+        '''
+    #else:
+    #    return # user cancelled
+"""
+
+
+#**************************************************************************
+# LabelImportHelper
+#**************************************************************************
+class LabelImportHelper(QObject):
+    """
+    Executes a layer export in the background, shows a progress dialog, and displays errors (if any).
+    """
+    # This signal is used to ensure that request 
+    #  callbacks are executed in the gui thread
+    _forwardingSignal = pyqtSignal( object )
+
+    def _handleForwardedCall(self, fn):
+        # Execute the callback
+        fn()
+    
+    def __init__(self, parent):
+        super( LabelImportHelper, self ).__init__(parent)
+        self._forwardingSignal.connect( self._handleForwardedCall )
+
+    def run(self, opImport):
+        """
+        Start the import and return immediately (after showing the progress dialog).
+        
+        :param opImport: The import object to execute.
+                         It must have a 'run_import()' method and a 'progressSignal' member.
+        """
+        progressDlg = MultiStepProgressDialog(parent=self.parent())
+        progressDlg.setNumberOfSteps(1)
+
+        def _forwardProgressToGui(progress):
+            self._forwardingSignal.emit( partial( progressDlg.setStepProgress, progress ) )
+
+        def _onFinishImport( *args ): # Also called on cancel
+            self._forwardingSignal.emit( progressDlg.finishStep )
+    
+        def _onFail( exc, exc_info ):
+            log_exception( logger, "Failed to import layer.", exc_info=exc_info )
+            msg = "Failed to import layer due to the following error:\n{}".format( exc )
+            self._forwardingSignal.emit( partial(QMessageBox.critical, self.parent(), "Import Failed", msg) )
+            self._forwardingSignal.emit( progressDlg.setFailed )
+
+        opImport.progressSignal.subscribe( _forwardProgressToGui )
+
+        # Use a request to execute in the background
+        req = Request( opImport.run_import )
+        req.notify_cancelled( _onFinishImport )
+        req.notify_finished( _onFinishImport )
+        req.notify_failed( _onFail )
+
+        # Allow cancel.
+        progressDlg.rejected.connect( req.cancel )
+
+        # Start the import
+        req.submit()
+
+        # Execute the progress dialog
+        # (We can block the thread here because the QDialog spins up its own event loop.)
+        progressDlg.exec_()
+
+
+#**************************************************************************
+# LabelImportOptionsDlg
+#**************************************************************************
+class LabelImportOptionsDlg(QDialog):
+
+    def __init__(self, parent, axisRanges, dataInputSlot, writeSeedsSlot):
+        """
+        Constructor.
+
+        :param parent: The parent widget
+        :param axisRanges: A vector of per-axis maximum values.
+        :param dataInputSlot: Slot with imported data
+        :param writeSeedsSlot: Slot for writing data to
+        """
+        super( LabelImportOptionsDlg, self ).__init__(parent)
+
+        localDir = os.path.split(__file__)[0]
+        uic.loadUi( os.path.join( localDir, "dataImportOptionsDlg.ui" ), self)
+
+        self._axisRanges = axisRanges
+        self._dataInputSlot = dataInputSlot
+        self._writeSeedsSlot = writeSeedsSlot
+
+        self._okay_conditions = {}
+        self._boxes = collections.OrderedDict()
+
+        # Init child widgets
+        self._initMetaInfoWidgets()
+        self._initInsertPositionWidget()
+        # TODO: show list of files in input stack
+        # self._initSourceFilesList()
+
+        # See self.eventFilter()
+        self.installEventFilter(self)
+
+    def eventFilter(self, watched, event):
+        # Ignore 'enter' keypress events, since the user may just be entering settings.
+        # The user must manually click the 'OK' button to close the dialog.
+        if watched == self and \
+           event.type() == QEvent.KeyPress and \
+           ( event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return):
+            return True
+        return False
+
+    def _set_okay_condition(self, name, status):
+        self._okay_conditions[name] = status
+        all_okay = all( self._okay_conditions.values() )
+        self.buttonBox.button(QDialogButtonBox.Ok).setEnabled( all_okay )
+
+
+    #**************************************************************************
+    # Input/Output Meta-info (display only)
+    #**************************************************************************
+    def _initMetaInfoWidgets(self):
+        ## Input/output meta-info display widgets
+        dataInputSlot = self._dataInputSlot
+        self.inputMetaInfoWidget.initSlot( dataInputSlot )
+        writeSeedsSlot = self._writeSeedsSlot
+        self.labelMetaInfoWidget.initSlot( writeSeedsSlot )
+
+    #**************************************************************************
+    # Insertion Position
+    #**************************************************************************
+    def _initInsertPositionWidget(self):
+        dataImportSlot = self._dataInputSlot
+        inputAxes = dataImportSlot.meta.getAxisKeys()
+
+        shape = dataImportSlot.meta.shape
+
+        axisRanges = self._axisRanges
+        insertPos = [0] * len(axisRanges)
+        maxValues = axisRanges
+
+        self._initInsertPositionTableWithExtents(inputAxes, maxValues)
+
+        self.positionWidget.itemChanged.connect( self._handleItemChanged )
+
+    def _initInsertPositionTableWithExtents(self, axes, mx):
+        positionTbl = self.positionWidget
+
+        positionTbl.setColumnCount( 2 )
+        positionTbl.setHorizontalHeaderLabels(["insert at", "max"])
+        positionTbl.resizeColumnsToContents()
+        tagged_insert = collections.OrderedDict( zip(axes, [0]*len(axes)) )
+        tagged_max = collections.OrderedDict( zip(axes, mx) )
+        self._tagged_insert = tagged_insert
+        positionTbl.setRowCount( len(tagged_insert) )
+        positionTbl.setVerticalHeaderLabels( tagged_insert.keys() )
+
+        self._boxes.clear()
+
+        for row, (axis_key, extent) in enumerate(tagged_max.items()):
+            # Init min/max spinboxes
+            default_insert = tagged_insert[axis_key] or 0
+            default_max = tagged_max[axis_key] or extent
+
+            insertBox = RoiSpinBox(self, 0, extent, 0 )
+            maxBox = RoiSpinBox(self, extent, extent, extent )
+
+            insertBox.setPartner( maxBox )
+            maxBox.setPartner( insertBox )
+
+            insertBox.setEnabled( tagged_insert[axis_key] is not None )
+            maxBox.setEnabled( True )
+
+            if insertBox.isEnabled():
+                insertBox.setValue( default_insert )
+            maxBox.setValue( default_max )
+
+            insertBox.valueChanged.connect( self._updatePosition )
+
+            positionTbl.setCellWidget( row, 0, insertBox )
+            positionTbl.setCellWidget( row, 1, maxBox )
+
+            self._boxes[axis_key] = (insertBox, maxBox)
+
+        positionTbl.resizeColumnsToContents()
+
+    def _updatePosition(self):
+        insert_boxes, max_boxes = zip( *self._boxes.values() )
+        box_inserts = map( RoiSpinBox.value, insert_boxes )
+        box_maxes = map( RoiSpinBox.value, max_boxes )
+
+        self.img_offset = box_inserts
+
+    def _handleItemChanged(self, item):
+        if len(self._boxes) == 0:
+            return
+        pos_boxes, max_boxes = zip( *self._boxes.values() )
+
+

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -251,7 +251,10 @@ class LabelImportOptionsDlg(QDialog):
         self._dataInputSlot.notifyMetaChanged( self._initInsertPositionMappingWidgets )
 
     def closeEvent(self, e):
+        # Clean-up
         self._dataInputSlot.unregisterMetaChanged( self._initInsertPositionMappingWidgets )
+        self.inputMetaInfoWidget.initSlot(None)
+        self.labelMetaInfoWidget.initSlot(None)
 
     @staticmethod
     def _defaultImageOffsets(axisRanges, srcInputFiles, dataInputSlot):

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -61,23 +61,26 @@ def import_labeling_layer(labelLayer, labelingSlots, parent_widget=None):
     opLabels = writeSeeds.getRealOperator()
     assert isinstance(opLabels, lazyflow.graph.Operator), "slot's operator is of type %r" % (type(opLabels))
 
-    # Find the directory of the most recently opened project
+
+    recentlyImported = PreferencesManager().get('labeling', 'recently imported')
     mostRecentProjectPath = PreferencesManager().get('shell', 'recently opened')
-    if mostRecentProjectPath:
+    mostRecentImageFile = PreferencesManager().get( 'DataSelection', 'recent image' )
+    if recentlyImported:
+        defaultDirectory = os.path.split(recentlyImported)[0]
+    elif mostRecentProjectPath:
         defaultDirectory = os.path.split(mostRecentProjectPath)[0]
+    elif mostRecentImageFile:
+        defaultDirectory = os.path.split(mostRecentImageFile)[0]
     else:
-        # Find the directory of the most recently opened image file
-        mostRecentImageFile = PreferencesManager().get( 'DataSelection', 'recent image' )
-        if mostRecentImageFile is not None:
-            defaultDirectory = os.path.split(mostRecentImageFile)[0]
-        else:
-            defaultDirectory = os.path.expanduser('~')
+        defaultDirectory = os.path.expanduser('~')
 
     fileNames = DataSelectionGui.getImageFileNamesToOpen(parent_widget, defaultDirectory)
     fileNames = map(str, fileNames)
 
     if not fileNames:
         return
+
+    PreferencesManager().set('labeling', 'recently imported', fileNames[0])
 
     # Initialize operators
     opImport = OpInputDataReader( parent=opLabels.parent )

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -262,8 +262,8 @@ class LabelImportOptionsDlg(QDialog):
 
         # Note: Convenience setting of starting 'z' offset; assumes that filenames are
         # numbered from 0, and they contain only a single number representing their index
-        if (srcInputFiles is not None):
-            inputAxes = dataInputSlot.meta.getAxisKeys()
+        inputAxes = dataInputSlot.meta.getAxisKeys()
+        if srcInputFiles is not None and 'z' in inputAxes:
             z_idx = inputAxes.index('z')
             filename_digits = filter(str.isdigit, os.path.basename(srcInputFiles[0]))
             idx = int(filename_digits) if filename_digits else 0


### PR DESCRIPTION
I took the commits from #1119 and rebased them against the latest master.  Then I made some changes on top of it.  See the commit log for details.  BTW, to use this branch you will need the latest versions of lazyflow and volumina (master branches).

Summary of the changes I added on top of #1119:
- The new GUI for label import options is always shown to the user -- no defaults are assumed.
- The user may specify the axis-order of the file she selected (in case the `OpInputDataReader` guessed wrong)
- Don't assume 3D (or 5D)
- Show a busy indicator while the data is loading