### PR TITLE
Bypassing cache when conservation tracking runs on headless mode

### DIFF
--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -310,6 +310,9 @@ class OpObjectExtraction(Operator):
     BinaryImage = InputSlot()
     BackgroundLabels = InputSlot(optional=True)
 
+    # Bypass cache (for headless mode)
+    BypassModeEnabled = InputSlot(value=False)
+    
     # which features to compute.
     # nested dictionary with format:
     # dict[plugin_name][feature_name][parameter_name] = parameter_value
@@ -350,7 +353,7 @@ class OpObjectExtraction(Operator):
         #TODO BinaryImage is not binary in some workflows, could be made more
         # efficient
         self._opLabelVolume = OpLabelVolume(parent=self)
-        self._opLabelVolume.name = "OpObjectExtraction._opLabelVolume"
+        self._opLabelVolume.name = "OpObjectExtraction._opLabelVolume"        
         self._opRegFeats = OpCachedRegionFeatures(parent=self)
         self._opRegFeatsAdaptOutput = OpAdaptTimeListRoi(parent=self)
         self._opObjectCenterImage = OpObjectCenterImage(parent=self)
@@ -358,6 +361,7 @@ class OpObjectExtraction(Operator):
         # connect internal operators
         self._opLabelVolume.Input.connect(self.BinaryImage)
         self._opLabelVolume.Background.connect(self.BackgroundLabels)
+        self._opLabelVolume.BypassModeEnabled.connect(self.BypassModeEnabled)
 
         self._opRegFeats.RawImage.connect(self.RawImage)
         self._opRegFeats.LabelImage.connect(self._opLabelVolume.CachedOutput)

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -507,6 +507,11 @@ class OpConservationTracking(Operator, ExportingOperator):
         # Populate events dictionary
         events = {}
         
+        # Get merger dict
+        resolvedMergersDict = self.ResolvedMergers.value
+        if not resolvedMergersDict: 
+            logger.info("Resolved Merger Dictionary not available for generating events vector. Please click on the Track button.")
+        
         # Save mergers, links, detections, and divisions
         for timestep in traxelIdPerTimestepToUniqueIdMap.keys():
             # We need to add an extra column with zeros in order to be backward compatible with the older version
@@ -542,9 +547,7 @@ class OpConservationTracking(Operator, ExportingOperator):
             if len(mul) > 0:
                 events[timestep]['mul'] = mul
 
-            # Write merger results dictionary
-            resolvedMergersDict = self.ResolvedMergers.value
-            
+            # Write merger results dictionary            
             if resolvedMergersDict:
                 mergerRes = {}
                 
@@ -552,8 +555,6 @@ class OpConservationTracking(Operator, ExportingOperator):
                     mergerRes[idx] = resolvedMergersDict[int(timestep)][idx]['newIds']
                     
                 events[timestep]['res'] = mergerRes
-            else:
-                logger.info("Resolved Merger Dictionary not available for generating events vector. Please click on the Track button.")
                 
         return events
 

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -552,9 +552,8 @@ class OpConservationTracking(Operator, ExportingOperator):
                     mergerRes[idx] = resolvedMergersDict[int(timestep)][idx]['newIds']
                     
                 events[timestep]['res'] = mergerRes
-                
-        else:
-            logger.info("Resolved Merger Dictionary not available. Please click on the Track button.")
+            else:
+                logger.info("Resolved Merger Dictionary not available for generating events vector. Please click on the Track button.")
                 
         return events
 

--- a/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
+++ b/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
@@ -134,7 +134,9 @@ class OpTrackingFeatureExtraction(Operator):
     FeatureNamesVigra = InputSlot(rtype=List, stype=Opaque, value={})
     
     FeatureNamesDivision = InputSlot(rtype=List, stype=Opaque, value={})
-        
+ 
+    # Bypass cache (for headless mode)
+    BypassModeEnabled = InputSlot(value=False)        
 
     LabelImage = OutputSlot()
     ObjectCenterImage = OutputSlot()
@@ -176,7 +178,7 @@ class OpTrackingFeatureExtraction(Operator):
         # connect internal operators
         self._objectExtraction.RawImage.connect(self.RawImage)
         self._objectExtraction.BinaryImage.connect(self.BinaryImage)
-
+        self._objectExtraction.BypassModeEnabled.connect(self.BypassModeEnabled)
         self._objectExtraction.Features.connect(self.FeatureNamesVigra)
         self._objectExtraction.RegionFeaturesCacheInput.connect(self.RegionFeaturesCacheInputVigra)
         self._objectExtraction.LabelImageCacheInput.connect(self.LabelImageCacheInput)

