### PR TITLE
Tracking memory and running-time optimization

### DIFF
--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -150,7 +150,7 @@ class OpTrackingBase(Operator, ExportingOperator):
 
     def execute(self, slot, subindex, roi, result):
         if slot is self.Output:
-            result = self.LabelImage.get(roi).wait()
+            result[:] = self.LabelImage.get(roi).wait()
             if not self.Parameters.ready():
                 raise Exception("Parameter slot is not ready")
             parameters = self.Parameters.value

--- a/ilastik/applets/tracking/base/opTrackingBase.py
+++ b/ilastik/applets/tracking/base/opTrackingBase.py
@@ -234,12 +234,12 @@ class OpTrackingBase(Operator, ExportingOperator):
             merger = get_dict_value(events[str(i - time_range[0])], "merger", [])
             res = get_dict_value(events[str(i - time_range[0])], "res", {})
 
-            logger.info(" {} dis at {}".format(len(dis), i))
-            logger.info(" {} app at {}".format(len(app), i))
-            logger.info(" {} div at {}".format(len(div), i))
-            logger.info(" {} mov at {}".format(len(mov), i))
-            logger.info(" {} merger at {}".format(len(merger), i))
-            logger.info(" {} res at {}".format(len(res), i))
+            logger.debug(" {} dis at {}".format(len(dis), i))
+            logger.debug(" {} app at {}".format(len(app), i))
+            logger.debug(" {} div at {}".format(len(div), i))
+            logger.debug(" {} mov at {}".format(len(mov), i))
+            logger.debug(" {} merger at {}".format(len(merger), i))
+            logger.debug(" {} res at {}".format(len(res), i))
 
             label2color.append({})
             mergers.append({})
@@ -456,7 +456,7 @@ class OpTrackingBase(Operator, ExportingOperator):
             if ct.size:
                 ct = ct[1:, ...]
 
-            logger.info("at timestep {}, {} traxels found".format(t, rc.shape[0]))
+            logger.debug("at timestep {}, {} traxels found".format(t, rc.shape[0]))
             count = 0
             filtered_labels_at = []
             for idx in range(rc.shape[0]):
@@ -531,7 +531,7 @@ class OpTrackingBase(Operator, ExportingOperator):
 
             if len(filtered_labels_at) > 0:
                 filtered_labels[str(int(t) - time_range[0])] = filtered_labels_at
-            logger.info("at timestep {}, {} traxels passed filter".format(t, count))
+            logger.debug("at timestep {}, {} traxels passed filter".format(t, count))
             max_traxel_id_at.append(int(rc.shape[0]))
             if count == 0:
                 empty_frame = True

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -67,9 +67,9 @@ class OpConservationTracking(OpTrackingBase):
         if slot is self.Output:
             parameters = self.Parameters.value
             trange = range(roi.start[0], roi.stop[0])
-            original = np.zeros(result.shape)
-            original = super(OpConservationTracking, self).execute(slot, subindex, roi, original).copy() # recursive call to get properly labeled image
-            result = self.LabelImage.get(roi).wait()
+            original = np.zeros(result.shape, dtype=slot.meta.dtype)
+            super(OpConservationTracking, self).execute(slot, subindex, roi, original)
+            result[:] = self.LabelImage.get(roi).wait()
             pixel_offsets=roi.start[1:-1]  # offset only in pixels, not time and channel
             for t in trange:
                 if ('time_range' in parameters
@@ -80,11 +80,11 @@ class OpConservationTracking(OpTrackingBase):
                     result[t-roi.start[0],...][:] = 0
 
             original[result != 0] = result[result != 0]
-            result = original
+            result[:] = original
         elif slot is self.MergerOutput:
             parameters = self.Parameters.value
             trange = range(roi.start[0], roi.stop[0])
-            result = self.LabelImage.get(roi).wait()
+            result[:] = self.LabelImage.get(roi).wait()
             pixel_offsets=roi.start[1:-1]  # offset only in pixels, not time and channel
             for t in trange:
                 if ('time_range' in parameters
@@ -99,7 +99,7 @@ class OpConservationTracking(OpTrackingBase):
         elif slot is self.RelabeledImage:
             parameters = self.Parameters.value
             trange = range(roi.start[0], roi.stop[0])
-            result = self.LabelImage.get(roi).wait()
+            result[:] = self.LabelImage.get(roi).wait()
             pixel_offsets=roi.start[1:-1]  # offset only in pixels, not time and channel
             for t in trange:
                 if ('time_range' in parameters
@@ -108,7 +108,7 @@ class OpConservationTracking(OpTrackingBase):
                         and 'withMergerResolution' in parameters.keys() and parameters['withMergerResolution']):
                         result[t-roi.start[0],...,0] = self._relabelMergers(result[t-roi.start[0],...,0], t, pixel_offsets, False, True)
         else:  # default bahaviour
-            result = super(OpConservationTracking, self).execute(slot, subindex, roi, result)
+            super(OpConservationTracking, self).execute(slot, subindex, roi, result)
         return result
 
     def setInSlot(self, slot, subindex, roi, value):

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -302,10 +302,25 @@ class ConservationTrackingWorkflowBase( Workflow ):
         parameters = self.trackingApplet.topLevelOperator.Parameters.value
         
         # Save state of axis ranges
-        self.prev_time_range = parameters['time_range']
-        self.prev_x_range = parameters['x_range']
-        self.prev_y_range = parameters['y_range']
-        self.prev_z_range = parameters['z_range']
+        if 'time_range' in parameters:
+            self.prev_time_range = parameters['time_range']
+        else:
+            self.prev_time_range = time_enum
+            
+        if 'x_range' in parameters:
+            self.prev_x_range = parameters['x_range']
+        else:
+            self.prev_x_range = x_range
+        
+        if 'y_range' in parameters:
+            self.prev_y_range = parameters['y_range']
+        else:
+            self.prev_y_range = y_range
+            
+        if 'z_range' in parameters:
+            self.prev_z_range = parameters['z_range']
+        else:
+            self.prev_z_range = z_range
         
         self.trackingApplet.topLevelOperator[lane_index].track(
             time_range = time_enum,


### PR DESCRIPTION
Added a couple of memory and running-time optimizations to the code:
* Optimized memory allocations in the `execute()` function of `opConservationTracking` and `opTrackingBase`
* Set some tracking logging messages to `debug` mode instead of `info` mode, since these messages where consuming a significant amount of time to print to screen

Also, added checks to make sure that `time_range`, `x_range`, `y_range`, and `z_range` are contained in the parameters when running batch processing.