### PR TITLE
Use the new pgmlink API in opConservationTracking

### DIFF
--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -372,7 +372,6 @@ class OpTrackingBase(Operator, ExportingOperator):
     def track_family(self, track_id):
         return self.track_children(track_id), self.track_parent(track_id)
 
-
     def _generate_traxelstore(self,
                               time_range,
                               x_range,
@@ -388,14 +387,10 @@ class OpTrackingBase(Operator, ExportingOperator):
                               max_traxel_id_at=None,
                               with_opt_correction=False,
                               with_coordinate_list=False,
-                              with_classifier_prior=False,
-                              coordinate_map=None):
+                              with_classifier_prior=False):
 
         if not self.Parameters.ready():
             raise Exception("Parameter slot is not ready")
-
-        if coordinate_map is not None and not with_coordinate_list:
-            coordinate_map.initialize()
 
         parameters = self.Parameters.value
         parameters['scales'] = [x_scale, y_scale, z_scale]
@@ -523,29 +518,6 @@ class OpTrackingBase(Operator, ExportingOperator):
                     obj_sizes.append(float(size))
 
                 ts.add(tr)
-
-                # add coordinate lists
-
-                if with_coordinate_list and coordinate_map is not None:  # store coordinates in arma::mat
-                    # generate roi: assume the following order: txyzc
-                    n_dim = len(rc[idx])
-                    roi = [0] * 5
-                    roi[0] = slice(int(t), int(t + 1))
-                    roi[1] = slice(int(lower[idx][0]), int(upper[idx][0] + 1))
-                    roi[2] = slice(int(lower[idx][1]), int(upper[idx][1] + 1))
-                    if n_dim == 3:
-                        roi[3] = slice(int(lower[idx][2]), int(upper[idx][2] + 1))
-                    else:
-                        assert n_dim == 2
-                    image_excerpt = self.LabelImage[roi].wait()
-                    if n_dim == 2:
-                        image_excerpt = image_excerpt[0, ..., 0, 0]
-                    elif n_dim == 3:
-                        image_excerpt = image_excerpt[0, ..., 0]
-                    else:
-                        raise Exception, "n_dim = %s instead of 2 or 3"
-
-                    pgmlink.extract_coordinates(coordinate_map, image_excerpt, lower[idx].astype(np.int64), tr)
 
             if len(filtered_labels_at) > 0:
                 filtered_labels[str(int(t) - time_range[0])] = filtered_labels_at

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -170,36 +170,6 @@ class OpConservationTracking(OpTrackingBase):
         if ndim == 2:
             assert z_range[0] * z_scale == 0 and (z_range[1]-1) * z_scale == 0, "fov of z must be (0,0) if ndim==2"
 
-        # tracker = pgmlink.ConsTracking(maxObj,
-        #                                  float(maxDist),
-        #                                  float(divThreshold),
-        #                                  "none",  # detection_rf_filename
-        #                                  sizeDependent,   # size_dependent_detection_prob
-        #                                  0,       # forbidden_cost
-        #                                  float(ep_gap), # ep_gap
-        #                                  float(median_obj_size[0]), # median_object_size
-        #                                  withTracklets,
-        #                                  divWeight,
-        #                                  transWeight,
-        #                                  withDivisions,
-        #                                  disappearance_cost, # disappearance cost
-        #                                  appearance_cost, # appearance cost
-        #                                  withMergerResolution,
-        #                                  ndim,
-        #                                  transition_parameter,
-        #                                  borderAwareWidth,
-        #                                  fov,
-        #                                  True, #with_constraints
-        #                                  cplex_timeout,
-        #                                  "none" # dump traxelstore
-        #                                  )
-        #
-        #
-        # try:
-        #     eventsVector = tracker(ts, coordinate_map.get())
-        # except Exception as e:
-        #     raise Exception, 'Tracking terminated unsuccessfully: ' + str(e)
-
         tracker = pgmlink.ConsTracking(maxObj,
                                      sizeDependent,   # size_dependent_detection_prob
                                      float(median_obj_size[0]), # median_object_size

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -1,11 +1,13 @@
 from lazyflow.graph import InputSlot, OutputSlot
 from lazyflow.rtype import List
 from lazyflow.stype import Opaque
+import numpy as np
 import pgmlink
 from ilastik.applets.tracking.base.opTrackingBase import OpTrackingBase
 from ilastik.applets.tracking.base.trackingUtilities import relabelMergers
 from ilastik.applets.tracking.base.trackingUtilities import get_events
 from lazyflow.operators.opCompressedCache import OpCompressedCache
+from ilastik.applets.objectExtraction.opObjectExtraction import default_features_key
 from lazyflow.roi import sliceToRoi
 
 import logging
@@ -129,22 +131,16 @@ class OpConservationTracking(OpTrackingBase):
         
         median_obj_size = [0]
 
-        coordinate_map = pgmlink.TimestepIdCoordinateMap()
-        if withArmaCoordinates:
-            coordinate_map.initialize()
         ts, empty_frame = self._generate_traxelstore(time_range, x_range, y_range, z_range, 
                                                                       size_range, x_scale, y_scale, z_scale, 
                                                                       median_object_size=median_obj_size, 
                                                                       with_div=withDivisions,
                                                                       with_opt_correction=withOpticalCorrection,
-                                                                      with_coordinate_list=withMergerResolution , # no vigra coordinate list, that is done by arma
-                                                                      with_classifier_prior=withClassifierPrior,
-                                                                      coordinate_map=coordinate_map)
+                                                                      with_classifier_prior=withClassifierPrior)
         
         if empty_frame:
             raise Exception, 'cannot track frames with 0 objects, abort.'
