### PR TITLE
Tracking: add Cell Tracking Challenge export format

### DIFF
--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -853,7 +853,7 @@ class OpConservationTracking(Operator):
                     logger.info("Omitting traxel with ID: {} {}".format(traxel.Id,t))
                     print("Omitting traxel with ID: {} {}".format(traxel.Id,t))
                 else:
-                    logger.info("Adding traxel with ID: {}  {}".format(traxel.Id,t))
+                    logger.debug("Adding traxel with ID: {}  {}".format(traxel.Id,t))
                     traxelstore.TraxelsPerFrame.setdefault(int(t), {})[int(idx + 1)] = traxel
 
             if len(filtered_labels_at) > 0:

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -1,6 +1,5 @@
-import os.path
+import os
 import numpy as np
-import shutil
 import vigra
 from skimage.external import tifffile
 from ilastik.plugins import TrackingExportFormatPlugin
@@ -21,7 +20,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         """
         Export the tracking model and result
 
-        :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
+        :param filename: string of the FOLDER where to save the result (will be filled with a res_track.txt and segmentation masks for each frame)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
                of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
@@ -93,7 +92,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         """
         Save a single frame to a 2D or 3D tif
         """
-        filename = os.path.join(output_dir, 'mask' + format(timestep, "0{}".format(filename_zero_padding)) + '.tif')
+        filename = os.path.join(output_dir, f"mask{timestep:0{filename_zero_padding}}.tif")
         # import ipdb; ipdb.set_trace()
         label_image = np.swapaxes(label_image.squeeze(), 0, 1)
         if len(label_image.shape) == 2: # 2d
@@ -114,7 +113,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         filename = os.path.join(output_dir, 'res_track.txt')
         with open(filename, 'wt') as f:
             for key, value in tracks.items():
-                if key ==  None:
+                if key is  None:
                     continue
                 # our track value contains parent, begin, end
                 # but here we need begin, end, parent. so swap

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -116,8 +116,9 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
                 if key is  None:
                     continue
                 # our track value contains parent, begin, end
-                # but here we need begin, end, parent. so swap
-                f.write("{} {} {} {}\n".format(key, value[1], value[2], value[0]))
+                # but here we need begin, end, parent. so swap.
+                # Also, ilastik uses trackIDs starting at 2, but CTC wants 1, so subtract 1
+                f.write(f"{int(key) - 1} {value[1]} {value[2]} {int(value[0]) - 1}\n")
 
     def _remap_label_image(self, label_image, mapping):
         """ 

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -118,7 +118,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
                 # our track value contains parent, begin, end
                 # but here we need begin, end, parent. so swap.
                 # Also, ilastik uses trackIDs starting at 2, but CTC wants 1, so subtract 1
-                f.write(f"{int(key) - 1} {value[1]} {value[2]} {int(value[0]) - 1}\n")
+                f.write(f"{int(key) - 1} {value[1]} {value[2]} {max(0, int(value[0]) - 1)}\n")
 
     def _remap_label_image(self, label_image, mapping):
         """ 

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -8,134 +8,125 @@ from ilastik.plugins import TrackingExportFormatPlugin
 import logging
 logger = logging.getLogger(__name__)
 
-try:
-    from hytra.core.jsongraph import writeToFormattedJSON
-except ImportError:
-    logger.warn("Could not load hytra. JSON export plugin not loaded.")
-else:
+class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
+    """CTC export"""
 
-    class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
-        """CTC export"""
+    exportsToFile = False
 
-        exportsToFile = False
+    def checkFilesExist(self, filename):
+        ''' Check whether the files we want to export are already present '''
+        return os.path.exists(filename)
 
-        def checkFilesExist(self, filename):
-            ''' Check whether the files we want to export are already present '''
-            return os.path.exists(filename)
+    def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
+        """
+        Export the tracking model and result
 
-        def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
-            """
-            Export the tracking model and result
+        :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
+        :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
+        :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+               of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
 
-            :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
-            :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-            :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
-                   of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+        :returns: True on success, False otherwise
+        """
+        if not os.path.exists(filename):
+            os.makedirs(filename)
 
