### PR TITLE
Blockwise Carving Refactor

### DIFF
--- a/ilastik/config.py
+++ b/ilastik/config.py
@@ -37,6 +37,7 @@ default_config = """
 [ilastik]
 debug: false
 plugin_directories: ~/.ilastik/plugins,
+default_blocksize: 256
 
 [lazyflow]
 threads: -1

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1396,6 +1396,7 @@ class IlastikShell(QMainWindow):
 
             self.openProjectFile(projectFilePath)
 
+    @timeLogged(logger, logging.INFO)
     def openProjectFile(self, projectFilePath, force_readonly=False):
         """
         Explicitly required by ShellABC
@@ -1426,6 +1427,7 @@ class IlastikShell(QMainWindow):
             QApplication.restoreOverrideCursor()
             self.statusBar.clearMessage()
 
+    @timeLogged(logger, logging.INFO)
     def _loadProject(self, hdf5File, projectFilePath, workflow_class, readOnly, importFromPath=None):
         """
         Load the data from the given hdf5File (which should already be open).

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -125,46 +125,6 @@ class CarvingGui(LabelingGui):
         self.topLevelOperatorView.Segmentation.notifyDirty( bind( self._update_rendering ) )
         self.topLevelOperatorView.HasSegmentation.notifyValueChanged( bind( self._updateGui ) )
 
-        ## uncertainty
-
-        #self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(False)
-        #self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(False)
-
-        #def onUncertaintyFGButton():
-        #    logger.debug( "uncertFG button clicked" )
-        #    pos = self.topLevelOperatorView.getMaxUncertaintyPos(label=2)
-        #    self.editor.posModel.slicingPos = (pos[0], pos[1], pos[2])
-        #self.labelingDrawerUi.pushButtonUncertaintyFG.clicked.connect(onUncertaintyFGButton)
-
-        #def onUncertaintyBGButton():
-        #    logger.debug( "uncertBG button clicked" )
-        #    pos = self.topLevelOperatorView.getMaxUncertaintyPos(label=1)
-        #    self.editor.posModel.slicingPos = (pos[0], pos[1], pos[2])
-        #self.labelingDrawerUi.pushButtonUncertaintyBG.clicked.connect(onUncertaintyBGButton)
-
-        #def onUncertaintyCombo(value):
-        #    if value == 0:
-        #        value = "none"
-        #        self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(False)
-        #        self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(False)
-        #        self._showUncertaintyLayer = False
-        #    else:
-        #        if value == 1:
-        #            value = "localMargin"
-        #        elif value == 2:
-        #            value = "exchangeCount"
-        #        elif value == 3:
-        #            value = "gabow"
-        #        else:
-        #            raise RuntimeError("unhandled case '%r'" % value)
-        #        self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(True)
-        #        self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(True)
-        #        self._showUncertaintyLayer = True
-        #        logger.debug( "uncertainty changed to %r" % value )
-        #    self.topLevelOperatorView.UncertaintyType.setValue(value)
-        #    self.updateAllLayers() #make sure that an added/deleted uncertainty layer is recognized
-        #self.labelingDrawerUi.uncertaintyCombo.currentIndexChanged.connect(onUncertaintyCombo)
-
         ## background priority
         
         def onBackgroundPrioritySpin(value):
@@ -651,20 +611,6 @@ class CarvingGui(LabelingGui):
             # Tell the editor where to draw label data
             self.editor.setLabelSink(labelsrc)
 
-        #uncertainty
-        #if self._showUncertaintyLayer:
-        #    uncert = self.topLevelOperatorView.Uncertainty
-        #    if uncert.ready():
-        #        colortable = []
-        #        for i in range(256-len(colortable)):
-        #            r,g,b,a = i,0,0,i
-        #            colortable.append(QColor(r,g,b,a).rgba())
-        #        layer = ColortableLayer(LazyflowSource(uncert), colortable, direct=True)
-        #        layer.name = "Uncertainty"
-        #        layer.visible = True
-        #        layer.opacity = 0.3
-        #        layers.append(layer)
-       
         #segmentation 
         seg = self.topLevelOperatorView.Segmentation
         if seg.ready():

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -106,9 +106,6 @@ class CarvingGui(LabelingGui):
         tagged_shape.update( topLevelOperatorView.InputData.meta.getTaggedShape() )
         is_3d = (tagged_shape['x'] > 1 and tagged_shape['y'] > 1 and tagged_shape['z'] > 1)
 
-        # TODO: fix
-        #is_3d = False;
-
         if is_3d:
             try:
                 self._renderMgr = RenderingManager( self.editor.view3d )

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -717,7 +717,7 @@ class CarvingGui(LabelingGui):
             layer = ColortableLayer(LazyflowSource(sv), colortable, direct=True)
             layer.name = "Supervoxels"
             layer.setToolTip("<html>This layer shows the partitioning of the input image into <b>supervoxels</b>. The carving " \
-                             "algorithm uses these tiny puzzle-piceces to piece together the segmentation of an " \
+                             "algorithm uses these tiny puzzle-pieces to piece together the segmentation of an " \
                              "object. Sometimes, supervoxels are too large and straddle two distinct objects " \
                              "(undersegmentation). In this case, it will be impossible to achieve the desired " \
                              "segmentation. This layer helps you to understand these cases.</html>")

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -110,7 +110,8 @@ class CarvingGui(LabelingGui):
             try:
                 self._renderMgr = RenderingManager( self.editor.view3d )
                 self._shownObjects3D = {}
-                self.render = True
+                # TODO: fix
+                #self.render = True
             except:
                 self.render = False
 

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -62,7 +62,6 @@ class CarvingGui(LabelingGui):
         #members
         self._doneSegmentationLayer = None
         self._showSegmentationIn3D = False
-        #self._showUncertaintyLayer = False
         #end: members
 
         labelingSlots = LabelingGui.LabelingSlots()
@@ -622,10 +621,8 @@ class CarvingGui(LabelingGui):
             self.editor.setLabelSink(labelsrc)
 
         #segmentation 
-        seg = self.topLevelOperatorView.Segmentation
+        seg = self.topLevelOperatorView._opSegmentationCache.Output
         if seg.ready():
-            #source = RelabelingArraySource(seg)
-            #source.setRelabeling(numpy.arange(256, dtype=numpy.uint8))
             colortable = [QColor(0,0,0,0).rgba(), QColor(0,0,0,0).rgba(), QColor(0,255,0).rgba()]
             for i in range(256-len(colortable)):
                 r,g,b = numpy.random.randint(0,255), numpy.random.randint(0,255), numpy.random.randint(0,255)

--- a/ilastik/workflows/carving/carvingWorkflow.py
+++ b/ilastik/workflows/carving/carvingWorkflow.py
@@ -90,8 +90,6 @@ class CarvingWorkflow(Workflow):
                                            hintOverlayFile=hintoverlayFile,
                                            pmapOverlayFile=pmapoverlayFile)
         
-        #self.carvingApplet.topLevelOperator.MST.connect(self.preprocessingApplet.topLevelOperator.PreprocessedData)
-        
         # Expose to shell
         self._applets = []
         self._applets.append(self.projectMetadataApplet)

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -199,8 +199,8 @@ class OpCarving(Operator):
         if self._mst is None:
             return
         with Timer() as timer:
-            self._done_lut = numpy.zeros(self._mst.numNodes+1, dtype=numpy.int32)
-            self._done_seg_lut = numpy.zeros(self._mst.numNodes+1, dtype=numpy.int32)
+            self._done_lut = numpy.zeros(self._mst.nodeNum+1, dtype=numpy.int32)
+            self._done_seg_lut = numpy.zeros(self._mst.nodeNum+1, dtype=numpy.int32)
             logger.info( "building 'done' luts" )
             for name, objectSupervoxels in self._mst.object_lut.iteritems():
                 if name == self._currObjectName:
@@ -623,6 +623,7 @@ class OpCarving(Operator):
             
         elif slot == self.Supervoxels:
             #avoid data being copied
+            # TODO: this assumes that supervoxels are allocated and calculated completely? -- fix
             temp = self._mst.supervoxelUint32[sl[1:4]]
             temp.shape = (1,) + temp.shape + (1,)
         elif slot  == self.DoneObjects:
@@ -711,7 +712,7 @@ class OpCarving(Operator):
             params["uncertainty"] = self.UncertaintyType.value
             params["noBiasBelow"] = noBiasBelow
             
-            unaries =  numpy.zeros((self._mst.numNodes+1,labelCount+1), dtype=numpy.float32)
+            unaries =  numpy.zeros((self._mst.nodeNum+1,labelCount+1), dtype=numpy.float32)
             self._mst.run(unaries, **params)
             logger.info( " ... carving took %f sec." % (time.time()-t1) )
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -287,6 +287,7 @@ class OpCarving(Operator):
         assert len(position3d) == 3
 
         #find the supervoxel that was clicked
+        # TODO: process blockwise
         sv = self._mst.supervoxelUint32[position3d]
         names = []
         for name, objectSupervoxels in self._mst.object_lut.iteritems():
@@ -610,7 +611,7 @@ class OpCarving(Operator):
 
     def execute(self, slot, subindex, roi, result):
         self._mst = self.MST.value
-        
+
         if slot == self.AllObjectNames:
             ret = self._mst.object_names.keys()
             return ret
@@ -623,9 +624,7 @@ class OpCarving(Operator):
             
         elif slot == self.Supervoxels:
             #avoid data being copied
-            # TODO: this assumes that supervoxels are allocated and calculated completely? -- fix
-            temp = self._mst.supervoxelUint32[sl[1:4]]
-            temp.shape = (1,) + temp.shape + (1,)
+            temp = self._mst.supervoxelUint32(sl).wait()
         elif slot  == self.DoneObjects:
             #avoid data being copied
             if self._done_lut is None:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -307,7 +307,6 @@ class OpCarving(Operator):
         logger.info( "click on %r, supervoxel=%d: %r" % (position3d, sv, names) )
         return names
 
-    @Operator.forbidParallelExecute
     def attachVoxelLabelsToObject(self, name, fgVoxels, bgVoxels):
         """
         Attaches Voxellabes to an object called name.