-              
-        
+
         if avgSize[0] > 0:
             median_obj_size = avgSize
         
@@ -174,43 +170,130 @@ class OpConservationTracking(OpTrackingBase):
         if ndim == 2:
             assert z_range[0] * z_scale == 0 and (z_range[1]-1) * z_scale == 0, "fov of z must be (0,0) if ndim==2"
 
-        tracker = pgmlink.ConsTracking(maxObj,
-                                         float(maxDist),
-                                         float(divThreshold),
-                                         "none",  # detection_rf_filename
-                                         sizeDependent,   # size_dependent_detection_prob
-                                         0,       # forbidden_cost
-                                         float(ep_gap), # ep_gap
-                                         float(median_obj_size[0]), # median_object_size
-                                         withTracklets,
-                                         divWeight,
-                                         transWeight,
-                                         withDivisions,
-                                         disappearance_cost, # disappearance cost
-                                         appearance_cost, # appearance cost
-                                         withMergerResolution,
-                                         ndim,
-                                         transition_parameter,
-                                         borderAwareWidth,
-                                         fov,
-                                         True, #with_constraints
-                                         cplex_timeout,
-                                         "none" # dump traxelstore
-                                         )
+        # tracker = pgmlink.ConsTracking(maxObj,
+        #                                  float(maxDist),
+        #                                  float(divThreshold),
+        #                                  "none",  # detection_rf_filename
+        #                                  sizeDependent,   # size_dependent_detection_prob
+        #                                  0,       # forbidden_cost
+        #                                  float(ep_gap), # ep_gap
+        #                                  float(median_obj_size[0]), # median_object_size
+        #                                  withTracklets,
+        #                                  divWeight,
+        #                                  transWeight,
+        #                                  withDivisions,
+        #                                  disappearance_cost, # disappearance cost
+        #                                  appearance_cost, # appearance cost
+        #                                  withMergerResolution,
+        #                                  ndim,
+        #                                  transition_parameter,
+        #                                  borderAwareWidth,
+        #                                  fov,
+        #                                  True, #with_constraints
+        #                                  cplex_timeout,
+        #                                  "none" # dump traxelstore
+        #                                  )
+        #
+        #
+        # try:
+        #     eventsVector = tracker(ts, coordinate_map.get())
+        # except Exception as e:
+        #     raise Exception, 'Tracking terminated unsuccessfully: ' + str(e)
 
-        
+        tracker = pgmlink.ConsTracking(maxObj,
+                                     sizeDependent,   # size_dependent_detection_prob
+                                     float(median_obj_size[0]), # median_object_size
+                                     float(maxDist),
+                                     withDivisions,
+                                     float(divThreshold),
+                                     "none",  # detection_rf_filename
+                                     fov,
+                                     "none" # dump traxelstore,
+                                     )
+        tracker.buildGraph(ts)
+
         try:
