### PR TITLE
Fixes `ZMQSubscriber` initialization in debug mode with python 3 / pyqt5 mro behaviour 

### DIFF
--- a/ilastik/shell/gui/ipcManager.py
+++ b/ilastik/shell/gui/ipcManager.py
@@ -601,8 +601,7 @@ class ZMQSubscriber(QObject, ZMQBase, Receiving):
     commandReceived = pyqtSignal(str, dict)
 
     def __init__(self, protocol, address):
-        super(ZMQSubscriber, self).__init__()
-        ZMQBase.__init__(self, protocol, address)
+        super().__init__(protocol=protocol, address=address)
         self.context = zmq.Context()
         self.socket = None
         self.thread = None


### PR DESCRIPTION
PyQt5 implements cooperative multi-inheritance behaviour.

In short, due to the `super().__init__(*kwargs)` call in `QObject.__init__`,
the `__init__` method of the next sibling (`ZMQBase`) is also called.
The arguments have to be, therefore, passed to the super init alread.

fixes #1588