@@ -315,7 +314,6 @@ class OpCarving(Operator):
         self._mst.object_seeds_fg_voxels[name] = fgVoxels
         self._mst.object_seeds_bg_voxels[name] = bgVoxels
 
-    @Operator.forbidParallelExecute
     def clearCurrentLabeling(self, trigger_recompute=True):
         """
         Clears the current labeling.
@@ -426,8 +424,7 @@ class OpCarving(Operator):
         
         return True
 
-    
-    @Operator.forbidParallelExecute
+
     def deleteObject_impl(self, name):
         """
         Deletes an object called name.
@@ -469,8 +466,7 @@ class OpCarving(Operator):
         self.HasSegmentation.setValue(False)
         
         return True
-    
-    @Operator.forbidParallelExecute
+
     def saveCurrentObject(self):
         """
         Saves the objects which is currently edited.
@@ -483,7 +479,6 @@ class OpCarving(Operator):
             return name
         return ""
 
-    @Operator.forbidParallelExecute
     def saveCurrentObjectAs(self, name):
         """
         Saves current object as name.

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -110,7 +110,6 @@ class OpCarving(Operator):
     def __init__(self, graph=None, hintOverlayFile=None, pmapOverlayFile=None, parent=None):
         super(OpCarving, self).__init__(graph=graph, parent=parent)
         self.opLabelArray = OpDenseLabelArray( parent=self )