-            :returns: True on success, False otherwise
-            """
-            # if os.path.exists(filename):
-            #     shutil.rmtree(filename)
+        mappings = {} # dictionary over timeframes, containing another dict objectId -> trackId per frame
+        tracks = {} # stores a list of timeframes per track, so that we can find from<->to per track
+        trackParents = {} # store the parent trackID of a track if known
+        gapTrackParents = {}
 
-            # hypothesesGraph.insertEnergies()
-            # hypothesesGraph.computeLineage(1, 1, 1)
-
-            mappings = {} # dictionary over timeframes, containing another dict objectId -> trackId per frame
-            tracks = {} # stores a list of timeframes per track, so that we can find from<->to per track
-            trackParents = {} # store the parent trackID of a track if known
-            gapTrackParents = {}
-
-            for n in hypothesesGraph.nodeIterator():
-                frameMapping = mappings.setdefault(n[0], {})
-                if 'trackId' not in hypothesesGraph._graph.node[n]:
-                    raise ValueError("You need to compute the Lineage of every node before accessing the trackId!")
-                trackId = hypothesesGraph._graph.node[n]['trackId']
-                if trackId is not None:
-                    frameMapping[n[1]] = trackId
-                if trackId in tracks.keys():
-                    tracks[trackId].append(n[0])
-                else:
-                    tracks[trackId] = [n[0]]
-                if 'parent' in hypothesesGraph._graph.node[n]:
-                    assert(trackId not in trackParents)
-                    trackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['parent']]['trackId']
-                if 'gap_parent' in hypothesesGraph._graph.node[n]:
-                    assert(trackId not in trackParents)
-                    gapTrackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['gap_parent']]['trackId']
-
-            # write res_track.txt
-            logger.debug("Writing track text file")
-            trackDict = {}
-            for trackId, timestepList in tracks.items():
-                timestepList.sort()
-                if trackId in trackParents.keys():
-                    parent = trackParents[trackId]
-                else:
-                    parent = 0
-                # jumping over time frames, so creating 
-                if trackId in gapTrackParents.keys():
-                    if gapTrackParents[trackId] != trackId:
-                        parent = gapTrackParents[trackId]
-                        logger.info("Jumping over one time frame in this link: trackid: {}, parent: {}, time: {}".format(trackId, parent, min(timestepList)))
-                trackDict[trackId] = [parent, min(timestepList), max(timestepList)]
-            self._save_tracks(trackDict, filename)
-
-            # load images, relabel, and export relabeled result
-            logger.debug("Saving relabeled images")
-
-            labelImage = labelImageSlot([]).wait()
-            labelImage = np.swapaxes(labelImage, 1, 3) # do we need that?
-            for timeframe in range(labelImage.shape[0]):
-                labelFrame = labelImage[timeframe, ...]
-
-                # check if frame is empty
-                if timeframe in mappings.keys():
-                    remapped_label_image = self._remap_label_image(labelFrame, mappings[timeframe])
-                    self._save_frame_to_tif(timeframe, remapped_label_image, filename)
-                else:
-                    self._save_frame_to_tif(timeframe, labelFrame, filename)
-
-            return True
-
-
-        def _save_frame_to_tif(self, timestep, label_image, output_dir, filename_zero_padding=3):
-            """
-            Save a single frame to a 2D or 3D tif
-            """
-            filename = os.path.join(output_dir, 'mask' + format(timestep, "0{}".format(filename_zero_padding)) + '.tif')
-            # import ipdb; ipdb.set_trace()
-            label_image = np.swapaxes(label_image.squeeze(), 0, 1)
-            if len(label_image.shape) == 2: # 2d
-                vigra.impex.writeImage(label_image.astype('uint16'), filename)
-            elif len(label_image.shape) == 3: # 3D
-                label_image = np.transpose(label_image, axes=[2, 0, 1])
-                tifffile.imsave(filename, label_image.astype('uint16'))
+        for n in hypothesesGraph.nodeIterator():
+            frameMapping = mappings.setdefault(n[0], {})
+            if 'trackId' not in hypothesesGraph._graph.node[n]:
+                raise ValueError("You need to compute the Lineage of every node before accessing the trackId!")
+            trackId = hypothesesGraph._graph.node[n]['trackId']
+            if trackId is not None:
+                frameMapping[n[1]] = trackId
+            if trackId in tracks.keys():
+                tracks[trackId].append(n[0])
             else:
-                raise ValueError("Image had the wrong dimensions, can only save 2 or 3D images with a single channel")
+                tracks[trackId] = [n[0]]
+            if 'parent' in hypothesesGraph._graph.node[n]:
+                assert(trackId not in trackParents)
+                trackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['parent']]['trackId']
+            if 'gap_parent' in hypothesesGraph._graph.node[n]:
+                assert(trackId not in trackParents)
+                gapTrackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['gap_parent']]['trackId']
+
+        # write res_track.txt
+        logger.debug("Writing track text file")
+        trackDict = {}
+        for trackId, timestepList in tracks.items():
+            timestepList.sort()
+            if trackId in trackParents.keys():
+                parent = trackParents[trackId]
+            else:
+                parent = 0
+            # jumping over time frames, so creating 
+            if trackId in gapTrackParents.keys():
+                if gapTrackParents[trackId] != trackId:
+                    parent = gapTrackParents[trackId]
+                    logger.info("Jumping over one time frame in this link: trackid: {}, parent: {}, time: {}".format(trackId, parent, min(timestepList)))
+            trackDict[trackId] = [parent, min(timestepList), max(timestepList)]
+        self._save_tracks(trackDict, filename)
+
+        # load images, relabel, and export relabeled result
+        logger.debug("Saving relabeled images")
+
+        labelImage = labelImageSlot([]).wait()
+        labelImage = np.swapaxes(labelImage, 1, 3) # do we need that?
+        for timeframe in range(labelImage.shape[0]):
+            labelFrame = labelImage[timeframe, ...]
+
+            # check if frame is empty
+            if timeframe in mappings.keys():
+                remapped_label_image = self._remap_label_image(labelFrame, mappings[timeframe])
+                self._save_frame_to_tif(timeframe, remapped_label_image, filename)
+            else:
+                self._save_frame_to_tif(timeframe, labelFrame, filename)
+
+        return True
 
 
-        def _save_tracks(self, tracks, output_dir):
-            """
-            Take a dictionary indexed by TrackId which contains
-            a list [parent, begin, end] per track, and save it 
-            in the text format of the cell tracking challenge.
-            """
-            filename = os.path.join(output_dir, 'res_track.txt')
-            with open(filename, 'wt') as f:
-                for key, value in tracks.items():
-                    if key ==  None:
-                        continue
-                    # our track value contains parent, begin, end
-                    # but here we need begin, end, parent. so swap
-                    f.write("{} {} {} {}\n".format(key, value[1], value[2], value[0]))
+    def _save_frame_to_tif(self, timestep, label_image, output_dir, filename_zero_padding=3):
+        """
+        Save a single frame to a 2D or 3D tif
+        """
+        filename = os.path.join(output_dir, 'mask' + format(timestep, "0{}".format(filename_zero_padding)) + '.tif')
+        # import ipdb; ipdb.set_trace()
+        label_image = np.swapaxes(label_image.squeeze(), 0, 1)
+        if len(label_image.shape) == 2: # 2d
+            vigra.impex.writeImage(label_image.astype('uint16'), filename)
+        elif len(label_image.shape) == 3: # 3D
+            label_image = np.transpose(label_image, axes=[2, 0, 1])
+            tifffile.imsave(filename, label_image.astype('uint16'))
+        else:
+            raise ValueError("Image had the wrong dimensions, can only save 2 or 3D images with a single channel")
 
-        def _remap_label_image(self, label_image, mapping):
-            """ 
-            given a label image and a mapping, creates and 
-            returns a new label image with remapped object pixel values 
-            """
-            remapped_label_image = np.zeros(label_image.shape, dtype=label_image.dtype)
-            for dest, src in mapping.items():
-                remapped_label_image[label_image == dest] = src
 
-            return remapped_label_image
+    def _save_tracks(self, tracks, output_dir):
+        """
+        Take a dictionary indexed by TrackId which contains
+        a list [parent, begin, end] per track, and save it 
+        in the text format of the cell tracking challenge.
+        """
+        filename = os.path.join(output_dir, 'res_track.txt')
+        with open(filename, 'wt') as f:
+            for key, value in tracks.items():
+                if key ==  None:
+                    continue
+                # our track value contains parent, begin, end
+                # but here we need begin, end, parent. so swap
+                f.write("{} {} {} {}\n".format(key, value[1], value[2], value[0]))
+
+    def _remap_label_image(self, label_image, mapping):
+        """ 
+        given a label image and a mapping, creates and 
+        returns a new label image with remapped object pixel values 
+        """
+        remapped_label_image = np.zeros(label_image.shape, dtype=label_image.dtype)
+        for dest, src in mapping.items():
+            remapped_label_image[label_image == dest] = src
+
+        return remapped_label_image

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -126,7 +126,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         returns a new label image with remapped object pixel values 
         """
         remapped_label_image = np.zeros(label_image.shape, dtype=label_image.dtype)
