### PR TITLE
Solved problem with wrong number of dimensions(ndim) in batch processing mode

### DIFF
--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -286,17 +286,18 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
          
     def prepare_lane_for_export(self, lane_index):
-        maxt = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[0] 
-        maxx = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[1] 
-        maxy = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[2] 
-        maxz = self.trackingApplet.topLevelOperator[lane_index].LabelImage.meta.shape[3] 
+        maxt = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[0] 
+        maxx = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[1] 
+        maxy = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[2] 
+        maxz = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[3] 
         time_enum = range(maxt)
         x_range = (0, maxx)
         y_range = (0, maxy)
         z_range = (0, maxz)
-        ndim = 3
+
+        ndim = 2
         if ( z_range[1] - z_range[0] ) > 1:
-            ndim = 2
+            ndim = 3
         
         parameters = self.trackingApplet.topLevelOperator.Parameters.value
         


### PR DESCRIPTION
Solved a problem with the wrong number of dimensions(ndim) in the tracking batch processing mode. When the wrong number of dimensions (eg. 3 instead of 2 for a 2D+t video) was set, the following message was displayed from pgmlink:

error: subtraction: incompatible matrix dimensions: 2x404 and 3x404
04:22:37.252 WARNING: GMM fitting failed for Traxel(15, 19592), reverting to KMeans: subtraction: incompatible matrix dimensions: 2x404 and 3x404