### PR TITLE
Show Dialog on the Object Classification GUI with Object Info to Assist Object Labelling 

### DIFF
--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -129,13 +129,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="labelAssistButton">
-       <property name="text">
-        <string>Label Assist</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,1,0,0,0">
        <property name="spacing">
         <number>2</number>
@@ -201,6 +194,13 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item>
+      <widget class="QPushButton" name="labelAssistButton">
+       <property name="text">
+        <string>Label Assist</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -129,6 +129,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="labelAssistButton">
+       <property name="text">
+        <string>Label Assist</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,1,0,0,0">
        <property name="spacing">
         <number>2</number>

--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -196,9 +196,32 @@
       </layout>
      </item>
      <item>
+      <widget class="Line" name="labelAssistLine">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelAssistLabel">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;Show table with object areas and number of labels per frame in order to find the frames where something interesting is happening.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Label-Assist</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="labelAssistButton">
        <property name="text">
-        <string>Label Assist</string>
+        <string>Label-Assist Table</string>
        </property>
       </widget>
      </item>

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -997,6 +997,19 @@ class LabelAssistDialog(QDialog):
 
 
     def _triggerTableUpdate(self):
+        # Check that object area is included in selected features
+        featureNames = self.topLevelOperatorView.SelectedFeatures.value
+        
+        if 'Standard Object Features' not in featureNames or 'Count' not in featureNames['Standard Object Features']:
+            box = QMessageBox(QMessageBox.Warning,
+                  'Warning',
+                  'Object area is not a selected feature. Please select this feature on: \"Standard Object Features > Shape > Size in pixels\"',
+                  QMessageBox.NoButton,
+                  self)
+            box.show()
+            return 
+        
+        # Clear table
         self.table.clearContents()
         self.table.setRowCount(0)
         self.table.setSortingEnabled(False)

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -211,6 +211,8 @@ class ObjectClassificationGui(LabelingGui):
         self.badObjectBox = None
 
         self.checkEnableButtons()
+        
+        self._labelAssistDialog = None
 
     def menus(self):
         m = QMenu("&Export", self.volumeEditorWidget)
@@ -351,7 +353,8 @@ class ObjectClassificationGui(LabelingGui):
 
     @pyqtSlot()
     def handleLabelAssistClicked(self):
-        self._labelAssistDialog = LabelAssistDialog(self, self.topLevelOperatorView)
+        if self._labelAssistDialog is None:
+            self._labelAssistDialog = LabelAssistDialog(self, self.topLevelOperatorView)
         self._labelAssistDialog.show()       
 
     @pyqtSlot()


### PR DESCRIPTION
New dialog that contains a table with max/min object areas and label counts per frame in order to assist with merger count labelling. The table can be sorted by frame number, object area, or label count. Users can also navigate to the frame when they click on a table row. Here's a screenshot:

 
![labelassist](https://cloud.githubusercontent.com/assets/5825034/24573480/73c05454-1651-11e7-9620-a3d4ee232928.png)


This dialog is accessed from `Object Classification Applet>Dialog-Assist Table`

This features was requested by @kristinbranson and @chaubold.
