### PR TITLE
opTrackingFeatureExtraction: Set LabelImageCacheInput slot to optional

### DIFF
--- a/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
+++ b/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
@@ -155,7 +155,7 @@ class OpTrackingFeatureExtraction(Operator):
     BlockwiseRegionFeaturesDivision = OutputSlot() 
     
     CleanLabelBlocks = OutputSlot()
-    LabelImageCacheInput = InputSlot()
+    LabelImageCacheInput = InputSlot(optional=True)
 
     RegionFeaturesCacheInputVigra = InputSlot(optional=True)
     RegionFeaturesCleanBlocksVigra = OutputSlot()


### PR DESCRIPTION
Set `LabelImageCacheInput` slot to optional, in `opTrackingFeatureExtraction`, in order to fix issue #1225 