### PR TITLE
Added single file hdf5 stack loading through the GUI

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -51,7 +51,8 @@ from ilastik.applets.base.applet import DatasetConstraintError
 from opDataSelection import OpDataSelection, DatasetInfo
 from dataLaneSummaryTableModel import DataLaneSummaryTableModel
 from datasetInfoEditorWidget import DatasetInfoEditorWidget
-from ilastik.widgets.stackFileSelectionWidget import StackFileSelectionWidget, H5VolumeSelectionDlg
+from ilastik.widgets.stackFileSelectionWidget import StackFileSelectionWidget
+from ilastik.widgets.stackFileSelectionWidget import H5VolumeSelectionDlg
 from datasetDetailedInfoTableModel import DatasetDetailedInfoColumn, DatasetDetailedInfoTableModel
 from datasetDetailedInfoTableView import DatasetDetailedInfoTableView
 

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -125,8 +125,15 @@ class DatasetInfo(object):
                     )
                     internalPathExts = [".{}".format(ipx) for ipx in internalPathExts]
                     if pathComponents[0].extension in internalPathExts and internalPaths[0]:
-                        for i in xrange(len(file_list)):
-                            file_list[i] += '/' + internalPaths[0]
+                        if len(file_list) == len(internalPaths):
+                            # assuming a matching internal paths to external paths
+                            file_list = ['{}/{}'.format(external, internal)
+                                         for external, internal
+                                         in zip(file_list, internalPaths)]
+                        else:
+                            # sort of fallback, in case of a mismatch in lengths
+                            for i in xrange(len(file_list)):
+                                file_list[i] += '/' + internalPaths[0]
 
             # For stacks, choose nickname based on a common prefix
             if file_list:

