### PR TITLE
opConservationTracking: Set the ideal_blockshape in MergerOutput and RelabeledImage

### DIFF
--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -62,6 +62,12 @@ class OpConservationTracking(OpTrackingBase):
 
         self._mergerOpCache.BlockShape.setValue( self._blockshape )
         self._relabeledOpCache.BlockShape.setValue( self._blockshape )
+        
+        frame_shape = (1,) + self.LabelImage.meta.shape[1:] # assumes t,x,y,z,c order
+        assert frame_shape[-1] == 1
+        self.MergerOutput.meta.ideal_blockshape = frame_shape
+        self.RelabeledImage.meta.ideal_blockshape = frame_shape
+        
     
     def execute(self, slot, subindex, roi, result):
         if slot is self.Output:


### PR DESCRIPTION
Set the `ideal_blockshape` to the shape of a single frame in `MergerOutput` and `RelabeledImage` since the blockshapes choosen by the `BigRequestStreamer` were not ideal.