### PR TITLE
Let DataExportApplets specify whether they provide checkOverwriteFiles

### DIFF
--- a/ilastik/applets/dataExport/dataExportApplet.py
+++ b/ilastik/applets/dataExport/dataExportApplet.py
@@ -76,6 +76,18 @@ class DataExportApplet( Applet ):
             self._gui = DataExportGui( self, self.topLevelOperator )
         return self._gui
 
+    @staticmethod
+    def postprocessCanCheckForExistingFiles():
+        '''
+        While exporting, we can check whether files would be overwritten.
+        This is handled by an additional parameter to post_process_lane_export called "checkOverwriteFiles",
+        and that method should return True if the export files do NOT exist yet.
+
+        By default we do not want to check for existing files,
+        and most operators don't provide checkOverwriteFiles, so return False.
+        '''
+        return False
+
     # The following functions act as hooks for subclasses to override or clients to 
     # monkey-patch for custom behavior before/during/after an export is performed.
     # (The GUI and/or batch applet will call them at the appropriate time.)

--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -393,11 +393,14 @@ class DataExportGui(QWidget):
                     opLaneView.run_export()
                     
                     # Client hook
-                    exportStatus = self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=True)
-                    if exportStatus == False:
-                        self.showOverwriteQuestion()
-                        if self.overwrite == True:
-                            self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=False)
+                    if self.parentApplet.postprocessCanCheckForExistingFiles():
+                        exportStatus = self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=True)
+                        if exportStatus == False:
+                            if self.showOverwriteQuestion():
+                                self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=False)
+                    else:
+                        self.parentApplet.post_process_lane_export(lane_index)
+
                 except Exception as ex:
                     if opLaneView.ExportPath.ready():
                         msg = "Failed to generate export file: \n"
@@ -448,7 +451,8 @@ class DataExportGui(QWidget):
                                          'This filename already exists. Are you sure you want to overwrite?',
                                          QMessageBox.Yes, QMessageBox.No)
         if reply == QMessageBox.Yes:
-            self.overwrite = True
+            return True
+        return False
 
     def exportResultsForSlot(self, opLane):
         # Make sure all 'on disk' layers are discarded so we aren't using those files any more.

--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -57,6 +57,17 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
             self._gui.set_default_export_filename(self._default_export_filename) # remove once the PGMLINK version is gone
         return self._gui
 
+    @staticmethod
+    def postprocessCanCheckForExistingFiles():
+        '''
+        While exporting, we can check whether files would be overwritten.
+        This is handled by an additional parameter to post_process_lane_export called "checkOverwriteFiles",
+        and that method should return True if the export files do NOT exist yet.
+
+        In Tracking export we want to check for existing files, so return True.
+        '''
+        return True
+
     @property
     def topLevelOperator(self):
         return self.__topLevelOperator


### PR DESCRIPTION
... which fixes #1466.

An alternative option would have been to change all signatures to e.g. `post_process_lane_export(self, lane_index, *args, **kwargs)`, but I think the way this PR handles it is more explicit and thus less prone to mistakes as the one we introduced, leading to #1466.