--- a/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
+++ b/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
@@ -108,14 +108,15 @@ class Hdf5StackingDlg(QDialog):
     """
     def __init__(self, parent=None, list_of_paths=None):
         super(Hdf5StackingDlg, self).__init__(parent)
+        self.setWindowTitle('Select images for stacking')
         if list_of_paths is None:
             list_of_paths = []
 
         self.list_of_paths = list_of_paths
 
         self.radio_group = QButtonGroup(parent=self)
-        label = QLabel("Your HDF5 File contains multiple image volumes.\n"
-                       "Please specify a pattern in order to stack multiple volumes.")
+        label = QLabel("Your HDF5 File contains multiple images.\n"
+                       "Please specify a pattern in order to stack multiple images.")
 
         self.stack_widget = Hdf5StackSelectionWidget(
             parent=self,

--- a/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
+++ b/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
@@ -1,0 +1,133 @@
+from PyQt4.QtGui import (
+    QDialogButtonBox, QButtonGroup, QComboBox, QDialog, QFileDialog, QGroupBox, QLabel, QLineEdit,
+    QMessageBox, QRadioButton, QStackedWidget, QTextEdit, QHBoxLayout, QVBoxLayout, QWidget
+)
+
+from PyQt4.QtCore import Qt
+
+from lazyflow.utility import globList
+
+
+class H5VolumeSelectionDlg(QDialog):
+    """
+    A window to ask the user to choose between multiple HDF5 datasets in a single file.
+    """
+    def __init__(self, datasetNames, parent):
+        super(H5VolumeSelectionDlg, self).__init__(parent)
+        label = QLabel("Your HDF5 File contains multiple image volumes.\n"
+                       "Please select the one you would like to open.")
+
+        self.combo = QComboBox()
+        for name in datasetNames:
+            self.combo.addItem(name)
+
+        buttonbox = QDialogButtonBox(Qt.Horizontal, parent=self)
+        buttonbox.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+
+        layout = QVBoxLayout()
+        layout.addWidget(label)
+        layout.addWidget(self.combo)
+        layout.addWidget(buttonbox)
+
+        self.setLayout(layout)
+
+
+class Hdf5StackSelectionWidget(QWidget):
+    def __init__(self, parent=None, list_of_paths=None, pattern=None):
+        super(Hdf5StackSelectionWidget, self).__init__(parent)
+        self.input_text = QLineEdit()
+        if pattern is None:
+            pattern = '*'
+        self.input_text.setText(pattern)
+        self.list_of_paths = list_of_paths
+        self.selected_paths = list_of_paths
+
+        self.info_text = QTextEdit()
+        self.info_text.setReadOnly(True)
+        self.info_text.setToolTip(
+            'Images included in the stack are displayed in black.\n'
+            'Images not included in the stack are shown in grey.')
+        info_label = QLabel(
+            'Resulting images used for stacking:\n')
+        self.n_label = QLabel('')
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.input_text)
+        layout.addWidget(info_label)
+        layout.addWidget(self.info_text)
+        layout.addWidget(self.n_label)
+        layout.setMargin(0)
+        self.setLayout(layout)
+
+        # connect the signals
+        self.input_text.textEdited.connect(self.validate_globstring)
+
+        self.validate_globstring(pattern)
+
+    def validate_globstring(self, globstring):
+        color_inside = '{}'
+        color_outside = '<font color ="#777">{}</font>'
+        self.selected_paths = globList(
+            self.list_of_paths, str(self.input_text.text()))
+
+        with_color = []
+        for path in self.list_of_paths:
+            if path in self.selected_paths:
+                with_color.append(color_inside.format(path))
+            else:
+                with_color.append(color_outside.format(path))
+        self.info_text.setText("<br>".join(with_color))
+        self.n_label.setText(
+            'Selected {} images'.format(len(self.selected_paths)))
+
+
+class Hdf5StackingDlg(QDialog):
+    """Dialogue for subvolume stack selection within single HDF5 files
+    """
+    def __init__(self, parent=None, list_of_paths=None):
+        super(Hdf5StackingDlg, self).__init__(parent)
+        if list_of_paths is None:
+            list_of_paths = []
+
+        self.list_of_paths = list_of_paths
+
+        self.radio_group = QButtonGroup(parent=self)
+        label = QLabel("Your HDF5 File contains multiple image volumes.\n"
+                       "Please specify a pattern in order to stack multiple volumes.")
+
+        self.stack_widget = Hdf5StackSelectionWidget(
+            parent=self,
+            list_of_paths=list_of_paths,
+            pattern='*')
+        layout = QVBoxLayout()
+        layout.addWidget(label)
+        layout.addWidget(self.stack_widget)
+        layout.addWidget(self._setup_buttonbox())
+
+        self.setLayout(layout)
+        self.setMinimumSize(600, 100)
+
+    def _setup_buttonbox(self):
+        buttonbox = QDialogButtonBox(Qt.Horizontal, parent=self)
+        buttonbox.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+        return buttonbox
+
+    def get_selected_datasets(self):
+        return self.stack_widget.selected_paths
+
+    def get_globstring(self):
+        return self.stack_widget.input_text.text()
+
+
+
+if __name__ == "__main__":
+    from PyQt4.QtGui import QApplication
+
+    app = QApplication([])
+    w = Hdf5StackingDlg(list_of_paths=['a/1', 'a/2', 'a/3', 'b/1', 'b/2'])
+    w.show()
+    app.exec_()

--- a/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
+++ b/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
@@ -1,6 +1,26 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2017, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 from PyQt4.QtGui import (
-    QDialogButtonBox, QButtonGroup, QComboBox, QDialog, QFileDialog, QGroupBox, QLabel, QLineEdit,
-    QMessageBox, QRadioButton, QStackedWidget, QTextEdit, QHBoxLayout, QVBoxLayout, QWidget
+    QDialogButtonBox, QButtonGroup, QComboBox, QDialog, QLabel, QLineEdit,
+    QTextEdit, QVBoxLayout, QWidget
 )
 
 from PyQt4.QtCore import Qt
@@ -121,7 +141,6 @@ class Hdf5StackingDlg(QDialog):
 
     def get_globstring(self):
         return self.stack_widget.input_text.text()
-
 
 
 if __name__ == "__main__":

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -238,7 +238,7 @@ class StackFileSelectionWidget(QDialog):
         thus, unclear.
 
         Args:
-            h5_files (list of strings): h5 files to be globbed internally
+            h5Files (list of strings): h5 files to be globbed internally
 
         Returns:
             list of internal paths

--- a/tests/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_applets/dataSelection/testOpDataSelection.py
@@ -800,7 +800,7 @@ class TestOpDataSelection_SingleFileH5Stacks():
         cls.tmpdir = tempfile.mkdtemp()
         cls.projectFileName = os.path.join(cls.tmpdir, 'testProject.ilp')
         # generate some test data 'tczyx'
-        cls.imgData3Dct = numpy.random.randint(0, 256, (10, 3, 8, 7, 6), dtype=numpy.uint8)
+        cls.imgData3Dct = numpy.random.randint(0, 256, (10, 3, 8, 7, 6)).astype(numpy.uint8)
 
         # write a h5-file to directory
         cls.image_file_name = os.path.join(cls.tmpdir, 'multi-h5.h5')

--- a/tests/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_applets/dataSelection/testOpDataSelection.py
@@ -794,6 +794,72 @@ class TestOpDataSelection_3DStacks():
             numpy.testing.assert_array_equal(imgData3Dc, self.imgData3Dc)
 
 
+class TestOpDataSelection_SingleFileH5Stacks():
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.projectFileName = os.path.join(cls.tmpdir, 'testProject.ilp')
+        # generate some test data 'tczyx'
+        cls.imgData3Dct = numpy.random.randint(0, 256, (10, 3, 8, 7, 6), dtype=numpy.uint8)
+
+        # write a h5-file to directory
+        cls.image_file_name = os.path.join(cls.tmpdir, 'multi-h5.h5')
+
+        h5file = h5py.File(cls.image_file_name)
+        cls.file_names = []
+        try:
+            g1 = h5file.create_group('g1')
+            for t_index, t_slice in enumerate(cls.imgData3Dct):
+                file_name = 'timeslice_{:03d}'.format(t_index)
+                g1.create_dataset(file_name, data=t_slice)
+                cls.file_names.append("{}/g1/{}".format(cls.image_file_name, file_name))
+        finally:
+            h5file.close()
+
+        cls.glob_string = '/timeslice_*'
+        # Create a 'project' file and give it some data
+        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile.create_group('DataSelection')
+        cls.projectFile['DataSelection'].create_group('local_data')
+        # Use the same data as the 3d+c data (above)
+        cls.projectFile['DataSelection/local_data'].create_dataset(
+            'dataset1', data=cls.imgData3Dct)
+        cls.projectFile.flush()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.projectFile.close()
+        try:
+            shutil.rmtree(cls.tmpdir)
+        except OSError, e:
+            print('Exception caught while deleting temporary files: {}'.format(e))
+
+    def test_load_single_file_with_list(self):
+        graph = lazyflow.graph.Graph()
+        reader = OperatorWrapper(OpDataSelection, graph=graph)
+        reader.ProjectFile.setValue(self.projectFile)
+        reader.WorkingDirectory.setValue(os.getcwd())
+        reader.ProjectDataGroup.setValue('DataSelection/local_data')
+
+        fileNameString = os.path.pathsep.join(self.file_names)
+        print(fileNameString)
+        info = DatasetInfo(filepath=fileNameString)
+        # Will be read from the filesystem since the data won't be found in the project file.
+        info.location = DatasetInfo.Location.ProjectInternal
+        info.internalPath = ""
+        info.invertColors = False
+        info.convertToGrayscale = False
+
+        reader.Dataset.setValues([info])
+
+        # Read the test files using the data selection operator and verify the contents
+        imgData = reader.Image[0][...].wait()
+
+        # Check raw images
+        assert imgData.shape == self.imgData3Dct.shape
+
+        numpy.testing.assert_array_equal(imgData, self.imgData3Dct)
+
 if __name__ == "__main__":
     import nose
     nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE': 1})

--- a/tests/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_applets/dataSelection/testOpDataSelection.py
@@ -816,7 +816,7 @@ class TestOpDataSelection_SingleFileH5Stacks():
         finally:
             h5file.close()
 
-        cls.glob_string = '{}/timeslice_*'.format(cls.image_file_name)
+        cls.glob_string = '{}/g1/timeslice_*'.format(cls.image_file_name)
         # Create a 'project' file and give it some data
         cls.projectFile = h5py.File(cls.projectFileName)
         cls.projectFile.create_group('DataSelection')
@@ -866,7 +866,6 @@ class TestOpDataSelection_SingleFileH5Stacks():
         reader.ProjectDataGroup.setValue('DataSelection/local_data')
 
         fileNameString = os.path.pathsep.join(self.file_names)
-        print(fileNameString)
         info = DatasetInfo(filepath=fileNameString)
         # Will be read from the filesystem since the data won't be found in the project file.
         info.location = DatasetInfo.Location.ProjectInternal


### PR DESCRIPTION
This PR only works with https://github.com/ilastik/lazyflow/pull/246 .

* Added tests for single file hdf5 stacks to `testOpDataSelection`
* Created a new Dialog to specify glob string for single file hdf5 files. This dialog is opened automatically if a single hdf5 file is supplied via the `Add single volume from image stack` dialog:
![stack_import](https://user-images.githubusercontent.com/24434157/28881014-11d2a30c-77a7-11e7-93c5-fffc267fef57.png)
* The performance is not the greatest, but it worked with real life test images

