### PR TITLE
Fix counting gui test freeze

### DIFF
--- a/ilastik/applets/counting/countingGui.py
+++ b/ilastik/applets/counting/countingGui.py
@@ -127,8 +127,8 @@ class CountingGui(LabelingGui):
         labelSlots = LabelingGui.LabelingSlots()
         labelSlots.labelInput = topLevelOperatorView.LabelInputs
         labelSlots.labelOutput = topLevelOperatorView.LabelImages
-        labelSlots.labelEraserValue = topLevelOperatorView.opLabelPipeline.opLabelArray.EraserLabelValue
-        labelSlots.labelDelete = topLevelOperatorView.opLabelPipeline.opLabelArray.DeleteLabel
+        labelSlots.labelEraserValue = topLevelOperatorView.opLabelPipeline.opLabelArray.eraser
+        labelSlots.labelDelete = topLevelOperatorView.opLabelPipeline.opLabelArray.deleteLabel
         labelSlots.maxLabelValue = topLevelOperatorView.MaxLabelValue
         labelSlots.labelNames = topLevelOperatorView.LabelNames
 
@@ -413,6 +413,7 @@ class CountingGui(LabelingGui):
     #    self.op.opTrain.UnderMult.setValue(self.labelingDrawerUi.UnderBox.value())
     def _updateC(self):
         self.op.opTrain.C.setValue(self.labelingDrawerUi.CBox.value())
+
     def _updateSigma(self):
         #if self._changedSigma:
 
@@ -620,25 +621,20 @@ class CountingGui(LabelingGui):
         # Base class provides the label layer.
         layers = super(CountingGui, self).setupLayers()
 
-        # Add each of the predictions
-        labels = self.labelListData
-
-
-
-        slots = { 'Prediction' : (self.op.Density, 0.5), 
-                 'LabelPreview': (self.op.LabelPreview, 1.0), 
-                 'Uncertainty' : (self.op.UncertaintyEstimate, 1.0) }
+        slots = {'Prediction': (self.op.Density, 0.5),
+                 'LabelPreview': (self.op.LabelPreview, 1.0),
+                 'Uncertainty': (self.op.UncertaintyEstimate, 1.0)}
 
         for name, (slot, opacity) in list(slots.items()):
             if slot.ready():
-                from volumina import colortables
-                layer = ColortableLayer(LazyflowSource(slot), colorTable = countingColorTable, normalize =
-                                       (0,self.upperBound))
+                layer = ColortableLayer(
+                    LazyflowSource(slot),
+                    colorTable=countingColorTable,
+                    normalize=(0, self.upperBound))
                 layer.name = name
                 layer.opacity = opacity
                 layer.visible = self.labelingDrawerUi.liveUpdateButton.isChecked()
                 layers.append(layer)
-
 
         #Set LabelPreview-layer to True
 
@@ -650,10 +646,8 @@ class CountingGui(LabelingGui):
         boxlabellayer.visibleChanged.connect(self.boxController.changeBoxesVisibility)
         boxlabellayer.opacityChanged.connect(self.boxController.changeBoxesOpacity)
 
-
         layers.append(boxlabellayer)
         self.boxlabelsrc = boxlabelsrc
-
 
         inputDataSlot = self.topLevelOperatorView.InputImages
         if inputDataSlot.ready():

--- a/ilastik/applets/counting/countingGui.py
+++ b/ilastik/applets/counting/countingGui.py
@@ -258,18 +258,15 @@ class CountingGui(LabelingGui):
 
         self.boxController.fixedBoxesChanged.connect(self._handleBoxConstraints)
         self.boxController.viewBoxesChanged.connect(self._changeViewBoxes)
-        
+
         self.op.LabelPreviewer.sigma.setValue(self.op.opTrain.Sigma.value)
         self.op.opTrain.fixClassifier.setValue(False)
-        self.op.Density.notifyDirty(self._normalizePrediction)
 