-            eventsVector = tracker(ts, coordinate_map.get())
+            eventVector = tracker.track(0,       # forbidden_cost
+                                            float(ep_gap), # ep_gap
+                                            withTracklets,
+                                            divWeight,
+                                            transWeight,
+                                            disappearance_cost, # disappearance cost
+                                            appearance_cost, # appearance cost
+                                            ndim,
+                                            transition_parameter,
+                                            borderAwareWidth,
+                                            True, #with_constraints
+                                            cplex_timeout)
+
+            # extract the coordinates with the given event vector
+            if withMergerResolution:
+                coordinate_map = pgmlink.TimestepIdCoordinateMap()
+                # TODO what should the variable withArmaCoordinates toggle?
+                # is this the intended use?
+                if withArmaCoordinates:
+                    coordinate_map.initialize()
+                self._get_merger_coordinates(coordinate_map,
+                                             time_range,
+                                             eventVector)
+
+                eventVector = tracker.resolve_mergers(eventVector,
+                                                coordinate_map.get(),
+                                                float(ep_gap),
+                                                transWeight,
+                                                withTracklets,
+                                                ndim,
+                                                transition_parameter,
+                                                True, # with_constraints
+                                                True) # with_multi_frame_moves
         except Exception as e:
             raise Exception, 'Tracking terminated unsuccessfully: ' + str(e)
-        
-        if len(eventsVector) == 0:
+
+        if len(eventVector) == 0:
             raise Exception, 'Tracking terminated unsuccessfully: Events vector has zero length.'
         
-        events = get_events(eventsVector)
+        events = get_events(eventVector)
         self.Parameters.setValue(parameters, check_changed=False)
         self.EventsVector.setValue(events, check_changed=False)
-        
+
+
+    def _get_merger_coordinates(self, coordinate_map, time_range, eventsVector):
+        # fetch features
+        feats = self.ObjectFeatures(time_range).wait()
+        # iterate over all timesteps
+        for t in feats.keys():
+            rc = feats[t][default_features_key]['RegionCenter']
+            lower = feats[t][default_features_key]['Coord<Minimum>']
+            upper = feats[t][default_features_key]['Coord<Maximum>']
+            size = feats[t][default_features_key]['Count']
+            for event in eventsVector[t]:
+                # check for merger events
+                if event.type == pgmlink.EventType.Merger:
+                    idx = event.traxel_ids[0]
+                    # generate roi: assume the following order: txyzc
+                    n_dim = len(rc[idx])
+                    roi = [0]*5
+                    roi[0] = slice(int(t), int(t+1))
+                    roi[1] = slice(int(lower[idx][0]), int(upper[idx][0] + 1))
+                    roi[2] = slice(int(lower[idx][1]), int(upper[idx][1] + 1))
+                    if n_dim == 3:
+                        roi[3] = slice(int(lower[idx][2]), int(upper[idx][2] + 1))
+                    else:
+                        assert n_dim == 2
+                    image_excerpt = self.LabelImage[roi].wait()
+                    if n_dim == 2:
+                        image_excerpt = image_excerpt[0, ..., 0, 0]
+                    elif n_dim ==3:
+                        image_excerpt = image_excerpt[0, ..., 0]
+                    else:
+                        raise Exception, "n_dim = %s instead of 2 or 3"
+
+                    pgmlink.extract_coord_by_timestep_id(coordinate_map,
+                                                         image_excerpt,
+                                                         lower[idx].astype(np.int64),
+                                                         t,
+                                                         idx,
+                                                         int(size[idx,0]))
 
     def propagateDirty(self, inputSlot, subindex, roi):
         super(OpConservationTracking, self).propagateDirty(inputSlot, subindex, roi)


### PR DESCRIPTION
After the recent confusion about which version of pgmlink is needed for ilastik master (again sorry about that), here is the change to use the current pgmlink master (tested with https://github.com/martinsch/pgmlink/commit/9c4dadb14dd97a4dd1b6d8aca408809978616c45) from ilastik.

@stuarteberg could you please verify that tracking also works for you with this combination? If it does, I'll also create a PR for ilastik-build-conda to use the most up to date versions of OpenGM and pgmlink and update the build numbers.