### PR TITLE
Fix 1194

### DIFF
--- a/ilastik/plugins_default/vigra_objfeats_convex_hull.py
+++ b/ilastik/plugins_default/vigra_objfeats_convex_hull.py
@@ -60,11 +60,17 @@ class VigraConvexHullObjFeats(ObjectFeaturesPlugin):
         except:
             logger.error('2D Convex Hull Features: Supported Convex Hull Features: failed (Vigra commit must be f8e48031abb1158ea804ca3cbfe781ccc62d09a2 or newer).')
             names = []
+
         try:
             # 'Polygon' is NOT usable as a feature
             names.remove('Polygon')
-        except:
+        except ValueError:
             pass
+
+        if 'Center' in names:
+            # To avoid name clashes with skeleton features,
+            # rename "center" to "hull center"
+            names[names.index('Center')] = 'Hull Center'
         
         tooltips = {}
         result = dict((n, {}) for n in names)  
@@ -81,6 +87,13 @@ class VigraConvexHullObjFeats(ObjectFeaturesPlugin):
         
         # 'Polygon' is NOT usable as a feature
         del result['Polygon']
+
+        # Rename 'Center' to 'Hull Center' to avoid name clash with skeleton features
+        if 'Center' in result.keys():
+            # To avoid name clashes with skeleton features,
+            # rename "center" to "hull center"
+            result['Hull Center'] = result['Center']
+            del result['Center']
         
         # find the number of objects
         nobj = result[features[0]].shape[0]

--- a/ilastik/plugins_default/vigra_objfeats_skeleton.py
+++ b/ilastik/plugins_default/vigra_objfeats_skeleton.py
@@ -59,6 +59,11 @@ class VigraSkeletonObjFeats(ObjectFeaturesPlugin):
         except:
             logger.error('2D Skeleton Features: Supported Skeleton Features: failed (Vigra commit must be f8e48031abb1158ea804ca3cbfe781ccc62d09a2 or newer).')
             names = []
+
+        if 'Center' in names:
+            # To avoid name clashes with convex hull features,
+            # rename "center" to "skeleton center"
+            names[names.index('Center')] = 'Skeleton Center'
         
         tooltips = {}
         result = dict((n, {}) for n in names)  
@@ -70,6 +75,13 @@ class VigraSkeletonObjFeats(ObjectFeaturesPlugin):
     def _do_4d(self, image, labels, features, axes):
         
         result = vigra.analysis.extractSkeletonFeatures(labels.squeeze().astype(np.uint32))
+
+        # Rename 'Center' to 'Hull Center' to avoid name clash with skeleton features
+        if 'Center' in result.keys():
+            # To avoid name clashes with convex hull features,
+            # rename "center" to "skeleton center"
+            result['Skeleton Center'] = result['Center']
+            del result['Center']
         
         # find the number of objects
         nobj = result[features[0]].shape[0]

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -71,9 +71,9 @@ def flatten_ilastik_feature_table(table, selection, signal):
 
     for cat_name, category in computed_feature[0].iteritems():
         for feat_name, feat_array in category.iteritems():
-            if cat_name == "Default features" or \
-                    feat_name not in feature_names and \
-                    feat_name in selection:
+            if (cat_name == "Default features" or \
+                     feat_name in selection) and \
+                     feat_name not in feature_names:
                 feature_names.append(feat_name)
                 feature_cats.append(cat_name)
                 feature_channels.append((feat_array.shape[1]))

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -56,8 +56,8 @@ def flatten_ilastik_feature_table(table, selection, signal):
     signal(0)
     if frames > 1:
         computed_feature = {}
-        for t in xrange(frames - 1):
-            request = table([t, t + 1])
+        for t in xrange(frames):
+            request = table([t])
             computed_feature.update(request.wait())
             signal(100 * t / frames)
     else:


### PR DESCRIPTION
This seems to fix #1194, but I would like a review.  The issue was that some feature names were present in multiple "categories", which means they were added to the table twice.  Of course, CSV can support two columns with the same name, but the numpy `recarray` data structure can't allow duplicates in `feature_table.dtype.names`, so the duplicated feature names caused trouble.