### PR TITLE
Fix/test file lists

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -125,7 +125,7 @@ class DatasetInfo(object):
                     )
                     internalPathExts = [".{}".format(ipx) for ipx in internalPathExts]
                     if pathComponents[0].extension in internalPathExts and internalPaths[0]:
-                        for i in range(file_list):
+                        for i in xrange(len(file_list)):
                             file_list[i] += '/' + internalPaths[0]
 
             # For stacks, choose nickname based on a common prefix


### PR DESCRIPTION
with recent commits to #1439 hdf5 stack reading functionality was broken. Loading hdf5 stacks resulted in an exception. Tests are adapted in order to detect such behaviour and the error itself is also fixed with this PR.

Previously, stack reading was only tested by passing `globStrings` to `OpDataSelection`, which works fine. In the GUI however, `OpDataSelection` will be passed a file list. This wasn't tested before.