### PR TITLE
Fixed problem with ilastik input parameters on dataSelectionApplet and conservationTrackingWorkflow when running on headless mode

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionApplet.py
+++ b/ilastik/applets/dataSelection/dataSelectionApplet.py
@@ -124,7 +124,7 @@ class DataSelectionApplet( Applet ):
             for arg_name in arg_names:
                 if getattr(parsed_args, arg_name):
                     # FIXME: This error message could be more helpful.
-                    role_args = map( self._role_name_to_arg_name, role_names )
+                    role_args = map( cls._role_name_to_arg_name, role_names )
                     role_args = map( lambda s: '--' + s, role_args )
                     role_args_str = ", ".join( role_args )
                     raise Exception("Invalid command line arguments: All roles must be configured explicitly.\n"

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -51,7 +51,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
         
         opDataSelection = self.dataSelectionApplet.topLevelOperator
         if self.fromBinary:
-            opDataSelection.DatasetRoles.setValue( ['Raw Data', 'Binary Image'] )
+            opDataSelection.DatasetRoles.setValue( ['Raw Data', 'Segmentation Image'] )
         else:
             opDataSelection.DatasetRoles.setValue( ['Raw Data', 'Prediction Maps'] )
                 


### PR DESCRIPTION
Changed `self` to `cls` reference in `dataSelectionApplet` and changed the name of the input parameter `binary-image` to `segmentation-image` in the tracking workflow in order to stay consistent with the object classfiication workflow and the ilastik docs. 