### PR TITLE
TrackingFeatureExtraction: do no overwrite input slot value...

### DIFF
--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -69,7 +69,6 @@ class ConservationTrackingWorkflowBase( Workflow ):
                                                                       name="Object Feature Computation")                                                                     
         
         opObjectExtraction = self.objectExtractionApplet.topLevelOperator
-        opObjectExtraction.FeatureNamesVigra.setValue(configConservation.allFeaturesObjectCount)
 
         self.divisionDetectionApplet = self._createDivisionDetectionApplet(configConservation.selectedFeaturesDiv) # Might be None
 
@@ -223,7 +222,8 @@ class ConservationTrackingWorkflowBase( Workflow ):
         if self.withOptTrans:
             opOptTranslation = self.opticalTranslationApplet.topLevelOperator.getLane(laneIndex)
         opObjExtraction = self.objectExtractionApplet.topLevelOperator.getLane(laneIndex)
-        
+        opObjExtraction.setDefaultFeatures(configConservation.allFeaturesObjectCount)
+
         if self.divisionDetectionApplet:
                 opDivDetection = self.divisionDetectionApplet.topLevelOperator.getLane(laneIndex)
             

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -213,6 +213,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
         # feature_names_vigra = {}
         # feature_names_vigra[config.features_vigra_name] = { name: {} for name in vigra_features }
 
+        opTrackingFeatureExtraction.setDefaultFeatures(configConservation.allFeaturesObjectCount)
         opTrackingFeatureExtraction.FeatureNamesVigra.setValue(configConservation.allFeaturesObjectCount)
         feature_dict_division = {}
         feature_dict_division[config.features_division_name] = { name: {} for name in config.division_features }


### PR DESCRIPTION
... depending on data shape. Adresses #1432 in tracking workflows.

Overwriting the list of pre-selected features for tracking depending on the raw shape is too restrictive. If the user first loads a 3D dataset but then, by adjusting the axestags, changes that to 2D+t, the 2D features should become available again. If the feature slot value is overwritten when loading the 3D data but the original value is lost, this cannot be recovered. 

Hence with this (admittedly hacky) PR the initial value is stored as member variable of the operator, and the input slot is overwritten with the correct value.

This does fix the problem in #1432, but it seems wrong to overwrite the `FeatureNamesVigra` input slot value (which is also connected to input slots of other operators..?). @stuarteberg what is the suggested solution, to create a `FilteredFeatureNamesVigra` **output** slot which is then connected to the other operators?

Btw, the Object Classification Workflow does **not** suffer from that problem, because it does not have a hard-coded preselection of features that would have to be filtered according to the dataset dimensionality.

Thanks to @k-dominik for debugging this with me.