### PR TITLE
Fix 1380 and 1382

### DIFF
--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -573,7 +573,6 @@ class ObjectExtractionGui(LayerViewerGui):
 
         if dlg.result() == QDialog.Accepted:
             mainOperator.Features.setValue(dlg.selectedFeatures)
-            mainOperator.augmentFeatureNames(dlg.selectedFeatures)
             self._calculateFeatures()
 
     def _calculateFeatures(self, interactive=True):

--- a/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
+++ b/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
@@ -210,8 +210,6 @@ class OpTrackingFeatureExtraction(Operator):
         self.ComputedFeatureNamesNoDivisions.meta.assignFrom(self.FeatureNamesVigra.meta)
         self.RegionFeaturesAll.meta.assignFrom(self.RegionFeaturesVigra.meta)
 
-        self._objectExtraction.augmentFeatureNames()
-
     def execute(self, slot, subindex, roi, result):
         if slot == self.ComputedFeatureNamesAll:
             feat_names_vigra = self.FeatureNamesVigra([]).wait()

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -69,17 +69,20 @@ def flatten_ilastik_feature_table(table, selection, signal):
     feature_types = []
 
     for plugin_name, feature_dict in computed_feature[0].iteritems():
+        all_props = None
+        
         if plugin_name==default_features_key:
             plugin = pluginManager.getPluginByName("Standard Object Features", "ObjectFeatures")
         else:
             plugin = pluginManager.getPluginByName(plugin_name, "ObjectFeatures")
-        plugin_feature_names = {el:{} for el in feature_dict.keys()}
-        all_props = plugin.plugin_object.fill_properties(plugin_feature_names) #fill in display name and such
+        if plugin:
+            plugin_feature_names = {el:{} for el in feature_dict.keys()}
+            all_props = plugin.plugin_object.fill_properties(plugin_feature_names) #fill in display name and such
 
         for feat_name, feat_array in feature_dict.iteritems():
-            try:
+            if all_props:
                 long_name = all_props[feat_name]["displaytext"]
-            except KeyError:
+            else:
                 long_name = feat_name
             if (plugin_name == default_features_key or \
                      long_name in selection) and \

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -85,7 +85,8 @@ def flatten_ilastik_feature_table(table, selection, signal):
             else:
                 long_name = feat_name
             if (plugin_name == default_features_key or \
-                     long_name in selection) and \
+                     long_name in selection or \
+                     feat_name in selection) and \
                      long_name not in feature_long_names:
                 feature_long_names.append(long_name)
                 feature_short_names.append(feat_name)

--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -80,14 +80,7 @@ class TestConservationTrackingHeadless(object):
 
 
     @timeLogged(logger)
-    def testTrackingHeadless(self):
-        # Skip test if conservation tracking can't be imported. If it fails the problem is most likely that CPLEX is not installed.
-        try:
-            import ilastik.workflows.tracking.conservation
-        except ImportError as e:
-            logger.warn( "Conservation tracking could not be imported: " + str(e) )
-            raise nose.SkipTest 
-        
+    def testTrackingHeadless(self):        
         # TODO: When Hytra is supported on Windows, we shouldn't skip the test and throw an assert instead
         try:
             import hytra

--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -70,7 +70,7 @@ class TestConservationTrackingHeadless(object):
     @classmethod
     def teardownClass(cls):
         removeFiles = ['data/inputdata/smallVideo_Tracking-Result.h5', 'data/inputdata/smallVideo-exported_data_table.csv', 'data/inputdata/smallVideo-exported_data_divisions.csv']
-         
+          
         # Clean up: Delete any test files we generated
         for f in removeFiles:
             try:
@@ -118,8 +118,8 @@ class TestConservationTrackingHeadless(object):
         assert data.shape[0] == self.EXPECTED_NUM_ROWS, 'Number of rows in csv file differs from expected' 
 
         # Check that csv contains RegionRadii and RegionAxes (necessary for animal tracking)
-        assert 'RegionRadii_0' in data.dtype.names, 'RegionRadii not found in csv file (required for animal tracking)'
-        assert  'RegionAxes_0' in data.dtype.names, 'RegionAxes not found in csv file (required for animal tracking)'   
+        assert 'Radii_of_the_object_0' in data.dtype.names, 'RegionRadii not found in csv file (required for animal tracking)'
+        assert  'Principal_components_of_the_object_0' in data.dtype.names, 'RegionAxes not found in csv file (required for animal tracking)'   
         
         # Check for expected number of mergers
         merger_count = 0


### PR DESCRIPTION
This PR moves **augmentFeaturesNames()** from `opObjectExtraction` to `opRegionExtraction`, and also removed the slot `FeaturesWithDefault` to fix #1380 and fix #1382.

Also fixes another issue on `exportFile` that occurs when `Cell Divsion Features` is not found in the plugin manager.

@akreshuk I am now able to export the csv table with the long names, combined with the short names for features related to `Cell Division Features`. The mix looks a bit odd.  Could you review my changes and tell me if I'm missing anything?