### PR TITLE
Fix 1188: Convex hull and skeleton features are now being used in the tracking workflow

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -31,6 +31,7 @@ from ilastik.applets.objectExtraction.opObjectExtraction import default_features
 from ilastik.applets.objectClassification.opObjectClassification import OpObjectClassification
 
 import os
+import copy
 import vigra
 
 import numpy
@@ -281,9 +282,9 @@ class ObjectClassificationGui(LabelingGui):
     @pyqtSlot()
     def handleSubsetFeaturesClicked(self):
         mainOperator = self.topLevelOperatorView
-        computedFeatures = mainOperator.ComputedFeatureNames([]).wait()
+        computedFeatures = copy.deepcopy(mainOperator.ComputedFeatureNames([]).wait())
         if mainOperator.SelectedFeatures.ready():
-            selectedFeatures = mainOperator.SelectedFeatures([]).wait()
+            selectedFeatures = copy.deepcopy(mainOperator.SelectedFeatures([]).wait())
         else:
             selectedFeatures = computedFeatures
 

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -321,17 +321,15 @@ class ObjectClassificationGui(LabelingGui):
         for pluginInfo in plugins:
             availableFeatures = pluginInfo.plugin_object.availableFeatures(fakeimg, fakelabels)
             if len(availableFeatures) > 0:
-                if pluginInfo.name in self.applet._selectedFeatures.keys() and not pluginInfo.name in computedFeatures.keys():
-                    computedFeatures[pluginInfo.name] = availableFeatures
+                if pluginInfo.name in self.applet._selectedFeatures.keys(): 
+                    assert pluginInfo.name in computedFeatures.keys(), 'Object Classification: {} not found in available (computed) object features'.format(pluginInfo.name)
 
-                if not pluginInfo.name in selectedFeatures and \
-                    pluginInfo.name in self.applet._selectedFeatures and \
-                    len(self.applet._selectedFeatures[pluginInfo.name].keys()) > 0:
+                if not pluginInfo.name in selectedFeatures and pluginInfo.name in self.applet._selectedFeatures:
                         selectedFeatures[pluginInfo.name]=dict()
-                        if pluginInfo.name in self.applet._selectedFeatures.keys():
-                            for feature in self.applet._selectedFeatures[pluginInfo.name].keys():
-                                if feature in availableFeatures.keys():
-                                    selectedFeatures[pluginInfo.name][feature] = availableFeatures[feature]
+
+                        for feature in self.applet._selectedFeatures[pluginInfo.name].keys():
+                            if feature in availableFeatures.keys():
+                                selectedFeatures[pluginInfo.name][feature] = availableFeatures[feature]
 
         dlg = FeatureSubSelectionDialog(computedFeatures,
                                         selectedFeatures=selectedFeatures, ndim=ndim)

--- a/ilastik/applets/tracking/conservation/config.py
+++ b/ilastik/applets/tracking/conservation/config.py
@@ -39,6 +39,61 @@ selectedFeaturesDiv = {
     }
 }
 
+allFeaturesObjectCount = {
+    '2D Skeleton Features': {
+        'Diameter': {},
+        'Total Length': {},
+        'Euclidean Diameter': {},
+        'Hole Count': {},
+        'Branch Count': {},
+        'Skeleton Center': {},
+        'Terminal 1': {},
+        'Terminal 2': {},
+        'Average Length': {},
+        'Total Length': {}
+    },
+    '2D Convex Hull Features': {
+        'Perimeter': {},
+        'Defect Area Kurtosis': {},
+        'Defect Mean Displacement': {},
+        'Area': {}, 
+        'Defect Count': {},
+        'Defect Area Variance': {},
+        'Input Count': {},
+        'Input Perimeter': {},
+        'Defect Area List': {},
+        'Defect Area Skewness': {},
+        'Rugosity': {},
+        'Defect Area Mean': {},
+        'Convexity': {},
+        'Hull Center': {},
+        'Input Center': {},
+        'Input Area': {}
+    },
+    'Standard Object Features': {
+        'Coord<Maximum>': {},
+        'Coord<Minimum>': {},
+        'Kurtosis': {},
+        'Kurtosis in neighborhood': {},
+        'Maximum': {},
+        'Maximum in neighborhood': {},
+        'Minimum': {},
+        'Minimum in neighborhood': {},               
+        'Count': {},
+        'Variance': {},
+        'Variance in neighborhood': {},
+        'Mean': {},
+        'Mean in neighborhood': {},
+        'Skewness': {},
+        'Skewness in neighborhood': {},
+        'Sum': {},
+        'Sum in neighborhood': {},
+        'RegionRadii': {},
+        'RegionAxes': {},
+        'RegionCenter': {}
+    }
+}
+
 selectedFeaturesObjectCount = {
     '2D Skeleton Features': {
         'Diameter': {},

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -64,14 +64,10 @@ class ConservationTrackingWorkflowBase( Workflow ):
             self.opticalTranslationApplet = OpticalTranslationApplet(workflow=self)
                                                                    
         self.objectExtractionApplet = TrackingFeatureExtractionApplet(workflow=self, interactive=False,
-                                                                      name="Object Feature Computation")                                                                      
-
-        vigra_features = list((set(config.vigra_features)).union(config.selected_features_objectcount[config.features_vigra_name])) 
-        feature_names_vigra = {}
-        feature_names_vigra[config.features_vigra_name] = { name: {} for name in vigra_features }
+                                                                      name="Object Feature Computation")                                                                     
         
         opObjectExtraction = self.objectExtractionApplet.topLevelOperator
-        opObjectExtraction.FeatureNamesVigra.setValue(feature_names_vigra)
+        opObjectExtraction.FeatureNamesVigra.setValue(configConservation.allFeaturesObjectCount)        
         
         self.divisionDetectionApplet = self._createDivisionDetectionApplet(configConservation.selectedFeaturesDiv) # Might be None
 


### PR DESCRIPTION
Fix #1188

The conservation tracking workflow was training the RF classifier only with the `Standard Object Features`, and it was ignoring the skeleton and convex hull features. In order to solve this problem the following changes were made:

1. The `opObjectExtraction` `Features` slot was populated with the `Standard Object Features`, `Skeleton Features` and `Convex Hull Features` on the initialization of the conservation tracking workflow.

2. In `objectClassificationGui` the values of the `computedFeatureNames` and `selectedFeatureNames` slots were obtained using a deep copy in order to prevent modfying them directly from the GUI.
