### PR TITLE
Tracking Export: Fix MaMuT export axis order, and fix existing file check

### DIFF
--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -394,9 +394,11 @@ class DataExportGui(QWidget):
                     
                     # Client hook
                     if self.parentApplet.postprocessCanCheckForExistingFiles():
-                        exportStatus = self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=True)
-                        if exportStatus == False:
-                            if self.showOverwriteQuestion():
+                        exportSuccessful = self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=True)
+                        if not exportSuccessful:
+                            userSelection = [None]
+                            self.showOverwriteQuestion(userSelection)
+                            if userSelection[0]:
                                 self.parentApplet.post_process_lane_export(lane_index, checkOverwriteFiles=False)
                     else:
                         self.parentApplet.post_process_lane_export(lane_index)
@@ -446,13 +448,15 @@ class DataExportGui(QWidget):
         QMessageBox.critical(self, "Failed to export", msg )
 
     @threadRouted
-    def showOverwriteQuestion(self):
+    def showOverwriteQuestion(self, userSelection):
+        assert isinstance(userSelection, list)
         reply = QMessageBox.question(self, 'Warning!',
                                          'This filename already exists. Are you sure you want to overwrite?',
                                          QMessageBox.Yes, QMessageBox.No)
         if reply == QMessageBox.Yes:
-            return True
-        return False
+            userSelection[0] = True
+        else:
+            userSelection[0] = False
 
     def exportResultsForSlot(self, opLane):
         # Make sure all 'on disk' layers are discarded so we aren't using those files any more.

--- a/ilastik/plugins_default/tracking_mamut_export.py
+++ b/ilastik/plugins_default/tracking_mamut_export.py
@@ -5,6 +5,7 @@ from ilastik.plugins import TrackingExportFormatPlugin
 from mamutexport.mamutxmlbuilder import MamutXmlBuilder
 from mamutexport.bigdataviewervolumeexporter import BigDataViewerVolumeExporter
 import vigra
+import h5py
 
 def convertKeyName(key):
     key = key.replace('<', '_')
@@ -53,8 +54,10 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         bigDataViewerFile = filename + '_bdv.xml'
 
         rawImage = rawImageSlot([]).wait()
-        vigra.writeHDF5(rawImage, filename + '_raw.h5', 'exported_data')
-
+        rawImage = np.swapaxes(rawImage, 1, 3)
+        with h5py.File(filename + '_raw.h5', 'w') as f:
+            f.create_dataset('exported_data', data=rawImage)
+        
         bve = BigDataViewerVolumeExporter(filename + '_raw.h5', 'exported_data', rawImage.shape[1:4])
         for t in range(rawImage.shape[0]):
             bve.addTimePoint(t)


### PR DESCRIPTION
The MaMuT export was tested with 2D+t and 3D+t data, works fine now.
The second commit fixes #1490.