### PR TITLE
Added New Object Features to Tracking

### DIFF
--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -66,7 +66,7 @@ class OpTrackingBase(Operator, ExportingOperator):
     Output = OutputSlot()
 
     # Use a slot for storing the export settings in the project file.
-    ExportSettings = OutputSlot()
+    ExportSettings = InputSlot()
 
     # Override functions ExportingOperator mixin
     def configure_table_export_settings(self, settings, selected_features):
@@ -188,6 +188,7 @@ class OpTrackingBase(Operator, ExportingOperator):
         elif inputSlot is self.EventsVector:
             self._setLabel2Color()
             self._setLabel2Color(export_mode=True)
+
 
     def setInSlot(self, slot, subindex, roi, value):
         assert slot == self.InputHdf5, "Invalid slot for setInSlot(): {}".format(slot.name)

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -84,8 +84,12 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
         dimensions = self.get_raw_shape()
         feature_names = self.get_feature_names()        
 
+        op = self.get_exporting_operator()
+        settings, selected_features = op.get_table_export_settings()
+                
         dialog = ExportObjectInfoDialog(dimensions, 
-                                        feature_names, 
+                                        feature_names,
+                                        selected_features=selected_features, 
                                         title=self.get_export_dialog_title(), 
                                         filename=self._default_export_filename)
         if not dialog.exec_():

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -43,9 +43,11 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
 
     def get_feature_names(self):
         op = self.get_exporting_operator()
-        if op.ComputedFeatureNamesWithDivFeatures:
+        try:
             slot = op.ComputedFeatureNamesWithDivFeatures
-        else:
+        except AttributeError:
+            slot = op.ComputedFeatureNames
+        if not slot:
             slot = op.ComputedFeatureNames
         return slot([]).wait()
 

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -43,9 +43,9 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
 
     def get_feature_names(self):
         op = self.get_exporting_operator()
-        try:
+        if op.ComputedFeatureNamesWithDivFeatures:
             slot = op.ComputedFeatureNamesWithDivFeatures
-        except AttributeError:
+        else:
             slot = op.ComputedFeatureNames
         return slot([]).wait()
 

--- a/ilastik/applets/tracking/base/trackingSerializer.py
+++ b/ilastik/applets/tracking/base/trackingSerializer.py
@@ -19,7 +19,7 @@
 #		   http://ilastik.org/license.html
 ###############################################################################
 from ilastik.applets.base.appletSerializer import AppletSerializer,\
-    SerialDictSlot, SerialSlot, SerialHdf5BlockSlot, SerialPickleableSlot
+    SerialDictSlot, SerialSlot, SerialHdf5BlockSlot, SerialPickleableSlot, SerialPickledValueSlot
 
 import pgmlink
 
@@ -33,7 +33,9 @@ class TrackingSerializer(AppletSerializer):
                                      name="CachedOutput"),
                  SerialDictSlot(mainOperator.EventsVector, transform=str, selfdepends=True),
                  SerialDictSlot(mainOperator.FilteredLabels, transform=str, selfdepends=True),
+                 SerialPickledValueSlot(mainOperator.ExportSettings)
                  ]