-        #self.opLabelArray.EraserLabelValue.setValue( 100 )
         self.opLabelArray.MetaInput.connect( self.InputData )
         
         self._hintOverlayFile = hintOverlayFile
@@ -332,12 +331,6 @@ class OpCarving(Operator):
         assert name in self._mst.object_seeds_bg_voxels
         assert name in self._mst.bg_priority
         assert name in self._mst.no_bias_below
-
-        #lut_segmentation = self._mst.segmentation.lut[:]
-        #lut_objects = self._mst.objects.lut[:]
-        #lut_seeds = self._mst.seeds.lut[:]
-        ## clean seeds
-        #lut_seeds[:] = 0
 
         # set foreground and background seeds
         fgVoxelsSeedPos = self._mst.object_seeds_fg_voxels[name]
@@ -621,10 +614,10 @@ class OpCarving(Operator):
             #avoid data being copied
             temp = self._mst.getVoxelSegmentation(roi=roi)
             temp.shape = (1,) + temp.shape + (1,)
-            
         elif slot == self.Supervoxels:
             #avoid data being copied
-            temp = self._mst.supervoxelUint32(sl).wait()
+            temp = self._mst.supervoxelUint32(sl[1:4]).wait()
+            temp.shape = (1,) + temp.shape + (1,)
         elif slot  == self.DoneObjects:
             #avoid data being copied
             if self._done_lut is None:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -222,9 +222,11 @@ class OpCarving(Operator):
         
     def setupOutputs(self):
         self.Segmentation.meta.assignFrom(self.InputData.meta)
