### PR TITLE
Modified run_each_unit_test script to not stop on first failure

### DIFF
--- a/tests/run_each_unit_test.sh
+++ b/tests/run_each_unit_test.sh
@@ -24,6 +24,9 @@ SKIP_GUI_TESTS=${SKIP_GUI_TESTS-0}
 
 SKIP_UNTIL=${2-"RUN_ALL"}
 
+FAILURES=0
+BROKEN=()
+
 for f in `find $NOSE_ARG -iname "*test*.py" | grep -v nanshe` 
 do
   if echo $f | grep -q "testPixelClassificationBenchmarking.py"; then
@@ -69,6 +72,19 @@ do
   
   RETVAL=$?
   if [[ $RETVAL -ne 0 ]]; then
-    exit $RETVAL
+    # exit $RETVAL
+    ((FAILURES+=1))
+    BROKEN+=($f)
   fi
 done
+
+
+if [[ $FAILURES -ne 0 ]]; then
+  echo "Encountered ${FAILURES} failures:"
+  for f in ${BROKEN[@]}
+  do
+    echo $f
+  done
+
+  exit $FAILURES
+fi


### PR DESCRIPTION
currently, `run_each_unit_test.sh` will exit on the first failed test.

A code change might effect multiple tests. All those tests offer the possibility to track down the bug/error, so testing should not stop after encountering the first fail.
With this commit, the script will continue to run each test, accumulate the number of test runs that fail (NOT the number of single test cases, but the number of nosetest executions that return with with an `errorcode != 0`. At the end of the script, the failing tests are printed to `stdout`.