--- a/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
+++ b/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
@@ -244,7 +244,9 @@ class OpTrackingFeatureExtraction(Operator):
             assert False, "Shouldn't get here."
 
     def propagateDirty(self, slot, subindex, roi):
-        if slot == self.FeatureNamesVigra or slot == self.FeatureNamesDivision:
+        if  slot == self.BypassModeEnabled:
+            pass
+        elif slot == self.FeatureNamesVigra or slot == self.FeatureNamesDivision:
             self.ComputedFeatureNamesAll.setDirty(roi)
             self.ComputedFeatureNamesNoDivisions.setDirty(roi)
 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -67,6 +67,10 @@ class ConservationTrackingWorkflowBase( Workflow ):
         
         opObjectExtraction = self.objectExtractionApplet.topLevelOperator
         opObjectExtraction.FeatureNamesVigra.setValue(configConservation.allFeaturesObjectCount)
+        
+        # Bypass array cache on headless mode 
+        if headless:
+            opObjectExtraction.BypassModeEnabled.setValue(True)
 
         self.divisionDetectionApplet = self._createDivisionDetectionApplet(configConservation.selectedFeaturesDiv) # Might be None
 
@@ -285,6 +289,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
          
     def prepare_lane_for_export(self, lane_index):
+          
         maxt = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[0] 
         maxx = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[1] 
         maxy = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[2] 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -118,7 +118,6 @@ class ConservationTrackingWorkflowBase( Workflow ):
         # Extra configuration for object export table (as CSV table or HDF5 table)
         opTracking = self.trackingApplet.topLevelOperator
         self.dataExportApplet.set_exporting_operator(opTracking)
-        self.dataExportApplet.prepare_for_entire_export = self.prepare_for_entire_export
         self.dataExportApplet.prepare_lane_for_export = self.prepare_lane_for_export
         self.dataExportApplet.post_process_lane_export = self.post_process_lane_export
         self.dataExportApplet.includeTableOnlyOption() # Export table only, without volumes
@@ -284,13 +283,10 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.Inputs[2].connect( opTracking.MergerOutput )
         opDataExport.RawData.connect( op5Raw.Output )
         opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
-    
-    
-    def prepare_for_entire_export(self):
-        # Bypass cache on headless mode and batch processing mode
-        self.objectExtractionApplet.topLevelOperator.BypassModeEnabled.setValue(True)
          
     def prepare_lane_for_export(self, lane_index):
+        # Bypass cache on headless mode and batch processing mode
+        self.objectExtractionApplet.topLevelOperator[lane_index].BypassModeEnabled.setValue(True)
           
         maxt = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[0] 
         maxx = self.trackingApplet.topLevelOperator[lane_index].RawImage.meta.shape[1] 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -67,10 +67,6 @@ class ConservationTrackingWorkflowBase( Workflow ):
         
         opObjectExtraction = self.objectExtractionApplet.topLevelOperator
         opObjectExtraction.FeatureNamesVigra.setValue(configConservation.allFeaturesObjectCount)
-        
-        # Bypass array cache on headless mode 
-        if headless:
-            opObjectExtraction.BypassModeEnabled.setValue(True)
 
         self.divisionDetectionApplet = self._createDivisionDetectionApplet(configConservation.selectedFeaturesDiv) # Might be None
 
@@ -122,6 +118,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
         # Extra configuration for object export table (as CSV table or HDF5 table)
         opTracking = self.trackingApplet.topLevelOperator
         self.dataExportApplet.set_exporting_operator(opTracking)
+        self.dataExportApplet.prepare_for_entire_export = self.prepare_for_entire_export
         self.dataExportApplet.prepare_lane_for_export = self.prepare_lane_for_export
         self.dataExportApplet.post_process_lane_export = self.post_process_lane_export
         self.dataExportApplet.includeTableOnlyOption() # Export table only, without volumes
@@ -287,6 +284,11 @@ class ConservationTrackingWorkflowBase( Workflow ):
         opDataExport.Inputs[2].connect( opTracking.MergerOutput )
         opDataExport.RawData.connect( op5Raw.Output )
         opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
+    
+    
+    def prepare_for_entire_export(self):
+        # Bypass cache on headless mode and batch processing mode
+        self.objectExtractionApplet.topLevelOperator.BypassModeEnabled.setValue(True)
          
     def prepare_lane_for_export(self, lane_index):
           


### PR DESCRIPTION
Bypassing cache (used in opObjectExtraction/opLabelVolume) when conservation tracking is running on headless mode.