### PR TITLE
Fix for issue #1217, carving workflow: watershed shown after successful preprocessing

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -732,6 +732,7 @@ class CarvingGui(LabelingGui):
                              "shows <b>all completed object</b>, each with a random color.</html>")
             layer.visible = False
             layer.opacity = 0.5
+            layer.colortableIsRandom = True
             self._doneSegmentationLayer = layer
             layers.append(layer)
 
@@ -750,6 +751,7 @@ class CarvingGui(LabelingGui):
                              "(undersegmentation). In this case, it will be impossible to achieve the desired " \
                              "segmentation. This layer helps you to understand these cases.</html>")
             layer.visible = False
+            layer.colortableIsRandom = True
             layer.opacity = 0.5
             layers.append(layer)
 

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -750,7 +750,7 @@ class CarvingGui(LabelingGui):
                              "(undersegmentation). In this case, it will be impossible to achieve the desired " \
                              "segmentation. This layer helps you to understand these cases.</html>")
             layer.visible = False
-            layer.opacity = 1.0
+            layer.opacity = 0.5
             layers.append(layer)
 
         # Visual overlay (just for easier labeling)

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -90,6 +90,8 @@ class PreprocessingGui(QMainWindow):
         self.drawer.invertWatershedSourceCheckbox.toggled.connect( self.handleInvertWatershedSourceChange )
         self.drawer.writeprotectBox.stateChanged.connect(self.handleWriterprotectStateChanged)
 
+        self.parentApplet.appletStateUpdateRequested.connect(self.processingFinished)
+
         #FIXME: for release 0.6, disable this (the reset button made the gui even more complicated)            
         #self.drawer.resetButton.clicked.connect(self.topLevelOperatorView.reset)
 
@@ -123,7 +125,27 @@ class PreprocessingGui(QMainWindow):
 
     def handleInvertWatershedSourceChange(self, checked):
         self.topLevelOperatorView.InvertWatershedSource.setValue( checked )
-    
+
+    def processingFinished(self):
+        """Method makes sure finished processing is communicated visually
+
+        After processing is finished it is checked whether one of the result
+        layers is visible. If not, finished processing is communicated by
+        showing the watershed layer.
+        """
+        layerStack = self.centralGui.editor.layerStack
+        watershedIndex = layerStack.findMatchingIndex(
+            lambda x: x.name == 'Watershed'
+            )
+        filteredIndex = layerStack.findMatchingIndex(
+            lambda x: x.name == 'Filtered Data'
+            )
+
+        # Only do something if none of the result layers is visible
+        if not layerStack[watershedIndex].visible:
+            if not layerStack[filteredIndex].visible:
+                layerStack[watershedIndex].visible = True
+
     @threadRouted 
     def onFailed(self, exception, exc_info):
         log_exception( logger, exc_info=exc_info )

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -90,7 +90,7 @@ class PreprocessingGui(QMainWindow):
         self.drawer.invertWatershedSourceCheckbox.toggled.connect( self.handleInvertWatershedSourceChange )
         self.drawer.writeprotectBox.stateChanged.connect(self.handleWriterprotectStateChanged)
 
-        self.parentApplet.appletStateUpdateRequested.connect(self.processingFinished)
+        self.parentApplet.appletStateUpdateRequested.subscribe(self.processingFinished)
 
         #FIXME: for release 0.6, disable this (the reset button made the gui even more complicated)            
         #self.drawer.resetButton.clicked.connect(self.topLevelOperatorView.reset)

--- a/ilastik/workflows/carving/preprocessingViewerGui.py
+++ b/ilastik/workflows/carving/preprocessingViewerGui.py
@@ -48,7 +48,10 @@ class PreprocessingViewerGui( LayerViewerGui ):
             watershedLayer = ColortableLayer(LazyflowSource(watershedSlot), colortable)
             watershedLayer.name = "Watershed"
             watershedLayer.visible = False
+
             watershedLayer.opacity = 0.5
+            watershedLayer.colortableIsRandom = True
+
             layers.append(watershedLayer)
 
         ''' FIXME: disabled for 0.6 release

--- a/ilastik/workflows/carving/preprocessingViewerGui.py
+++ b/ilastik/workflows/carving/preprocessingViewerGui.py
@@ -48,7 +48,7 @@ class PreprocessingViewerGui( LayerViewerGui ):
             watershedLayer = ColortableLayer(LazyflowSource(watershedSlot), colortable)
             watershedLayer.name = "Watershed"
             watershedLayer.visible = False
-            watershedLayer.opacity = 1.0
+            watershedLayer.opacity = 0.5
             layers.append(watershedLayer)
 
         ''' FIXME: disabled for 0.6 release


### PR DESCRIPTION
In preprocessing for the carving workflow, watershed layer is set visible iif none of the result layers are visible

Fix for issue #1217 @akreshuk 