### PR TITLE
Fixed 2 problems when new lane is added for batch-processing

### DIFF
--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -397,18 +397,20 @@ class OpTrackingBase(Operator, ExportingOperator):
                               max_traxel_id_at=None,
                               with_opt_correction=False,
                               with_coordinate_list=False,
-                              with_classifier_prior=False):
+                              with_classifier_prior=False,
+                              with_batch_processing = False):
 
         if not self.Parameters.ready():
             raise Exception("Parameter slot is not ready")
 
-        parameters = self.Parameters.value
-        parameters['scales'] = [x_scale, y_scale, z_scale]
-        parameters['time_range'] = [min(time_range), max(time_range)]
-        parameters['x_range'] = x_range
-        parameters['y_range'] = y_range
-        parameters['z_range'] = z_range
-        parameters['size_range'] = size_range
+        if not with_batch_processing:
+            parameters = self.Parameters.value
+            parameters['scales'] = [x_scale, y_scale, z_scale]
+            parameters['time_range'] = [min(time_range), max(time_range)]
+            parameters['x_range'] = x_range
+            parameters['y_range'] = y_range
+            parameters['z_range'] = z_range
+            parameters['size_range'] = size_range
 
         logger.info("generating traxels")
         logger.info("fetching region features and division probabilities")

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -203,7 +203,8 @@ class OpConservationTracking(OpTrackingBase):
                                                                       median_object_size=median_obj_size, 
                                                                       with_div=withDivisions,
                                                                       with_opt_correction=withOpticalCorrection,
-                                                                      with_classifier_prior=withClassifierPrior)
+                                                                      with_classifier_prior=withClassifierPrior,
+                                                                      with_batch_processing=withBatchProcessing)
         
         if empty_frame:
             raise Exception, 'cannot track frames with 0 objects, abort.'


### PR DESCRIPTION
Fixed 2 problems when connecting new lanes for batch-processing:

* New object features were erased every time a new lane was connected. To fix this bug, the `setValue()` functions of `opCellClassification` and `opDivisionDetection` were moved from `connectLane()` to the constructor of the workflow.

* Problem with conflicting sizes of `EventsVector` and `time_range` when adding a new lane. This problem was fixed by adding a `with_batch_processing` flag to the function `_generate_traxelstore` in `opConservationTracking.py`