### PR TITLE
added status badge for appveyor build to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 =============================================
 
 [![Circle CI](https://circleci.com/gh/ilastik/ilastik.svg?style=svg)](https://circleci.com/gh/ilastik/ilastik)
+[![Build status](https://ci.appveyor.com/api/projects/status/38r7mxcc9e3rxdn1/branch/master?svg=true)](https://ci.appveyor.com/project/k-dominik/ilastik-ewtlc/branch/master)
 
 Please see the online [developer documentation](http://ilastik.github.com/ilastik/) for details regarding installation, testing, and writing your own workflows. The project roadmap with our current work and future plans can be found [here](http://github.com/ilastik/ilastik/wiki/Roadmap). 
 


### PR DESCRIPTION
Sorry for the overhead, but I wanted to make sure the appveyor build works with master before including the badge