### PR TITLE
Variable Importance Table GUI

### DIFF
--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -46,6 +46,7 @@ from ilastik.utility.gui import threadRouted
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui, H5VolumeSelectionDlg
+from ilastik.shell.gui.variableImportanceDialog import VariableImportanceDialog
 
 try:
     from volumina.view3d.volumeRendering import RenderingManager
@@ -121,7 +122,8 @@ class ClassifierSelectionDlg(QDialog):
             import warnings
             warnings.warn("Couldn't import sklearn. Scikit-learn classifiers not available.")
 
-        # Debug classifiers        
+        # Debug classifiers
+        classifiers["Parallel Random Forest with Variable Importance (VIGRA)"] = ParallelVigraRfLazyflowClassifierFactory(100, variable_importance_enabled=True)        
         classifiers["(debug) Single-threaded Random Forest (VIGRA)"] = VigraRfLazyflowClassifierFactory(100)
         classifiers["(debug) Pixelwise Random Forest (VIGRA)"] = VigraRfPixelwiseClassifierFactory(100)
         
@@ -160,13 +162,18 @@ class PixelClassificationGui(LabelingGui):
         # For now classifier selection is only available in debug mode
         if ilastik_config.getboolean('ilastik', 'debug'):
             advanced_menu = QMenu("Advanced", parent=self)
-            
+                        
             def handleClassifierAction():
                 dlg = ClassifierSelectionDlg(self.topLevelOperatorView, parent=self)
                 dlg.exec_()
             
             classifier_action = advanced_menu.addAction("Classifier...")
             classifier_action.triggered.connect( handleClassifierAction )
+            
+            def showVarImpDlg():
+                varImpDlg = VariableImportanceDialog(self.topLevelOperatorView.Classifier.value.named_importances, parent=self)
+                
+            advanced_menu.addAction("Variable Importance Table").triggered.connect(showVarImpDlg)            
             
             def handleImportLabelsAction():
                 # Find the directory of the most recently opened image file

--- a/ilastik/shell/gui/variableImportanceDialog.py
+++ b/ilastik/shell/gui/variableImportanceDialog.py
@@ -1,0 +1,99 @@
+import collections
+
+from PyQt4.QtCore import Qt
+from PyQt4.QtGui import QDialog, QPushButton, QWidget, QLabel, QTableWidget, QTableWidgetItem, QGridLayout, QColor
+import re
+
+# Overload QTableWidgetItem class to allow comparisons of float instead of strings
+class QTableWidgetItemWithFloatSorting(QTableWidgetItem):
+    def __lt__(self, other):
+        if ( isinstance(other, QTableWidgetItem) ):
+            my_value, my_ok = self.data(Qt.EditRole).toFloat()
+            other_value, other_ok = other.data(Qt.EditRole).toFloat()
+
+            if ( my_ok and other_ok ):
+                return my_value < other_value
+
+        return super(QTableWidgetItemWithFloatSorting, self).__lt__(other)
+
+
+class VariableImportanceDialog(QDialog):
+    def __init__(self, named_importances, *args, **kwargs):
+        super(VariableImportanceDialog, self).__init__(*args, **kwargs)
+        self.setWindowTitle("Variable Importance Table")
+        self.setMinimumWidth(700)
+        self.setMinimumHeight(800)
+
+        layout = QGridLayout() 
+        layout.setContentsMargins(10, 10, 10, 10)
+               
+        if named_importances:
+            # Show variable importance table
+            rows = len(named_importances.items())
+            columns = 5
+            table = QTableWidget(rows, columns)   
+            table.setHorizontalHeaderLabels(['Variable Name', 'Class #0', 'Class #1', 'Overall', 'Gini'])
+            table.verticalHeader().setVisible(False)      
+            
+            importances_mins = map(min, zip(*named_importances.values()))
+            importances_maxs = map(max, zip(*named_importances.values()))
+            
+            for i, (variable, importances) in enumerate(named_importances.items()):     
+                # Remove non-ASCII characters to get rid of the sigma character in the variable names.
+                variable = re.sub(r'[^\x00-\x7F]+','s', variable)
+                
+                item = QTableWidgetItem(variable)
+                item.setFlags( Qt.ItemIsSelectable |  Qt.ItemIsEnabled )
+                table.setItem(i, 0, item)
+
+                for j, importance in enumerate(importances):
+                    # Get color based on the importance value
+                    val = importances[j]
+                    imin = importances_mins[j]
+                    imax = importances_maxs[j]
+                    range = importances_maxs[j] - importances_mins[j]
+                    color = int( 255 - ( (val-imin) * 200) / range )    
+
+                    # Load items as strings
+                    item = QTableWidgetItemWithFloatSorting(str("{: .05f}".format(importance)))
+                    item.setFlags( Qt.ItemIsSelectable |  Qt.ItemIsEnabled )
+                    item.setBackground(QColor(color,255,color))
+                    table.setItem(i, j+1, item)
+                    
+            table.resizeColumnsToContents()  
+            
+            table.setSortingEnabled(True)
+            table.sortByColumn(3) # Sort by overall importance
+
+            layout.addWidget(table, 1, 0, 3, 2)  
+            
+        else:
+            # Classifier is not trained. Show warning message.
+            warningLabel = QLabel("You need to choose the Parallel Random Forest Classifier with Variable Importance (VIGRA) from the menu Advanced>Classifier...")
+            warningLabel.setAlignment(Qt.AlignCenter)
+            warningLabel.setWordWrap(True) 
+            layout.addWidget(warningLabel, 3, 0, 1 ,2)
+
+        # Create and add close button
+        closeButton = QPushButton("Close")
+        closeButton.clicked.connect(self.close)
+        layout.addWidget(closeButton, 4, 1)
+        
+        self.setLayout(layout)
+        
+        # Show the window
+        result = self.exec_()
+
+                
+if __name__ == "__main__":
+    from PyQt4.QtGui import QApplication
+    
+    named_importances = { 'feature_1' : [1.2,4.3,3.1,4.8], 'feature_2' : [7.4,3.4,5.5,5.9], 'feature_3' : [1,2,3.5,5.2] , 'feature_4' : [1.9,9.1,2.5,7.1] , 'feature_5' : [6.4,2.0,8.5,1.1]  }
+
+    app = QApplication([])
+    mainWindow = QWidget()
+    varImpDlg = VariableImportanceDialog(named_importances, mainWindow)
+    
+
+
+


### PR DESCRIPTION
Added a variable-importance-table dialog accessible from the `Advanced` section of the menu bar. In order for the table to work, the user has to first activate the `Parallel Random Forest with Variable Importance (Vigra)` in the `Select Classifier Type` dialog:

![varimp2](https://cloud.githubusercontent.com/assets/5825034/11753754/10c0c284-a015-11e5-984c-29fada68de28.png)

Here's a screenshot of the table with color codes based on feature importance:

![varimptable](https://cloud.githubusercontent.com/assets/5825034/11753758/17d52240-a015-11e5-9cb2-46a5aa5c75c6.png)
The table is sorted by overall feature importance.