-        for dest, src in mapping.items():
-            remapped_label_image[label_image == dest] = src
+        for src, dest in mapping.items():
+            remapped_label_image[label_image == src] = dest - 1
 
         return remapped_label_image

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -1,0 +1,141 @@
+import os.path
+import numpy as np
+import shutil
+import vigra
+from skimage.external import tifffile
+from ilastik.plugins import TrackingExportFormatPlugin
+
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    from hytra.core.jsongraph import writeToFormattedJSON
+except ImportError:
+    logger.warn("Could not load hytra. JSON export plugin not loaded.")
+else:
+
+    class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
+        """CTC export"""
+
+        exportsToFile = False
+
+        def checkFilesExist(self, filename):
+            ''' Check whether the files we want to export are already present '''
+            return os.path.exists(filename)
+
+        def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
+            """
+            Export the tracking model and result
+
+            :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
+            :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
+            :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+                   of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+
+            :returns: True on success, False otherwise
+            """
+            # if os.path.exists(filename):
+            #     shutil.rmtree(filename)
+
+            # hypothesesGraph.insertEnergies()
+            # hypothesesGraph.computeLineage(1, 1, 1)
+
+            mappings = {} # dictionary over timeframes, containing another dict objectId -> trackId per frame
+            tracks = {} # stores a list of timeframes per track, so that we can find from<->to per track
+            trackParents = {} # store the parent trackID of a track if known
+            gapTrackParents = {}
+
+            for n in hypothesesGraph.nodeIterator():
+                frameMapping = mappings.setdefault(n[0], {})
+                if 'trackId' not in hypothesesGraph._graph.node[n]:
+                    raise ValueError("You need to compute the Lineage of every node before accessing the trackId!")
+                trackId = hypothesesGraph._graph.node[n]['trackId']
+                if trackId is not None:
+                    frameMapping[n[1]] = trackId
+                if trackId in tracks.keys():
+                    tracks[trackId].append(n[0])
+                else:
+                    tracks[trackId] = [n[0]]
+                if 'parent' in hypothesesGraph._graph.node[n]:
+                    assert(trackId not in trackParents)
+                    trackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['parent']]['trackId']
+                if 'gap_parent' in hypothesesGraph._graph.node[n]:
+                    assert(trackId not in trackParents)
+                    gapTrackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]['gap_parent']]['trackId']
+
+            # write res_track.txt
+            logger.debug("Writing track text file")
+            trackDict = {}
+            for trackId, timestepList in tracks.items():
+                timestepList.sort()
+                if trackId in trackParents.keys():
+                    parent = trackParents[trackId]
+                else:
+                    parent = 0
+                # jumping over time frames, so creating 
+                if trackId in gapTrackParents.keys():
+                    if gapTrackParents[trackId] != trackId:
+                        parent = gapTrackParents[trackId]
+                        logger.info("Jumping over one time frame in this link: trackid: {}, parent: {}, time: {}".format(trackId, parent, min(timestepList)))
+                trackDict[trackId] = [parent, min(timestepList), max(timestepList)]
+            self._save_tracks(trackDict, filename)
+
+            # load images, relabel, and export relabeled result
+            logger.debug("Saving relabeled images")
+
+            labelImage = labelImageSlot([]).wait()
+            labelImage = np.swapaxes(labelImage, 1, 3) # do we need that?
+            for timeframe in range(labelImage.shape[0]):
+                labelFrame = labelImage[timeframe, ...]
+
+                # check if frame is empty
+                if timeframe in mappings.keys():
+                    remapped_label_image = self._remap_label_image(labelFrame, mappings[timeframe])
+                    self._save_frame_to_tif(timeframe, remapped_label_image, filename)
+                else:
+                    self._save_frame_to_tif(timeframe, labelFrame, filename)
+
+            return True
+
+
+        def _save_frame_to_tif(self, timestep, label_image, output_dir, filename_zero_padding=3):
+            """
+            Save a single frame to a 2D or 3D tif
+            """
+            filename = os.path.join(output_dir, 'mask' + format(timestep, "0{}".format(filename_zero_padding)) + '.tif')
+            # import ipdb; ipdb.set_trace()
+            label_image = np.swapaxes(label_image.squeeze(), 0, 1)
+            if len(label_image.shape) == 2: # 2d
+                vigra.impex.writeImage(label_image.astype('uint16'), filename)
+            elif len(label_image.shape) == 3: # 3D
+                label_image = np.transpose(label_image, axes=[2, 0, 1])
+                tifffile.imsave(filename, label_image.astype('uint16'))
+            else:
+                raise ValueError("Image had the wrong dimensions, can only save 2 or 3D images with a single channel")
+
+
+        def _save_tracks(self, tracks, output_dir):
+            """
+            Take a dictionary indexed by TrackId which contains
+            a list [parent, begin, end] per track, and save it 
+            in the text format of the cell tracking challenge.
+            """
+            filename = os.path.join(output_dir, 'res_track.txt')
+            with open(filename, 'wt') as f:
+                for key, value in tracks.items():
+                    if key ==  None:
+                        continue
+                    # our track value contains parent, begin, end
+                    # but here we need begin, end, parent. so swap
+                    f.write("{} {} {} {}\n".format(key, value[1], value[2], value[0]))
+
+        def _remap_label_image(self, label_image, mapping):
+            """ 
+            given a label image and a mapping, creates and 
+            returns a new label image with remapped object pixel values 
+            """
+            remapped_label_image = np.zeros(label_image.shape, dtype=label_image.dtype)
+            for dest, src in mapping.items():
+                remapped_label_image[label_image == dest] = src
+
+            return remapped_label_image