+        # TODO: check if defer makes sense here!
+        self.op.Density.notifyDirty(self._normalizePrediction, defer=True)
+        self.op.LabelImages.notifyDirty(self._normalizeLayers, defer=True)
 
         self._updateSVROptions()
-
-
-     
-
-
 
     def _connectUIParameters(self):
 
@@ -428,12 +425,12 @@ class CountingGui(LabelingGui):
         #    self._changedSigma = False
         self._normalizeLayers()
 
-    def _normalizeLayers(self):
+    def _normalizeLayers(self, *args):
         upperBound = self.op.UpperBound.value
         self.upperBound = upperBound
 
         if hasattr(self, "labelPreviewLayer"):
-            self.labelPreviewLayer.set_normalize(0,(0,upperBound))
+            self.labelPreviewLayer.set_normalize(0, (0, upperBound))
         return
 
 
@@ -442,7 +439,6 @@ class CountingGui(LabelingGui):
             self.predictionLayer.set_normalize(0,(0,self.upperBound))
         if hasattr(self, "uncertaintyLayer") and hasattr(self, "upperBound"):
             self.uncertaintyLayer.set_normalize(0,(0,self.upperBound))
-
 
     def _updateEpsilon(self):
         self.op.opTrain.Epsilon.setValue(self.labelingDrawerUi.EpsilonBox.value())

--- a/ilastik/applets/counting/countingOperators.py
+++ b/ilastik/applets/counting/countingOperators.py
@@ -389,7 +389,7 @@ class OpPredictCounter(Operator):
         traceLogger.debug("OpPredictRandomForest: Requesting classifier. roi={}".format(roi))
         forests=self.inputs["Classifier"][:].wait()
 
-        if forests is None:
+        if any(forest is None for forest in forests):
             # Training operator may return 'None' if there was no data to train with
             return np.zeros(np.subtract(roi.stop, roi.start), dtype=np.float32)[...]
 

--- a/ilastik/applets/counting/countingsvr.py
+++ b/ilastik/applets/counting/countingsvr.py
@@ -636,9 +636,8 @@ class SVR(object):
 
     def writeHDF5(self, cachePath, targetname):
         f = h5py.File(cachePath)
-        str_type = h5py.special_dtype(vlen = str)
-        dataset = f.create_dataset(targetname, shape = (1,), dtype = str_type)
-        dataset[0] = pickle.dumps(self)
+        dataset = f.create_dataset(targetname, shape = (1,), dtype=np.dtype('V13'))
+        dataset[0] = np.void(pickle.dumps(self))
         f.close()
 
     def get_params(self):

--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -629,7 +629,7 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
         self.UncertaintyEstimate.connect( self.opUncertaintyCache.Output )
 
         self.meaner = OpMean(parent = self)
-        self.meaner.Input.connect(self.prediction_cache_gui.Output)
+        self.meaner.Input.connect(self.predict.PMaps)
 
         self.precomputed_predictions_gui = OpPrecomputedInput( ignore_dirty_input=False, parent=self )
         self.precomputed_predictions_gui.name = "precomputed_predictions_gui"

--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -492,10 +492,9 @@ class OpLabelPipeline(Operator):
         self.opLabelArray.Input.connect(self.LabelInput)
         self.opLabelArray.eraser.setValue(100)
 
-        self.opBoxArray = OpDenseLabelArray(parent=self)
-        self.opBoxArray.MetaInput.connect(self.RawImage)
-        self.opBoxArray.LabelSinkInput.connect(self.BoxLabelInput)
-        self.opBoxArray.EraserLabelValue.setValue(100)
+        self.opBoxArray = OpCompressedUserLabelArray(parent=self)
+        self.opBoxArray.Input.connect(self.BoxLabelInput)
+        self.opBoxArray.eraser.setValue(100)
 
         self.opLabelArray.deleteLabel.connect(self.DeleteLabel)
 
