### PR TITLE
testConservationTrackingHeadless: Removed unused import of ilastik.config

### DIFF
--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -34,8 +34,6 @@ from lazyflow.operators.opReorderAxes import OpReorderAxes
 import ilastik
 from lazyflow.utility.timer import timeLogged
 
-from ilastik.config import cfg as ilastik_config
-
 import logging
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Removed unused import of `ilastik.config` that was causing an error in the learning branch.