--- a/ilastik/plugins_default/tracking_ctc_export.yapsy-plugin
+++ b/ilastik/plugins_default/tracking_ctc_export.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = CellTrackingChallenge
+Module = tracking_ctc_export
+
+[Documentation]
+Author = Carsten Haubold
+Version = 0.1
+Website = ilastik.org
+Description = Tracking format used in the <a href="">ISBI Cell Tracking Challenges</a> <br> <br> <b>Usage: </b> Select the folder in which the following files will be exported: <ul> <li> The <i>images</i> containing the segmented and tracked cells as masks (labelimages), which will be saved as one tiff file per timeframe with the names <i> t000XX.tif </i>. </li> <li> A file about the <b>tracks</b> and lineages called <i> res_track.txt </i>. </li> </ul> <br><br> See the Cell Tracking Challenge documentation for more details ().

--- a/ilastik/plugins_default/tracking_h5_event_export.py
+++ b/ilastik/plugins_default/tracking_h5_event_export.py
@@ -89,7 +89,7 @@ else:
     
         def checkFilesExist(self, filename):
             ''' Check whether the files we want to export are already present '''
-            return os.path.exists(os.path.join(filename, 'H5-Event-Sequence'))
+            return os.path.exists(filename)
     
         def export(self, filename, hypothesesGraph, objectFeaturesSlot, labelImageSlot, rawImageSlot):
             """Export the tracking solution stored in the hypotheses graph as a sequence of H5 files,
@@ -119,6 +119,9 @@ else:
             pool = RequestPool()
     
             timeIndex = labelImageSlot.meta.axistags.index('t')
+
+            if not os.path.exists(filename):
+                os.makedirs(filename)
     
             for timestep in traxelIdPerTimestepToUniqueIdMap.keys():
                 # extract current frame lable image
@@ -127,9 +130,7 @@ else:
                 roi = tuple(roi)
                 labelImage = labelImageSlot[roi].wait()
     
-                if not os.path.exists(filename + '/H5-Event-Sequence'):
-                    os.makedirs(filename + '/H5-Event-Sequence')
-                fn = os.path.join(filename, "H5-Event-Sequence/{0:05d}.h5".format(int(timestep)))
+                fn = os.path.join(filename, "{0:05d}.h5".format(int(timestep)))
                 pool.add(Request(partial(writeEvents,
                                             int(timestep),
                                              linksPerTimestep[timestep],

--- a/ilastik/plugins_default/tracking_json_export.py
+++ b/ilastik/plugins_default/tracking_json_export.py
@@ -31,6 +31,28 @@ else:
 
             :returns: True on success, False otherwise
             """
