### PR TITLE
Plugin to export tracking results to .outline contour files and MWT files

### DIFF
--- a/ilastik/plugins_default/tracking_contour_export.py
+++ b/ilastik/plugins_default/tracking_contour_export.py
@@ -66,8 +66,6 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
                         contoursDict[lineageId][t] = contours[0]
                     else:
                         contoursDict[lineageId] = {t:contours[0]}
-                else: 
-                    print('Skipping node {}'.format(nodeId))
             
         # Compute the contours in parallel
         pool = RequestPool()

--- a/ilastik/plugins_default/tracking_contour_export.py
+++ b/ilastik/plugins_default/tracking_contour_export.py
@@ -20,6 +20,11 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
     def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
         """
         Export the contours and corresponding IDs for all objects on the video
+        
+         Each .outline file consists of a line for each frame the animal is tracked for. 
+         The first number on this line is the timestamp of the frame, followed by the id, 
+         and unknown number, and then the rest of numbers are the (x,y) coordinates of 
+         the contour points (in what units?).
 
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
@@ -80,7 +85,7 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
                 # Generate contour string compatible with the .outline format
                 contour = contoursDict[id][t]
                 contourString =' '.join(str(contour[i, 1])+' '+str(contour[i, 0]) for i in range(len(contour)))
-                contourString = '00000000_000000 '+str(int(id)).zfill(5)+' '+'0.000 '+contourString+'\n'
+                contourString = '00000000_'+str(int(t)).zfill(6)+' '+str(int(id)).zfill(5)+' '+'0.000 '+contourString+'\n'
                  
                 # Append contour to file
                 outlineFile.write(contourString)

--- a/ilastik/plugins_default/tracking_contour_export.py
+++ b/ilastik/plugins_default/tracking_contour_export.py
@@ -1,0 +1,73 @@
+import os.path
+import numpy as np
+from ilastik.plugins import TrackingExportFormatPlugin
+import vigra
+
+from skimage import measure
+
+class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
+    """Contour export"""
+
+    exportsToFile = True
+
+    def checkFilesExist(self, filename):
+        ''' Check whether the files we want to export are already present '''
+        return os.path.exists(filename + '.outline')
+
+    def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
+        """
+        Export the contours and corresponding IDs for all objects on the video
+
+        :param filename: string of the FILE where to save the result (different .xml files were)
+        :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
+        :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+               of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+
+        :returns: True on success, False otherwise
+        """
+        
+        contoursDict = {}
+        
+        tIndex = labelImageSlot.meta.axistags.index('t')
+        tMax = labelImageSlot.meta.shape[tIndex] 
+        
+        for t in range(tMax):
+            s = [slice(None) for i in range(len(labelImageSlot.meta.shape))]
+            s[tIndex] = slice(t, t+1)
+            s = tuple(s)
+
+            # Request in parallel
+            frame = labelImageSlot[s].wait()            
+            frame = frame.squeeze()#frame[0,:,:,0,0]
+        
+            for label in vigra.analysis.unique(frame):
+                # Generate frame with single label
+                frameSingleLabel = np.zeros(frame.shape).astype(np.uint8)
+                frameSingleLabel[frame==label] = 1
+            
+                # Find contours using skimage marching squares
+                contours = measure._find_contours.find_contours(frameSingleLabel,0)
+                
+                # Save contours to dictionary
+                id = label
+                if id in contoursDict:
+                    contoursDict[id].append(contours[0])
+                else:
+                    contoursDict[id] = [contours[0]]           
+        
+        
+        # Generate contour string and save .outline file
+        outlineFile = open(filename + '.outline', 'w')
+
+        for id, contours in contoursDict.iteritems():
+            for contour in contours:
+                # Generate contour string compatible with the .outline format
+                contourString =' '.join(str(contour[i, 1])+' '+str(contour[i, 0]) for i in range(len(contour)))
+                contourString = '20170201_000000 '+str(int(id)).zfill(5)+' '+'0.000 '+contourString+'\n'
+                
+                # Append contour
+                outlineFile.write(contourString)
+              
+        outlineFile.close()
+
+        return True

--- a/ilastik/plugins_default/tracking_contour_export.yapsy-plugin
+++ b/ilastik/plugins_default/tracking_contour_export.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = Contours
+Module = tracking_contour_export
+
+[Documentation]
+Author = Jaime I. Cervantes
+Version = 0.1
+Website = ilastik.org
+Description = Plugin to export the ilastik tracking results as contours (initially used to larvae contours) <br> <br> <b>Usage: </b> Select the filename where the contours will be saved to an ASCII file. <br> <br> The resulting file will contain a list of x,y coordinates with the contour information for each object.

--- a/ilastik/plugins_default/tracking_contour_export.yapsy-plugin
+++ b/ilastik/plugins_default/tracking_contour_export.yapsy-plugin
@@ -6,4 +6,4 @@ Module = tracking_contour_export
 Author = Jaime I. Cervantes
 Version = 0.1
 Website = ilastik.org
-Description = Plugin to export the ilastik tracking results as contours (initially used to larvae contours) <br> <br> <b>Usage: </b> Select the filename where the contours will be saved to an ASCII file. <br> <br> The resulting file will contain a list of x,y coordinates with the contour information for each object.
+Description = Plugin to export the ilastik tracking results as contours (used mainly to export larvae contours for Zlatics Lab). Each .outline file consists of a line for each frame the animal is tracked for. The first number on this line is the timestamp of the frame, followed by the id, and an unused number left as 0.000, and then the rest of numbers are the (x,y) coordinates of the contour points (in pixels). Numbers are separated by a single white space.<br> <br> <b>Usage: </b> Select the filename where the contours will be saved to an ASCII file. <br> <br> The resulting file will contain a list of 3 words, followed by the (x,y) coordinates for the contour information of each object.

--- a/ilastik/plugins_default/tracking_mwt_export.py
+++ b/ilastik/plugins_default/tracking_mwt_export.py
@@ -1,0 +1,231 @@
+import os.path
+import numpy as np
+from ilastik.plugins import TrackingExportFormatPlugin
+import vigra
+
+from functools import partial
+from lazyflow.request import Request, RequestPool
+
+from skimage import measure
+
+class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
+    """MWT export"""
+
+    exportsToFile = True
+
+    def checkFilesExist(self, filename):
+        ''' Check whether the files we want to export are already present '''
+        return os.path.exists(filename + '.outline')
+
+    def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
+        """
+        Export the Multi-Worm-Tracker .summary and .blobs files.
+
+        :param filename: string of the FILE where to save the result (different .xml files were)
+        :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
+        :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+               of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+
+        :returns: True on success, False otherwise
+        """
+        
+        # Get object features
+        features = objectFeaturesSlot([]).wait()
+        
+        contoursDict = {}
+        
+        summaryDict = {}
+        
+        tIndex = labelImageSlot.meta.axistags.index('t')
+        tMax = labelImageSlot.meta.shape[tIndex] 
+       
+        # Method to compute contours for single frame (called in parallel by a request parallel)
+        def compute_dicts_for_frame(tIndex, t, labelImageSlot, hypothesesGraph, contoursDict): 
+            roi = [slice(None) for i in range(len(labelImageSlot.meta.shape))]
+            roi[tIndex] = slice(t, t+1)
+            roi = tuple(roi)
+
+            frame = labelImageSlot[roi].wait()            
+            frame = frame.squeeze()
+                   
+            for idx in vigra.analysis.unique(frame):
+                nodeId = (t, idx)
+                
+                if hypothesesGraph.hasNode(nodeId) and 'lineageId' in hypothesesGraph._graph.node[nodeId]:
+                    if t in summaryDict:
+                        summaryDict[t]['objectsNumber'] += 1
+                        summaryDict[t]['validObjectsNumber'] += 1
+                        summaryDict[t]['averageDuration'] = 0.0
+                        summaryDict[t]['averageSpeed'] = 0.0
+                        summaryDict[t]['averageAngularSpeed'] = 0.0
+                        summaryDict[t]['averageLength'] += features[t]['Standard Object Features']['RegionRadii'][idx,0]
+                        summaryDict[t]['averageRelativeLength'] = summaryDict[t]['averageLength']
+                        summaryDict[t]['averageWidth'] += features[t]['Standard Object Features']['RegionRadii'][idx,1]
+                        summaryDict[t]['averageRelativeWidth'] = summaryDict[t]['averageWidth']         
+                        summaryDict[t]['averageAspectRatio'] += features[t]['Standard Object Features']['RegionRadii'][idx,0] / features[t]['Standard Object Features']['RegionRadii'][idx,1]
+                        summaryDict[t]['averageRelativeAspectRatio'] = summaryDict[t]['averageAspectRatio']
+                        summaryDict[t]['endWiggle'] = 0.0               
+                    else:
+                        summaryDict[t] = {}
+                        summaryDict[t]['objectsNumber'] = 1
+                        summaryDict[t]['validObjectsNumber'] = 1
+                        summaryDict[t]['averageDuration'] = 0.0
+                        summaryDict[t]['averageSpeed'] = 0.0
+                        summaryDict[t]['averageAngularSpeed'] = 0.0
+                        summaryDict[t]['averageLength'] = features[t]['Standard Object Features']['RegionRadii'][idx,0]
+                        summaryDict[t]['averageRelativeLength'] = summaryDict[t]['averageLength']
+                        summaryDict[t]['averageWidth'] = features[t]['Standard Object Features']['RegionRadii'][idx,1]
+                        summaryDict[t]['averageRelativeWidth'] = summaryDict[t]['averageWidth']         
+                        summaryDict[t]['averageAspectRatio'] = features[t]['Standard Object Features']['RegionRadii'][idx,0] / features[t]['Standard Object Features']['RegionRadii'][idx,1]
+                        summaryDict[t]['averageRelativeAspectRatio'] = summaryDict[t]['averageAspectRatio']
+                        summaryDict[t]['endWiggle'] = 0.0                             
+                    
+                # Generate frame with single label idx
+                frameSingleLabel = np.zeros(frame.shape).astype(np.uint8)
+                frameSingleLabel[frame==idx] = 1
+            
+                # Find contours using skimage marching squares
+                contours = measure._find_contours.find_contours(frameSingleLabel,0)
+            
+                # Save contours to dictionary                    
+                if idx in contoursDict:
+                    contoursDict[idx][t] = contours[0]
+                else:
+                    contoursDict[idx] = {t:contours[0]}
+            
+        # Compute the contours in parallel
+        pool = RequestPool()
+        
+        for t in range(tMax):
+            pool.add( Request( partial(compute_dicts_for_frame, tIndex, t, labelImageSlot, hypothesesGraph, contoursDict) ) )
+         
+        pool.wait()  
+        
+        # Generate .summary file
+        summaryFile = open(filename + '.summary', 'w')
+        
+        for t in sorted(summaryDict):
+            summaryDict[t]['averageLength'] /= summaryDict[t]['objectsNumber']
+            summaryDict[t]['averageRelativeLength'] = summaryDict[t]['averageLength']
+            summaryDict[t]['averageWidth'] /= summaryDict[t]['objectsNumber']
+            summaryDict[t]['averageRelativeWidth'] = summaryDict[t]['averageWidth']         
+            summaryDict[t]['averageAspectRatio'] /= summaryDict[t]['objectsNumber']
+            summaryDict[t]['averageRelativeAspectRatio'] = summaryDict[t]['averageAspectRatio']
+            
+            summaryFile.write('{} {} {} {} {} {} {} {} {} {} {} {} {} {}\n'.format(t+1, \
+                                                                                   t, \
+                                                                                   summaryDict[t]['objectsNumber'], \
+                                                                                   summaryDict[t]['validObjectsNumber'], \
+                                                                                   summaryDict[t]['averageDuration'], \
+                                                                                   summaryDict[t]['averageSpeed'], \
+                                                                                   summaryDict[t]['averageAngularSpeed'], \
+                                                                                   summaryDict[t]['averageLength'], \
+                                                                                   summaryDict[t]['averageRelativeLength'], \
+                                                                                   summaryDict[t]['averageWidth'], \
+                                                                                   summaryDict[t]['averageRelativeWidth'], \
+                                                                                   summaryDict[t]['averageAspectRatio'], \
+                                                                                   summaryDict[t]['averageRelativeAspectRatio'], \
+                                                                                   summaryDict[t]['endWiggle']))
+            
+        summaryFile.close()
+                  
+        # Generate contour string and save .blobs file        
+        blobsFile = open(filename + '.blobs', 'w')
+
+        for idx in sorted(contoursDict): 
+            #blobsFile.write('%{}\n'.format(int(idx)))
+            
+            count = 0
+            for t in sorted(contoursDict[idx]):
+                
+                nodeId = (t, idx)
+                
+                if hypothesesGraph.hasNode(nodeId) and 'lineageId' in hypothesesGraph._graph.node[nodeId]:
+                    lineageId = hypothesesGraph._graph.node[nodeId]['lineageId']
+                    
+                    contour = contoursDict[idx][t]
+                    
+                    count += 1
+                    time = t
+                    xCoord = features[t]['Standard Object Features']['RegionCenter'][idx,0]
+                    yCoord = features[t]['Standard Object Features']['RegionCenter'][idx,1]
+                    area = features[t]['Standard Object Features']['Count'][idx,0]
+                    xMajorAxis = features[t]['Standard Object Features']['RegionAxes'][idx,0]*features[t]['Standard Object Features']['RegionRadii'][idx,0]
+                    yMajorAxis = features[t]['Standard Object Features']['RegionAxes'][idx,1]*features[t]['Standard Object Features']['RegionRadii'][idx,0]
+                    std = np.mean([features[t]['Standard Object Features']['RegionRadii'][idx,0],features[t]['Standard Object Features']['RegionRadii'][idx,1]])
+                    length = features[t]['Standard Object Features']['RegionRadii'][idx,0]
+                    width = features[t]['Standard Object Features']['RegionRadii'][idx,1]
+                    
+                    xOffset = contour[0,0]
+                    yOffset = contour[0,1]
+                    
+                    # Generate contour string
+                    prevPoint = []
+                    contourLength = 0
+                    binaryString = ''
+                    pointsString = ''
+                    
+                    for i, point in enumerate(contour):                        
+                        if len(prevPoint) > 0:
+                            # 4-way connected points
+                            if point[0]-prevPoint[0] == -1 and point[1]-prevPoint[1] == 0:
+                                binaryString += '00'
+                                contourLength += 1
+                            elif point[0]-prevPoint[0] == 1 and point[1]-prevPoint[1] == 0:
+                                binaryString += '01'
+                                contourLength += 1
+                            elif point[0]-prevPoint[0] == 0 and point[1]-prevPoint[1] == -1:
+                                binaryString += '10'
+                                contourLength += 1
+                            elif point[0]-prevPoint[0] == 0 and point[1]-prevPoint[1] == 1:
+                                binaryString += '11'
+                                contourLength += 1
+                            # Diagonal points
+                            elif point[0]-prevPoint[0] == -1 and point[1]-prevPoint[1] == -1:
+                                binaryString += '00'
+                                binaryString += '10'
+                                contourLength += 2
+                            elif point[0]-prevPoint[0] == -1 and point[1]-prevPoint[1] == 1:
+                                binaryString += '00'
+                                binaryString += '11'
+                                contourLength += 2
+                            elif point[0]-prevPoint[0] == 1 and point[1]-prevPoint[1] == -1:
+                                binaryString += '01'
+                                binaryString += '10'
+                                contourLength += 2
+                            elif point[0]-prevPoint[0] == 1 and point[1]-prevPoint[1] == 1:
+                                binaryString += '01'
+                                binaryString += '11'
+                                contourLength += 2
+                        
+                        if len(binaryString) == 6:
+                            pointsString += chr(int(binaryString, 2)+ord('0'))
+                            binaryString = ''
+                        elif len(binaryString) > 6:
+                            diff = len(binaryString) - 6 
+                            pointsString += chr(int(binaryString[:-diff], 2)+ord('0'))
+                            binaryString = binaryString[-diff:]
+                        elif i >= contour.shape[0]-1:
+                            if len(binaryString) == 2:
+                                binaryString += '00001'
+                                pointsString += chr(int(binaryString, 2)+ord('0'))
+                                binaryString = ''
+                            elif len(binaryString) == 4:
+                                binaryString += '00'
+                                pointsString += chr(int(binaryString, 2)+ord('0'))
+                                binaryString = ''
+                                
+                        prevPoint = point
+ 
+                    # Create contour string and append to file
+                    contourString = '{} {} {} {} {} {} {} {} {} {} %% {} {} {} '.format(count, time , xCoord, yCoord, area, xMajorAxis, yMajorAxis, std, length, width, xOffset, yOffset, contourLength+1)
+                    contourString += pointsString
+                    
+                    if count == 1:
+                        blobsFile.write('% {}\n'.format(int(idx)))
+                        
+                    blobsFile.write(contourString+'\n')
+              
+        blobsFile.close()
+
+        return True

--- a/ilastik/plugins_default/tracking_mwt_export.yapsy-plugin
+++ b/ilastik/plugins_default/tracking_mwt_export.yapsy-plugin
@@ -6,4 +6,4 @@ Module = tracking_mwt_export
 Author = Jaime I. Cervantes
 Version = 0.1
 Website = ilastik.org
-Description = Plugin to export the ilastik tracking results in the Multi-Worm Tracker format (.blobs and .summary file). Each .outline file consists of a line for each frame the animal is tracked for. The first number on this line is the timestamp of the frame, followed by the id, and an unused number left as 0.000, and then the rest of numbers are the (x,y) coordinates of the contour points (in pixels). Numbers are separated by a single white space.<br> <br> <b>Usage: </b> Select the filename where the contours will be saved to an ASCII file. <br> <br> The resulting file will contain a list of 3 words, followed by the (x,y) coordinates for the contour information of each object.
+Description = Plugin to export the ilastik tracking results in the Multi-Worm Tracker format (.blobs and .summary files). The .blobs file contains properties of the larvae and a the compressed contours in a string. More information on this format can be found in the MWT Users Guide by Rex Kerr.

--- a/ilastik/plugins_default/tracking_mwt_export.yapsy-plugin
+++ b/ilastik/plugins_default/tracking_mwt_export.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = Multi-Worm-Tracker
+Module = tracking_mwt_export
+
+[Documentation]
+Author = Jaime I. Cervantes
+Version = 0.1
+Website = ilastik.org
+Description = Plugin to export the ilastik tracking results in the Multi-Worm Tracker format (.blobs and .summary file). Each .outline file consists of a line for each frame the animal is tracked for. The first number on this line is the timestamp of the frame, followed by the id, and an unused number left as 0.000, and then the rest of numbers are the (x,y) coordinates of the contour points (in pixels). Numbers are separated by a single white space.<br> <br> <b>Usage: </b> Select the filename where the contours will be saved to an ASCII file. <br> <br> The resulting file will contain a list of 3 words, followed by the (x,y) coordinates for the contour information of each object.


### PR DESCRIPTION
2 Plugins to export the tracking results to `.outline` files, which contain larvae contours, and also to Multi-Worm-Tracker `.summary` and `.blobs` files.

These file formats are mainly used by Marta Zlatic's lab.