@@ -518,10 +517,11 @@ class OpLabelPipeline(Operator):
         if 't' in tagged_shape:
             tagged_shape['t'] = 1
 
-        # Aim for blocks that are roughly 20px
-        block_shape = determineBlockShape(list(tagged_shape.values()), 40**3)
+        # Aim for blocks with roughly the same size as in pixel classification,
+        # taking into account that counting will be 2d: 40 ** 3 = 256 ** 2
+        block_shape = determineBlockShape(list(tagged_shape.values()), 256 ** 2)
         self.opLabelArray.blockShape.setValue(block_shape)
-        pass
+        self.opBoxArray.blockShape.setValue(block_shape)
 
     def setInSlot(self, slot, subindex, roi, value):
         # Nothing to do here: All inputs that support __setitem__

--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -517,7 +517,6 @@ class OpPredictionPipelineNoCache(Operator):
     FeatureImages = InputSlot()
     MaxLabel = InputSlot()
     Classifier = InputSlot()
-    FreezePredictions = InputSlot()
     PredictionsFromDisk = InputSlot( optional=True )
     
     HeadlessPredictionProbabilities = OutputSlot() # drange is 0.0 to 1.0
@@ -561,13 +560,14 @@ class OpPredictionPipelineNoCache(Operator):
         # Our output changes when the input changed shape, not when it becomes dirty.
         pass
 
+
 class OpPredictionPipeline(OpPredictionPipelineNoCache):
     """
     This operator extends the cacheless prediction pipeline above with additional outputs for the GUI.
     (It uses caches for these outputs, and has an extra input for cached features.)
-    """        
+    """
     CachedFeatureImages = InputSlot()
-
+    FreezePredictions = InputSlot()
     PredictionProbabilities = OutputSlot()
     CachedPredictionProbabilities = OutputSlot()
     UncertaintyEstimate = OutputSlot()

--- a/tests/test_applets/objectCounting/testObjectCountingMultiImageGui.py
+++ b/tests/test_applets/objectCounting/testObjectCountingMultiImageGui.py
@@ -685,7 +685,8 @@ class TestObjectCountingGuiMultiImage(ShellGuiTestCaseBase):
                 start = boxHandle.getStart()
                 stop = boxHandle.getStop()
                 slicing = [slice(s1, s2) for s1, s2 in zip(start, stop)]
-                val = numpy.sum(gui.currentGui().op.Density[slicing[1:3]].wait())
+                # rounding here is necessary, because box label is rounded too
+                val = numpy.round(numpy.sum(gui.currentGui().op.Density[slicing[1:3]].wait()), 1)
                 val2 = float(box.density)
                 assert abs(val - val2) < 1E-3, "The value written to the box {} differs from the one gotten via the\
                 operator {}".format(val, val2)


### PR DESCRIPTION
The main commit is "solves" the problem of the gui test halting is https://github.com/ilastik/ilastik/commit/533006600dc185135cd7c6473ecfdb952a79bf09 . Unfortunately it is not a real solution, but rather a mere hack: Due to not yet clearly identified problems in lazyflow, `OpCacheFixer` will block the main thread if `OpCacheFixer.fixAtCurrent` is changed, while at the same time someone pulls from its output.

In any case, this will let the tests run through for now.
Note, that there will still be an error in the tests, which I will address in a different PR (out of scope).

This PR includes a few minor changes that I have introduced to make it more like pixelClassification.

Summary of other changes:

* didn't see a reason why `OpDenseLabelArray` was used, so changed it to `OpCompressedLabelArray`, as in pixel classification
* there was a problem serializing to hdf5 with pickled objects. these should be saved as `numpy.void`
* the callback added in https://github.com/ilastik/ilastik/commit/be2fb4c0528085a951ab7a62908cd2eacc08590d, works around the a part of the problem mentioned in https://github.com/ilastik/ilastik/issues/956, where the gaussian would only be drawn in the current tile and not across tile borders