-        self.Segmentation.meta.dtype = numpy.int32
-        
+        self.Segmentation.meta.dtype = numpy.uint8
+
         self.Supervoxels.meta.assignFrom(self.Segmentation.meta)
+        self.Supervoxels.meta.dtype = numpy.uint32
+
         self.DoneObjects.meta.assignFrom(self.Segmentation.meta)
         self.DoneSegmentation.meta.assignFrom(self.Segmentation.meta)
 

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -307,7 +307,6 @@ class OpMstSegmentorProvider(Operator):
         self.MST.meta.shape = (1,)
         self.MST.meta.dtype = object
 
-    @Operator.forbidParallelExecute
     def execute(self, slot, subindex, unused_roi, result):
         assert slot == self.MST, "Invalid output slot: {}".format(slot.name)
 
@@ -364,6 +363,8 @@ class OpMstSegmentorProvider(Operator):
                     mst.preprocess(labelVolume[0,...,0], numpy.asarray(featureVolume[0,...,0], numpy.float32), TinyVector(block_roi[1:-1]))
 
                     updateProgressBar(b_id, block_count, labels_roi, mst, mstBlockTimer)
+
+            mst.finalize()
 
             result[0] = mst
             return result

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -441,8 +441,8 @@ class OpPreprocessing(Operator):
         innerCacheBlockShape = (256,256,256,256,256)
         outerCacheBlockShape = (512,512,512,512,512)
         # TODO: remove testing values
-        #innerCacheBlockShape = (100,100,100,100,100)
-        #outerCacheBlockShape = (100,100,100,100,100)
+        innerCacheBlockShape = (100,100,100,100,100)
+        outerCacheBlockShape = (100,100,100,100,100)
 
         self._opFilterCache.fixAtCurrent.setValue(False)
         self._opFilterCache.innerBlockShape.setValue( innerCacheBlockShape )
@@ -482,26 +482,16 @@ class OpPreprocessing(Operator):
         #self.applet.topLevelOperator.ProjectDataGroup.ready()
 
         # opWatershedCache
-        self._opWatershedCache.fixAtCurrent.setValue(False)
+        h5PreprocessingGrp = self._hdf5File.require_group('preprocessing')
+        h5WatershedGrp = h5PreprocessingGrp.require_group('watershed_labels')
+        h5WatershedCached = len(h5WatershedGrp.keys()) > 0
+
+        self._opWatershedCache.fixAtCurrent.setValue(h5WatershedCached)
         self._opWatershedCache.innerBlockShape.setValue( innerCacheBlockShape )
         self._opWatershedCache.outerBlockShape.setValue( outerCacheBlockShape )
 
-        preprocessingKey = 'preprocessing'
-        watershedLabelsKey = 'watershed_labels'
-
-        try:
-            h5PreprocessingGrp = self._hdf5File[preprocessingKey]
-        except:
-            h5PreprocessingGrp = self._hdf5File.create_group(preprocessingKey)
-
-        try:
-            h5WatershedGrp = h5PreprocessingGrp[watershedLabelsKey]
-        except:
-            h5WatershedGrp = h5PreprocessingGrp.create_group(watershedLabelsKey)
-
         self._hdf5File.file.flush()
 
-        self._opWatershedCache.fixAtCurrent.setValue( self.applet.writeprotected )
         self._opWatershedCache.H5CacheGroup.setValue( h5WatershedGrp )
 
 

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -228,6 +228,7 @@ class OpMstSegmentorProvider(Operator):
         self.MST.meta.shape = (1,)
         self.MST.meta.dtype = object
 
+    @Operator.forbidParallelExecute
     def execute(self, slot, subindex, unused_roi, result):
         assert slot == self.MST, "Invalid output slot: {}".format(slot.name)
 
@@ -241,11 +242,13 @@ class OpMstSegmentorProvider(Operator):
                 self.applet.progressSignal.emit(p)
                 self.applet.progress = p
 