+
+            # The nodes inserted into the graph after merger resolving
+            # do not have detectionProbabilities set. We first find one node that was no merger,
+            # check how many entries are needed, and then insert 0.0 as detection probabilities there everywhere.
+
+            numStates = -1
+            for n in hypothesesGraph.nodeIterator():
+                t = hypothesesGraph._graph.node[n]['traxel']
+                if 'detProb' in t.Features:
+                    numStates = len(t.Features['detProb'])
+                    break
+
+            assert numStates > 0, "Cannot export hypotheses graph without features (e.g. only resolved mergers) to JSON"
+
+            dummyVector = np.zeros(numStates)
+            for n in hypothesesGraph.nodeIterator():
+                t = hypothesesGraph._graph.node[n]['traxel']
+                if 'detProb' not in t.Features:
+                    logger.debug(f"replacing detProb of node with ID={hypothesesGraph._graph.node[n]['id']}")
+                    t.Features['detProb'] = dummyVector
+
+            # now we can insert the energies into the graph
             hypothesesGraph.insertEnergies()
             trackingGraph = hypothesesGraph.toTrackingGraph()
 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -384,7 +384,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
                     if os.path.basename(filename) == '':
                         filename = os.path.join(filename, 'pluginExport.txt')
                 else:
-                    filename = os.path.dirname(partially_formatted_name)
+                    filename = partially_formatted_name
 
                 if filename is None or len(str(filename)) == 0:
                     logger.error("Cannot export from plugin with empty output filename")

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -457,7 +457,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
                     if os.path.basename(filename) == '':
                         filename = os.path.join(filename, 'pluginExport.txt')
                 else:
