### PR TITLE
Fixed problem with axis ranges stored in parameters

### DIFF
--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -397,20 +397,18 @@ class OpTrackingBase(Operator, ExportingOperator):
                               max_traxel_id_at=None,
                               with_opt_correction=False,
                               with_coordinate_list=False,
-                              with_classifier_prior=False,
-                              with_batch_processing = False):
+                              with_classifier_prior=False):
 
         if not self.Parameters.ready():
             raise Exception("Parameter slot is not ready")
 
-        if not with_batch_processing:
-            parameters = self.Parameters.value
-            parameters['scales'] = [x_scale, y_scale, z_scale]
-            parameters['time_range'] = [min(time_range), max(time_range)]
-            parameters['x_range'] = x_range
-            parameters['y_range'] = y_range
-            parameters['z_range'] = z_range
-            parameters['size_range'] = size_range
+        parameters = self.Parameters.value
+        parameters['scales'] = [x_scale, y_scale, z_scale]
+        parameters['time_range'] = [min(time_range), max(time_range)]
+        parameters['x_range'] = x_range
+        parameters['y_range'] = y_range
+        parameters['z_range'] = z_range
+        parameters['size_range'] = size_range
 
         logger.info("generating traxels")
         logger.info("fetching region features and division probabilities")

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -203,8 +203,7 @@ class OpConservationTracking(OpTrackingBase):
                                                                       median_object_size=median_obj_size, 
                                                                       with_div=withDivisions,
                                                                       with_opt_correction=withOpticalCorrection,
-                                                                      with_classifier_prior=withClassifierPrior,
-                                                                      with_batch_processing=withBatchProcessing)
+                                                                      with_classifier_prior=withClassifierPrior)
         
         if empty_frame:
             raise Exception, 'cannot track frames with 0 objects, abort.'

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -286,8 +286,6 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
          
     def prepare_lane_for_export(self, lane_index):
-        parameters = self.trackingApplet.topLevelOperator.Parameters.value
-        
         maxt = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[0] 
         maxx = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[1] 
         maxy = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[2] 
@@ -299,6 +297,14 @@ class ConservationTrackingWorkflowBase( Workflow ):
         ndim = 3
         if ( z_range[1] - z_range[0] ) > 1:
             ndim = 2
+        
+        parameters = self.trackingApplet.topLevelOperator.Parameters.value
+        
+        # Save state of axis ranges
+        self.prev_time_range = parameters['time_range']
+        self.prev_x_range = parameters['x_range']
+        self.prev_y_range = parameters['y_range']
+        self.prev_z_range = parameters['z_range']
         
         self.trackingApplet.topLevelOperator[lane_index].track(
             time_range = time_enum,
@@ -364,6 +370,13 @@ class ConservationTrackingWorkflowBase( Workflow ):
 
             req.wait()
             self.dataExportApplet.progressSignal.emit(100)
+            
+            # Restore state of axis ranges
+            parameters = self.trackingApplet.topLevelOperator.Parameters.value
+            parameters['time_range'] = self.prev_time_range
+            parameters['x_range'] = self.prev_x_range
+            parameters['y_range'] = self.prev_y_range
+            parameters['z_range'] = self.prev_z_range          
     
     def _inputReady(self, nRoles):
         slot = self.dataSelectionApplet.topLevelOperator.ImageGroup


### PR DESCRIPTION
The axis ranges (stored in the `Parameters` slot) of the first lane were being used incorrectly for all the lanes during batch-processing. In order to fix the problem, I removed the `withBatchProcessing` flag from `_generate_traxelstore`, and restore the original axis ranges in `post_process_lane_export`.

There is a fundamental problem with the `Parameters` slot since it is a broadcasted slot, and therefore the same for all the lanes, but it also contains information on axis ranges that is different for every lane. The ideal fix would be to split `Parameters` into two slots, `Parameters`  and `AxisRanges`. This change however, requires a lot of modifications to the code which will make the merging of structured learning more difficult. For now I fixed the problem in a more simple way, by doing the least changes, but after structured learning is changed, I will split `Parameters` as described.