+            gridSeg = mst.gridSegmentor
+
             logger.info( "Segmentor preprocessed block: {} out of {}, took {} seconds".format( blk + 1, max_blk, timer.seconds() ) )
             logger.info( "  roi: {}".format(roi) )
             logger.info( "  mst: nodes: {} (max id: {}), edges: {} (max id: {})".format(
-                        mst.gridSegmentor.nodeNum(), mst.gridSegmentor.maxNodeId(),
-                        mst.gridSegmentor.edgeNum(), mst.gridSegmentor.maxEdgeId()) )
+                        gridSeg.nodeNum(), gridSeg.maxNodeId(),
+                        gridSeg.edgeNum(), gridSeg.edgeNum()) )#gridSeg.maxEdgeId()) ) # TODO: why does gridSeg.maxEdgeId() crash?
             logger.info( "  memory: used {} out of {} total avail (cache: {}, compute: {})".format(
                         Memory.format(Memory.getMemoryUsage()),
                         Memory.format(Memory.getAvailableRam()),

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -206,7 +206,7 @@ class OpSimpleWatershed(Operator):
 
             result_view[...] += old_max_seed_value
 
-            logger.info( "Watershed took {} seconds - calculated range {}: {}-{}, offset {}".format(watershedTimer.seconds(), result_range, result_min, result_max, old_max_seed_value))
+            logger.info( "Watershed took {} seconds - calculated range {}: {}-{}, offset {}, roi: {}".format(watershedTimer.seconds(), result_range, result_min, result_max, old_max_seed_value, roi))
 
         return result
 

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -248,7 +248,7 @@ class OpMstSegmentorProvider(Operator):
             logger.info( "  roi: {}".format(roi) )
             logger.info( "  mst: nodes: {} (max id: {}), edges: {} (max id: {})".format(
                         gridSeg.nodeNum(), gridSeg.maxNodeId(),
-                        gridSeg.edgeNum(), gridSeg.edgeNum()) )#gridSeg.maxEdgeId()) ) # TODO: why does gridSeg.maxEdgeId() crash?
+                        gridSeg.edgeNum(), gridSeg.maxEdgeId()) ) 
             logger.info( "  memory: used {} out of {} total avail (cache: {}, compute: {})".format(
                         Memory.format(Memory.getMemoryUsage()),
                         Memory.format(Memory.getAvailableRam()),

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -165,7 +165,6 @@ class OpFilter(Operator):
 
 
 # TODO: Split into variadic operators: OpBlockwiseFold, OpStats
-# TODO: fix duplicatation (time 2min on test project)
 class OpBlockwiseTotalStats(Operator):
     MINIMUM = 'minimum'
     MAXIMUM = 'maximum'

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -225,7 +225,7 @@ class OpNormalize255(Operator):
     MAXIMUM = 'maximum'
 
     Input = InputSlot()
-    TotalStats = InputSlot(value={MINIMUM:-128.0, MAXIMUM:127.0}) # numpy.min(result)
+    TotalStats = InputSlot(value={MINIMUM:-128.0, MAXIMUM:127.0})
     Output = OutputSlot()
 
     def setupOutputs(self):

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -330,11 +330,11 @@ class OpPreprocessing(Operator):
 
         self._opFilterNormalize = OpNormalize255( parent=self )
         self._opFilterNormalize.Input.connect( self._opFilter.Output )
-        
+
         self._opFilterCache = OpBlockedArrayCache( parent=self )
 
         self._opWatershed = OpSimpleWatershed( parent=self )
-        
+
         self._opWatershedCache = OpBlockedArrayCache( parent=self )
 
         self._opOverlayFilter = OpFilter( parent=self )
@@ -395,11 +395,11 @@ class OpPreprocessing(Operator):
         self.PreprocessedData.meta.shape = (1,)
         self.PreprocessedData.meta.dtype = object
 
-        # TODO: Fix corruption issue (maybe try opSplitRequestsBlockwise everywhere instead?)
         innerCacheBlockShape = (256,256,256,256,256)
-        outerCacheBlockShape = (10000,10000,10000,10000,10000) # must be larger than max block size, otherwise data is corrupted
+        outerCacheBlockShape = (512,512,512,512,512)
+        # TODO: remove testing values
         innerCacheBlockShape = (100,100,100,100,100)
-        outerCacheBlockShape = (100,100,100,100,100) # must be larger than max block size, otherwise data is corrupted
+        outerCacheBlockShape = (100,100,100,100,100)
 
         self._opFilterCache.fixAtCurrent.setValue(False)
         self._opFilterCache.innerBlockShape.setValue( innerCacheBlockShape )

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -556,7 +556,7 @@ class OpPreprocessing(Operator):
         self._opOverlayCache.fixAtCurrent.setValue(False)
         self._opOverlayCache.innerBlockShape.setValue( cacheBlockShape )
         self._opOverlayCache.outerBlockShape.setValue( cacheBlockShape )
-        self._opOverlayCache.Input.connect( self._opRawNormalize.Output )
+        self._opOverlayCache.Input.connect( self._opOverlayNormalize.Output )
 
         self._opInputCache.fixAtCurrent.setValue(False)
         self._opInputCache.innerBlockShape.setValue( cacheBlockShape )

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -88,9 +88,6 @@ class PreprocessingGui(QMainWindow):
         self.drawer.invertWatershedSourceCheckbox.toggled.connect( self.handleInvertWatershedSourceChange )
         self.drawer.writeprotectBox.stateChanged.connect(self.handleWriterprotectStateChanged)
 
-        #FIXME: for release 0.6, disable this (the reset button made the gui even more complicated)            
-        #self.drawer.resetButton.clicked.connect(self.topLevelOperatorView.reset)
-
         # Slot change handlers (in case the operator is somehow changed *outside* the gui, such as by the workflow.
         self.topLevelOperatorView.Filter.notifyDirty(self.updateDrawerFromOperator)
         self.topLevelOperatorView.Sigma.notifyDirty(self.updateDrawerFromOperator)
@@ -158,9 +155,7 @@ class PreprocessingGui(QMainWindow):
     
     def enableReset(self,er):
         pass
-        #TODO: re-enable this after the 0.6 release
-        #self.drawer.resetButton.setEnabled(er)
-    
+
     def centralWidget( self ):
         return self.centralGui
     

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -19,53 +19,62 @@
 #		   http://ilastik.org/license.html
 ###############################################################################
 from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
+from lazyflow.utility.timer import timeLogged
+
 import h5py
-import numpy
 import os
 
 from watershed_segmentor import WatershedSegmentor
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 class PreprocessingSerializer( AppletSerializer ):
     def __init__(self, preprocessingTopLevelOperator, *args, **kwargs):
         super(PreprocessingSerializer, self).__init__(*args, **kwargs)
         self._o = preprocessingTopLevelOperator 
         self.caresOfHeadless = True
-        
+
+
+    @timeLogged(logger, logging.INFO)
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         preproc = topGroup
         
         for opPre in self._o.innerOperators:
             mst = opPre._prepData[0]
-            
+
             if mst is not None:
-                
+
                 #The values to be saved for sigma and filter are the
                 #values of the last valid preprocess
                 #!These may differ from the current settings!
-                
+
                 deleteIfPresent(preproc, "sigma")
                 deleteIfPresent(preproc, "filter")
                 deleteIfPresent(preproc, "watershed_source")
                 deleteIfPresent(preproc, "invert_watershed_source")
                 deleteIfPresent(preproc, "graph")
-                
+
                 preproc.create_dataset("sigma",data= opPre.initialSigma)
                 preproc.create_dataset("filter",data= opPre.initialFilter)
                 ws_source = str(opPre.WatershedSource.value)
                 assert isinstance( ws_source, str ), "WatershedSource was {}, but it should be a string.".format( ws_source )
-                preproc.create_dataset("watershed_source", data=ws_source)                 
+                preproc.create_dataset("watershed_source", data=ws_source)
                 preproc.create_dataset("invert_watershed_source", data=opPre.InvertWatershedSource.value)
-                
+
                 preprocgraph = getOrCreateGroup(preproc, "graph")
                 mst.saveH5G(preprocgraph)
-            
+
             opPre._unsavedData = False
-            
+
+
+    @timeLogged(logger, logging.INFO)
     def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath,headless = False):
         
         assert "sigma" in topGroup.keys()
         assert "filter" in topGroup.keys()
-        
+
         sigma = topGroup["sigma"].value
         sfilter = topGroup["filter"].value
         try:
@@ -74,7 +83,7 @@ class PreprocessingSerializer( AppletSerializer ):
         except KeyError:
             watershed_source = None
             invert_watershed_source = False
-        
+
         if "graph" in topGroup.keys():
             graphgroup = topGroup["graph"]
         else:
@@ -86,7 +95,7 @@ class PreprocessingSerializer( AppletSerializer ):
                     raise RuntimeError("Could not find data at " + filePath)
                 filePath = self.repairFile(filePath,"*.h5")
             graphgroup = h5py.File(filePath,"r")["graph"]
-            
+
         for opPre in self._o.innerOperators:
             opPre.initialSigma = sigma
             opPre.Sigma.setValue(sigma)
@@ -96,7 +105,7 @@ class PreprocessingSerializer( AppletSerializer ):
             opPre.initialFilter = sfilter
             opPre.Filter.setValue(sfilter)
 
-            mst = WatershedSegmentor(labels=opPre._opWatershedCache.Output,
+            mst = WatershedSegmentor(labels=opPre._opWatershedArrayCache.Output,
                                      h5file=graphgroup)
             opPre._prepData[0] = mst
 
@@ -105,6 +114,7 @@ class PreprocessingSerializer( AppletSerializer ):
             opPre._dirty = False
             opPre.PreprocessedData.setDirty()
             opPre.enableDownstream(True)
+
            
     def isDirty(self):
         for opPre in self._o.innerOperators:            

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -96,8 +96,9 @@ class PreprocessingSerializer( AppletSerializer ):
                 opPre.InvertWatershedSource.setValue( invert_watershed_source )
             opPre.initialFilter = sfilter
             opPre.Filter.setValue(sfilter)
-            
-            mst = WatershedSegmentor(h5file=graphgroup)
+
+            #TODO: Cleanup how labels are handled
+            mst = WatershedSegmentor(labels=opPre._opMstProvider.LabelImage, h5file=graphgroup)
             opPre._prepData = numpy.array([mst])
         
             

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -106,7 +106,9 @@ class PreprocessingSerializer( AppletSerializer ):
             opPre.Filter.setValue(sfilter)
 
             mst = WatershedSegmentor(labels=opPre._opWatershedArrayCache.Output,
-                                     h5file=graphgroup)
+                                     blockSize=opPre._blockSize,
+                                     prepGrp=topGroup,
+                                     graphGrp=graphgroup)
             opPre._prepData[0] = mst
 
             opPre.applet.writeprotected = True

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -89,6 +89,8 @@ class PreprocessingSerializer( AppletSerializer ):
             
         for opPre in self._o.innerOperators:
             
+            opPre.applet.writeprotected = True
+
             opPre.initialSigma = sigma
             opPre.Sigma.setValue(sigma)
             if watershed_source:
@@ -97,14 +99,11 @@ class PreprocessingSerializer( AppletSerializer ):
             opPre.initialFilter = sfilter
             opPre.Filter.setValue(sfilter)
 
-            #TODO: Cleanup how labels are handled
-            mst = WatershedSegmentor(labels=opPre._opMstProvider.LabelImage, h5file=graphgroup)
-            opPre._prepData = numpy.array([mst])
-        
-            
+            mst = WatershedSegmentor(labels=opPre._opWatershedCache.Output,
+                                     h5file=graphgroup)
+            opPre._prepData[0] = mst
+
             opPre._dirty = False
-            opPre.applet.writeprotected = True
-            
             opPre.PreprocessedData.setDirty()
             opPre.enableDownstream(True)
            

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -88,9 +88,6 @@ class PreprocessingSerializer( AppletSerializer ):
             graphgroup = h5py.File(filePath,"r")["graph"]
             
         for opPre in self._o.innerOperators:
-            
-            opPre.applet.writeprotected = True
-
             opPre.initialSigma = sigma
             opPre.Sigma.setValue(sigma)
             if watershed_source:
@@ -102,6 +99,8 @@ class PreprocessingSerializer( AppletSerializer ):
             mst = WatershedSegmentor(labels=opPre._opWatershedCache.Output,
                                      h5file=graphgroup)
             opPre._prepData[0] = mst
+
+            opPre.applet.writeprotected = True
 
             opPre._dirty = False
             opPre.PreprocessedData.setDirty()

--- a/ilastik/workflows/carving/preprocessingViewerGui.py
+++ b/ilastik/workflows/carving/preprocessingViewerGui.py
@@ -50,16 +50,6 @@ class PreprocessingViewerGui( LayerViewerGui ):
             watershedLayer.opacity = 1.0
             layers.append(watershedLayer)
 
-        ''' FIXME: disabled for 0.6 release
-        wsSourceSlot = opLane.WatershedSourceImage
-        if wsSourceSlot.ready():
-            wsSourceLayer = self.createStandardLayerFromSlot( wsSourceSlot )
-            wsSourceLayer.name = "Watershed Source"
-            wsSourceLayer.visible = False
-            wsSourceLayer.opacity = 1.0
-            layers.append( wsSourceLayer )
-        '''
-
         filteredSlot = opLane.FilteredImage
         if filteredSlot.ready():
             filteredLayer = self.createStandardLayerFromSlot( filteredSlot )
@@ -84,4 +74,5 @@ class PreprocessingViewerGui( LayerViewerGui ):
             inputLayer.opacity = 1.0
             layers.append( inputLayer )
 
-        return layers 
+        return layers
+

--- a/ilastik/workflows/carving/watershed_segmentor.py
+++ b/ilastik/workflows/carving/watershed_segmentor.py
@@ -70,8 +70,12 @@ class WatershedSegmentor(object):
     @timeLogged(logger, logging.INFO)
     def preprocess(self, labels, volume_features, roi_stop):
         assert not self.hasSeg, "gridSegmentor was finalized; cannot preprocess."
+        assert not self.gridSegmentor.isFinalized(), "gridSegmentor was finalized; cannot preprocess."
         self.gridSegmentor.preprocessing(labels=labels, weightArray=volume_features, roiEnd=roi_stop)
         self.nodeNum = self.gridSegmentor.nodeNum()
+
+    def finalize(self):
+        self.gridSegmentor.finalize()
 
     @timeLogged(logger, logging.INFO)
     def run(self, unaries, prios = None, noBiasBelow = 0, **kwargs):
@@ -123,6 +127,12 @@ class WatershedSegmentor(object):
     def saveH5G(self, h5g):
         g = h5g
         gridSeg = self.gridSegmentor
+
+        if not gridSeg.isFinalized():
+            logger.warning(
+                "GridSegmentor must be finalized prior to saving graph: '{}'.  File a bug report.".format(
+                    g.file.filename))
+            gridSeg.finalize()
 
         def saveDataArray(group_name, data_array):
             gc.collect()

--- a/ilastik/workflows/carving/watershed_segmentor.py
+++ b/ilastik/workflows/carving/watershed_segmentor.py
@@ -20,29 +20,26 @@ class WatershedSegmentor(object):
 
         if h5file is None:
             self.supervoxelUint32 = labels
-            self.volumeFeat = volume_feat.squeeze()
-            if self.volumeFeat.ndim == 3:
+            ndim = self.supervoxelUint32.value.squeeze().ndim
+            if ndim == 3:
                 self.gridSegmentor = ilastiktools.GridSegmentor_3D_UInt32()
-                self.gridSegmentor.init()
-
-            elif self.volumeFeat.ndim == 2:
+            elif ndim == 2:
                 self.gridSegmentor = ilastiktools.GridSegmentor_2D_UInt32()
-                self.gridSegmentor.init()
-                # TODO: remove after preprocess fixed                
-                #self.gridSegmentor.preprocessing(self.supervoxelUint32.squeeze(),self.volumeFeat)
-
             else:
                 raise RuntimeError("internal error")
 
+            self.gridSegmentor.init()
             self.nodeNum = self.gridSegmentor.nodeNum()
             self.hasSeg = False
         else:
             self.supervoxelUint32 = labels
-
-            if(self.supervoxelUint32.squeeze().ndim == 3):
+            ndim = self.supervoxelUint32.value.squeeze().ndim
+            if ndim == 3:
                 self.gridSegmentor = ilastiktools.GridSegmentor_3D_UInt32()
-            else:
+            elif ndim == 2:
                 self.gridSegmentor = ilastiktools.GridSegmentor_2D_UInt32()
+            else:
+                raise RuntimeError("internal error")
 
             self.nodeNum = h5file.attrs["numNodes"]
 

--- a/ilastik/workflows/carving/watershed_segmentor.py
+++ b/ilastik/workflows/carving/watershed_segmentor.py
@@ -25,6 +25,11 @@ class WatershedSegmentor(object):
             self.volumeFeat = volume_feat.squeeze()
             if self.volumeFeat.ndim == 3:
                 self.gridSegmentor = ilastiktools.GridSegmentor_3D_UInt32()
+
+                # TODO: Remove horrible hack -- ilastiktools/carving.hxx asserts that the min node range is 1
+                # Is that required?  Fix in ilastiktools / vigra
+                self.supervoxelUint32[0][0][0] = 1
+
                 self.gridSegmentor.preprocessing(self.supervoxelUint32,self.volumeFeat)
 
             elif self.volumeFeat.ndim == 2:


### PR DESCRIPTION
Blockwise Carving refactor of ilastik (requires ilastiktools/blockwise_carving and latest lazyflow/h5-cache from holstgr-kaust). The segmentor is now built in multiple steps, processing the large filter and labels arrays in smaller chunks.  Other functionality, like export meshes and load object, are also done blockwise. The watershed labels are now cached as part of the project file.  With these changes, ilastik can carve a large EM stack (4000x4000x1500) in less than 250GB of memory.