-                    filename = os.path.dirname(partially_formatted_name)
+                    filename = partially_formatted_name
 
                 if filename is None or len(str(filename)) == 0:
                     logger.error("Cannot export from plugin with empty output filename")

--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -80,16 +80,10 @@ class TestConservationTrackingHeadless(object):
 
     @timeLogged(logger)
     def testTrackingHeadless(self):        
-        # TODO: When Hytra is supported on Windows, we shouldn't skip the test and throw an assert instead
-        try:
-            import hytra
-        except ImportError as e:
-            logger.warn( "Hytra tracking pipeline couldn't be imported: " + str(e) )
-            raise nose.SkipTest
-        
         # Skip test because there are missing files
         if not os.path.isfile(self.PROJECT_FILE) or not os.path.isfile(self.RAW_DATA_FILE) or not os.path.isfile(self.BINARY_SEGMENTATION_FILE):
-            logger.info("Test files not found.")   
+            logger.info("Test files not found.")
+            raise nose.SkipTest   
         
         args = ' --project='+self.PROJECT_FILE
         args += ' --headless'
@@ -114,17 +108,11 @@ class TestConservationTrackingHeadless(object):
 
     @timeLogged(logger)
     def testCSVExport(self):
-        # TODO: When Hytra is supported on Windows, we shouldn't skip the test and throw an assert instead
-        try:
-            import hytra
-        except ImportError as e:
-            logger.warn("Hytra tracking pipeline couldn't be imported: " + str(e))
-            raise nose.SkipTest
-
         # Skip test because there are missing files
         if not os.path.isfile(self.PROJECT_FILE) or not os.path.isfile(self.RAW_DATA_FILE) or not os.path.isfile(
                 self.BINARY_SEGMENTATION_FILE):
             logger.info("Test files not found.")