+        
 
         if 'MergerOutput' in mainOperator.outputs:
             slots.append(SerialHdf5BlockSlot(mainOperator.MergerOutputHdf5,

--- a/ilastik/applets/tracking/conservation/conservationTrackingApplet.py
+++ b/ilastik/applets/tracking/conservation/conservationTrackingApplet.py
@@ -15,7 +15,7 @@ class ConservationTrackingApplet( StandardApplet ):
 
     @property
     def broadcastingSlots( self ):
-        return ['Parameters']
+        return ['Parameters', 'ExportSettings']
 
     @property
     def singleLaneGuiClass( self ):

--- a/ilastik/applets/trackingFeatureExtraction/config.py
+++ b/ilastik/applets/trackingFeatureExtraction/config.py
@@ -4,7 +4,7 @@ compress_labels = False
 # all these features are precalculated in opExtractObjects
 '''
 
-vigra_features = ['Count', 'RegionCenter', 'Mean', 'Variance', 'RegionRadii', 'Maximum', 'Minimum', 'Skewness', 'Sum', 'Coord<Principal<Kurtosis>>', 'Coord<Principal<Skewness>>', 'Kurtosis']
+vigra_features = ['Count', 'RegionCenter', 'Mean', 'Variance', 'RegionRadii', 'Maximum', 'Minimum', 'Skewness', 'Sum', 'Coord<Principal<Kurtosis>>', 'Coord<Principal<Skewness>>', 'Kurtosis', 'RegionAxes']
 features_vigra_name = 'Standard Object Features'
 
 other_features = []
@@ -15,10 +15,10 @@ division_features = ['ParentChildrenRatio_Count', 'ParentChildrenRatio_Mean', 'C
                    'ParentChildrenAngle_RegionCenter', 'ChildrenRatio_SquaredDistances']
 
 selected_features_division[features_division_name] = division_features
-selected_features_division[features_vigra_name] = [ 'Count', 'Mean', 'Variance' ]
+selected_features_division[features_vigra_name] = ['Count', 'Mean', 'Variance']
 
 selected_features_objectcount = {}
-selected_features_objectcount[features_vigra_name] = ['Count', 'Mean', 'Variance', 'RegionRadii' ]
+selected_features_objectcount[features_vigra_name] = ['Count', 'Mean', 'Variance', 'RegionRadii']
 
 # anisotropy scales
 image_scale = [1.0, 1.0, 1.0]

--- a/ilastik/widgets/exportObjectInfoDialog.py
+++ b/ilastik/widgets/exportObjectInfoDialog.py
@@ -33,7 +33,7 @@ class ExportObjectInfoDialog(QDialog):
     :param filename: The filename to use as default
     :type filename: str or None
     """
-    def __init__(self, dimensions, feature_table, req_features=None, title=None, parent=None, filename=None):
+    def __init__(self, dimensions, feature_table, req_features=None, selected_features=None, title=None, parent=None, filename=None):
         super(ExportObjectInfoDialog, self).__init__(parent)
 
         ui_class, widget_class = uic.loadUiType(os.path.split(__file__)[0] + "/exportObjectInfoDialog.ui")
@@ -47,8 +47,11 @@ class ExportObjectInfoDialog(QDialog):
         if req_features is None:
             req_features = []
         req_features.extend(DEFAULT_REQUIRED_FEATURES)
+        
+        if selected_features is None:
+            selected_features = []
 
-        self._setup_features(feature_table, req_features)
+        self._setup_features(feature_table, req_features, selected_features)
         self.ui.featureView.setHeaderLabels(("Select Features",))
         self.ui.featureView.expandAll()
 
@@ -120,7 +123,7 @@ class ExportObjectInfoDialog(QDialog):
                 text = data.text()
             self.ui.exportPath.setText(text)
 
-    def _setup_features(self, features, reqs, max_depth=2, parent=None):
+    def _setup_features(self, features, req_features, selected_features, max_depth=2, parent=None):
         if max_depth == 2 and not features:
             item = QTreeWidgetItem(parent)
             item.setText(0, "All Default Features will be exported.")
@@ -134,10 +137,12 @@ class ExportObjectInfoDialog(QDialog):
         for entry, child in features.iteritems():
             item = QTreeWidgetItem(parent)
             item.setText(0, entry)
-            self._setup_features(child, reqs, max_depth-1, item)
+            self._setup_features(child, req_features, selected_features, max_depth-1, item)
             if child == {} or max_depth == 1:  # no children
                 state = Qt.Unchecked
-                if entry in reqs:
+                if entry in selected_features:
+                    state = Qt.Checked
+                if entry in req_features:
                     state = Qt.Checked
                     item.setDisabled(True)
                     item.setText(0, "%s%s" % (item.text(0), REQ_MSG))

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -118,13 +118,16 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.SelectionNames.setValue( ['Object-Identities', 'Tracking-Result', 'Merger-Result'] )
         opDataExport.WorkingDirectory.connect( opDataSelection.WorkingDirectory )
 
-        self.batchProcessingApplet = BatchProcessingApplet(self, "Batch Processing", self.dataSelectionApplet, self.dataExportApplet)
-        
         # Extra configuration for object export table (as CSV table or HDF5 table)
         opTracking = self.trackingApplet.topLevelOperator
         self.dataExportApplet.set_exporting_operator(opTracking)
         self.dataExportApplet.prepare_lane_for_export = self.prepare_lane_for_export
         self.dataExportApplet.post_process_lane_export = self.post_process_lane_export
+        
+        # configure export settings
+        settings = {'file path': self.default_export_filename, 'compression': {}, 'file type': 'csv'}
+        selected_features = ['Count', 'RegionCenter', 'RegionRadii', 'RegionAxes']                  
+        opTracking.ExportSettings.setValue( (settings, selected_features) )
         
         self._applets = []                
         self._applets.append(self.dataSelectionApplet)
@@ -137,6 +140,8 @@ class ConservationTrackingWorkflowBase( Workflow ):
         
         if self.divisionDetectionApplet:
             self._applets.append(self.divisionDetectionApplet)
+        
+        self.batchProcessingApplet = BatchProcessingApplet(self, "Batch Processing", self.dataSelectionApplet, self.dataExportApplet)
             
         self._applets.append(self.cellClassificationApplet)
         self._applets.append(self.trackingApplet)
@@ -272,11 +277,6 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opTracking.ComputedFeatureNames.connect( opObjExtraction.FeatureNamesVigra)
         opTracking.DetectionProbabilities.connect( opCellClassification.Probabilities )
         opTracking.NumLabels.connect( opCellClassification.NumLabels )
-
-        # configure export settings
-        settings = {'file path': self.default_export_filename, 'compression': {}, 'file type': 'csv'}
-        selected_features = ['Count', 'RegionCenter']
-        opTracking.configure_table_export_settings(settings, selected_features)
     
         opDataExport.Inputs.resize(3)
         opDataExport.Inputs[0].connect( opTracking.RelabeledImage )


### PR DESCRIPTION
Added new object features, `RegionRadii` and `RegionAxes`, to conservation tracking in order to export the data in a format required by Branson's lab.

Also, fixed 2 errors when exporting object features:
* The was an error on the animal conservation tracking workflow when clicking on "Configure Table Export" of the `Data Export Applet`. Since the slot `ComputedFeatureNamesWithDivFeatures` is set to `None` in animal tracking, clicking on the button was crashing ilastik.
* The features and settings chosen on the object feature dialog in the `Tracking Result Export` section were reset everytime the dialog was closed or a new lane was added.