### PR TITLE
highlight selected applet drawer item

### DIFF
--- a/ilastik/shell/gui/ilastik-style.qss
+++ b/ilastik/shell/gui/ilastik-style.qss
@@ -14,7 +14,7 @@ QToolBox::tab {
 }
 QToolBox::tab:selected {
     font: bold;
-    border-bottom: 0px;
+    border-bottom: 1px solid darkgray;
     background-color: -1;
 }
 /********************************************

--- a/ilastik/shell/gui/ilastik-style.qss
+++ b/ilastik/shell/gui/ilastik-style.qss
@@ -15,9 +15,7 @@ QToolBox::tab {
 QToolBox::tab:selected {
     font: bold;
     border-bottom: 0px;
-}
-QToolBox::Tab QWidget {
-    #background-color: white;
+    background-color: -1;
 }
 /********************************************
 The entries below are now commented out because it is better 

--- a/ilastik/shell/gui/ilastik-style.qss
+++ b/ilastik/shell/gui/ilastik-style.qss
@@ -7,13 +7,18 @@ ImageView2D { background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
                                       stop: 0 #000000, stop: 1 #ffffff); }
 /* Applet bar */
 QToolBox { border: 1px inset gray }
-QToolBox::tab { border:2px outset lightgray }
-
-/* Drawer */
+QToolBox::tab {
+    background-color: white;
+    border-top: 2px solid darkgray;
+    border-bottom: 2px solid darkgray;
+}
 QToolBox::tab:selected {
     font: bold;
+    border-bottom: 0px;
 }
-
+QToolBox::Tab QWidget {
+    #background-color: white;
+}
 /********************************************
 The entries below are now commented out because it is better 
 to defer to the user's system color settings than to hard-code 

--- a/ilastik/shell/gui/ilastik-style.qss
+++ b/ilastik/shell/gui/ilastik-style.qss
@@ -9,6 +9,11 @@ ImageView2D { background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
 QToolBox { border: 1px inset gray }
 QToolBox::tab { border:2px outset lightgray }
 
+/* Drawer */
+QToolBox::tab:selected {
+    font: bold;
+}
+
 /********************************************
 The entries below are now commented out because it is better 
 to defer to the user's system color settings than to hard-code 


### PR DESCRIPTION
addresses #1513
In ilastik, the currently selected (workflow) item in the app drawer doesn't stand out particularly well:

![ilastik-drawer-old](https://user-images.githubusercontent.com/24434157/27081501-fa4980f8-5040-11e7-8df3-ba826ce60163.png)

now the title of the current drawer is highlighted in bold font as follows:

![ilastik-drawer-new](https://user-images.githubusercontent.com/24434157/27081512-09cd9866-5041-11e7-90af-577d6384d9c6.png)
