### PR TITLE
switched package to ilastik-everything-no-solvers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,9 +25,9 @@ dependencies:
 
     - >
       if [ ! -d ${TEST_ENV_PREFIX} ]; then
-          conda create -y -n ${TEST_ENV_NAME} -c ilastik ilastik-everything-but-tracking ilastik-meta;
+          conda create -y -n ${TEST_ENV_NAME} -c ilastik ilastik-everything-no-solvers;
       else
-          conda install -y -n ${TEST_ENV_NAME} -c ilastik ilastik-everything-but-tracking;
+          conda install -y -n ${TEST_ENV_NAME} -c ilastik ilastik-everything-no-solvers;
       fi
 
     # Replace packaged source with full git repo


### PR DESCRIPTION
`ilastik-everything-but-tracking` is deprecated in favour of `ilastik-everything-no-solvers`, see https://github.com/ilastik/ilastik-build-conda/issues/25