### PR TITLE
Adapted appveyor.yml for python 3 testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,42 @@
 clone_folder: c:\projects\ilastik
 
-cache:
-  - C:\ilastik.exe -> appveyor.yml
+environment:
+  ENV_NAME: test-env
+  # set miniconda version explicitly
+  MINICONDA: C:\Miniconda36-x64
+
 install:
-  - ps: >-
-      if (-Not (Test-Path "C:\ilastik.exe")){
-        wget http://files.ilastik.org/ilastik-1.2.2rc4-win64.exe -OutFile C:\ilastik.exe
-      }
-  - c:\ilastik.exe /VERYSILENT /DIR=C:\ilastik
-  - timeout 60
-  - ps: rm -Force -Recurse c:\ilastik\ilastik-meta
+  - set DEV_PREFIX=%MINICONDA%/envs/%ENV_NAME%
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda create -q --yes -n %ENV_NAME% -c ilastik-forge -c conda-forge python=3.6 numpy=1.12 ilastik-dependencies-no-solvers
+  - activate %ENV_NAME%
   - cd \
+  # Get the current master of all submodules
   - git clone https://github.com/ilastik/ilastik-meta c:\ilastik\ilastik-meta
   - cd ilastik\ilastik-meta
   - git submodule update --init --recursive
   - git submodule foreach "git checkout master"
-  - ps: rm -Force -Recurse c:\ilastik\ilastik-meta\ilastik
+  # Remove the conda ilastik-meta
+  - conda remove ilastik-meta
+  - ps: rm -Force -Recurse c:\ilastik\ilastik-meta\ilastik\
+  # replace with whatever version of ilastik triggered the appveyor
   - ps: cp -recurse C:\projects\ilastik c:\ilastik\ilastik-meta\ilastik
+  # Point to the current ilastik-meta
+  - set ILASTIK_PTH=%MINICONDA%/envs/%ENV_NAME%/Lib/site-packages/ilastik-meta.pth
+  - echo C:/ilastik/ilastik-meta/lazyflow > %ILASTIK_PTH%
+  - echo C:/ilastik/ilastik-meta/volumina >> %ILASTIK_PTH%
+  - echo C:/ilastik/ilastik-meta/ilastik >> %ILASTIK_PTH%
 
 build: off
 
 test_script:
+  - set DEV_PREFIX=%MINICONDA%/envs/%ENV_NAME%
+  - activate %ENV_NAME%
   - cd \
   - cd ilastik\ilastik-meta\ilastik\tests
-  - set Path=C:\ilastik;"C:\Program Files\Git\usr\bin";%Path%
+  - set Path="C:\Program Files\Git\usr\bin";%Path%
   - set CONTINUE_ON_FAILURE=1
   - sh run_each_unit_test.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   # set miniconda version explicitly
   MINICONDA: C:\Miniconda36-x64
 
+
 install:
   - set DEV_PREFIX=%MINICONDA%/envs/%ENV_NAME%
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"


### PR DESCRIPTION
I have updated the appveyor config to use our latest recipe based on python 3.

There is a failure on appveyor is a real failure and should be fixed. This PR re-enables appveyor testing and should be merged.