+            raise nose.SkipTest
 
         args = ' --project=' + self.PROJECT_FILE
         args += ' --headless'

--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -24,6 +24,7 @@ import numpy as np
 import h5py
 import sys
 import nose
+import shutil
 
 import ilastik
 from lazyflow.utility.timer import timeLogged
@@ -189,6 +190,7 @@ class TestConservationTrackingHeadless(object):
 
         for i in range(7):
             assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_CellTrackingChallenge', f'mask00{i}.tif')), f"Missing frame {i}"
+        shutil.rmtree(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_CellTrackingChallenge'))
 
     @timeLogged(logger)
     def testHDF5Export(self):
@@ -215,6 +217,7 @@ class TestConservationTrackingHeadless(object):
         # check output files exist
         for i in range(7):
             assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_H5-Event-Sequence', f'0000{i}.h5')), f"Missing frame {i}"
+        shutil.rmtree(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_H5-Event-Sequence'))
 
     @timeLogged(logger)
     def testMamutExport(self):
@@ -244,9 +247,13 @@ class TestConservationTrackingHeadless(object):
         self.ilastik_startup.main()
 
         # check output files exist
-        assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_mamut.xml'))
-        assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_bdv.xml'))
-        assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_raw.h5'))
+        files = [os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_mamut.xml'), 
+                 os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_bdv.xml'), 
+                 os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_Fiji-MaMuT_raw.h5')]
+        
+        for f in files:
+            assert os.path.exists(f)
+            os.remove(f)
 
     @timeLogged(logger)
     def testJsonExport(self):
@@ -276,9 +283,12 @@ class TestConservationTrackingHeadless(object):
         self.ilastik_startup.main()
 
         # check output files exist
-        assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_JSON_graph.json'))
-        assert os.path.exists(os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_JSON_result.json'))
-
+        files = [os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_JSON_graph.json'),
+                 os.path.join(self.ilastik_tests_file_path, 'data', 'inputdata', 'smallVideo_JSON_result.json')]
+        
+        for f in files:
+            assert os.path.exists(f)
+            os.remove(f)
 
 if __name__ == "__main__":
     # Make the program quit on Ctrl+C


### PR DESCRIPTION
This PR adds functionality to export the tracking result in the format defined by the [ISBI Cell Tracking Challenge](http://www.codesolorzano.com/Challenges/CTC/Welcome.html). Check [here](http://ctc2015.gryf.fi.muni.cz/Public/Documents/Naming%20and%20file%20content%20conventions.pdf) for a detailed description of the file contents.

It also fixes the export filename for tracking plugins that take the name as folder instead of file.

**Update 25.10.2017:**
* fixed a problem with mergers in JSON export
* added a bunch of tests that at least runs our plugins and also verifies the result for some of them