### PR TITLE
Remove all evals

### DIFF
--- a/bin/pointcloud_csv_to_ply.py
+++ b/bin/pointcloud_csv_to_ply.py
@@ -5,6 +5,8 @@ import collections
 
 import numpy
 
+from ilastik.utility.commandLineProcessing import ParseListFromString
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -67,10 +69,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("csv_filepath")
     parser.add_argument("ply_filepath")
-    parser.add_argument("offset", nargs='?', default=None, 
-                        help="Offset to remove from all point coordinates during export, e.g. 10.0 or [7.1, 8, 0]")
-    parser.add_argument("scale", nargs='?', default=None, 
-                        help="Scale to divide from all point coordinates during export, e.g. 100.0 or [100, 100, 1.1]")
+    parser.add_argument("offset", required=False,
+                        help="Offset to remove from all point coordinates during export, e.g. [7.1, 8, 0]",
+                        action=ParseListFromString)
+    parser.add_argument("scale", required=False,
+                        help="Scale to divide from all point coordinates during export, e.g. [100, 100, 1.1]",
+                        action=ParseListFromString)
 
     parsed_args = parser.parse_args()
 
@@ -78,8 +82,8 @@ if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)    
 
     # Evaluate offset/scale strings if provided
-    offset = parsed_args.offset and eval(parsed_args.offset)
-    scale = parsed_args.scale and eval(parsed_args.scale)
+    offset = parsed_args.offset
+    scale = parsed_args.scale
 
     sys.exit( pointcloud_csv_to_ply( parsed_args.csv_filepath, 
                                      parsed_args.ply_filepath,

--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -30,6 +30,7 @@ from abc import ABCMeta
 from ilastik.config import cfg as ilastik_config
 from lazyflow.utility.orderedSignal import OrderedSignal
 from ilastik.utility.maybe import maybe
+from ilastik.utility.commandLineProcessing import convertStringToList
 import os
 import sys
 import re
@@ -574,7 +575,7 @@ class SerialHdf5BlockSlot(SerialBlockSlot):
             groupName, labelGroup = t
             assert extract_index(groupName) == index, "subgroup extraction order should be numerical order!"
             for blockRoiString, blockDataset in list(labelGroup.items()):
-                blockRoi = eval(blockRoiString)
+                blockRoi = convertStringToList(blockRoiString)
                 roiShape = TinyVector(blockRoi[1]) - TinyVector(blockRoi[0])
                 assert roiShape == blockDataset.shape
 

--- a/ilastik/applets/dataExport/dataExportSerializer.py
+++ b/ilastik/applets/dataExport/dataExportSerializer.py
@@ -20,6 +20,15 @@
 ###############################################################################
 from functools import partial
 from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot, SerialListSlot
+import numpy
+
+
+_ALLOWED_TYPES = [
+    numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64,
+    numpy.int8, numpy.int16, numpy.int32, numpy.int64,
+    numpy.float32, numpy.float64
+]
+
 
 class SerialDtypeSlot(SerialSlot):
     
@@ -34,8 +43,9 @@ class SerialDtypeSlot(SerialSlot):
 
     @staticmethod
     def _getValue(subgroup, slot):
-        from numpy import uint8, uint16, uint32, uint64, int8, int16, int32, int64, float32, float64
-        val = eval(subgroup[()])
+        val = numpy.dtype(subgroup[()]).type
+        if val not in _ALLOWED_TYPES:
+            raise ValueError(f"Datatype {val.name} not allowed!")
         slot.setValue(val)
 
 class DataExportSerializer(AppletSerializer):

--- a/ilastik/applets/objectExtraction/objectExtractionSerializer.py
+++ b/ilastik/applets/objectExtraction/objectExtractionSerializer.py
@@ -31,6 +31,7 @@ from lazyflow.request import Request, RequestLock, RequestPool
 
 from ilastik.applets.base.appletSerializer import AppletSerializer,\
     deleteIfPresent, getOrCreateGroup, SerialSlot, SerialBlockSlot, SerialDictSlot
+from ilastik.utility.commandLineProcessing import convertStringToList
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,10 @@ class SerialObjectFeaturesSlot(SerialSlot):
             assert int(group_name) == i, "subgroup extraction order should be numerical order!"
             for roiString, roi_grp in subgroup.items():
                 logger.debug('Loading region features from dataset: "{}"'.format( roi_grp.name ))
-                roi = eval(roiString)
+                roi = convertStringToList(roiString)
+                roi = tuple(map(tuple, roi))
+                assert len(roi) == 2
+                assert len(roi[0]) == len(roi[1])
 
                 region_features = {}
                 for key, val in roi_grp.items():

--- a/ilastik/utility/commandLineProcessing.py
+++ b/ilastik/utility/commandLineProcessing.py
@@ -48,6 +48,7 @@ def convertStringToList(some_string):
     replace_values = {
         '(': '[',
         ')': ']',
+        'None': 'null',
     }
     to_parse = some_string
     for k, v in replace_values.items():

--- a/ilastik/utility/commandLineProcessing.py
+++ b/ilastik/utility/commandLineProcessing.py
@@ -1,0 +1,99 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2017, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#                 http://ilastik.org/license/
+###############################################################################
+"""
+Some tools and helpers for command line processing
+"""
+import argparse
+import json
+
+
+def convertStringToList(some_string):
+    """Helper function in order to parse lists encoded as strings
+
+    This is often found for Rois, ranges...
+
+    e.g.
+      - [0, 1]
+      - [(0, 0, ..), (1, 1, ...)]
+
+    Note: in order to use json for safe parsing of values, round brackets `(, )`
+    are replaced by square brackets `[, ]` during parsing. It is up to the user
+    to convert lists to tuples where it is expected.
+
+    e.g.
+      - [(0, 0, ..), (1, 1, ...)] will be parse to [[0, 0 ...], [1, 1, ...]]
+    """
+    assert isinstance(some_string, str), "Expected a string!"
+
+    # replace round brackets:
+    replace_values = {
+        '(': '[',
+        ')': ']',
+    }
+    to_parse = some_string
+    for k, v in replace_values.items():
+        to_parse = to_parse.replace(k, v)
+
+    try:
+        parsed = json.loads(to_parse)
+    except json.JSONDecodeError as e:
+        message = (
+            f"Expected a list encoded as a string, e.g. '[0, 1]' but got '{some_string}'. "
+            f"Encountered the following parsing problem: {e.msg} at pos {e.pos} in doc '{e.doc}'."
+        )
+        raise ValueError(message)
+
+    if not isinstance(parsed, list):
+        message = (
+            f"Expected a list encoded as a string, e.g. '[0, 1]' but got '{some_string}' -> "
+            f"type {type(parsed)}."
+        )
+        raise ValueError(message)
+
+    return parsed
+
+
+class ParseListFromString(argparse.Action):
+    """Little helper action in order to parse lists encoded as strings
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            parsed = convertStringToList(values)
+        except ValueError as e:
+            raise argparse.ArgumentError(self, str(e))
+
+        setattr(namespace, self.dest, parsed)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('this', action=ParseListFromString)
+    args = parser.parse_args(["[0, 1]"])
+    print(args)
+    assert isinstance(args.this, list)
+
+    args = parser.parse_args(["(0, 1)"])
+    print(args)
+    assert isinstance(args.this, list)
+
+    # this will raise
+    args = parser.parse_args(["(0, 1"])

--- a/tests/test_applets/base/testSerializer.py
+++ b/tests/test_applets/base/testSerializer.py
@@ -181,7 +181,7 @@ class TestSerializer(unittest.TestCase):
         #  the extra subslots are NOT removed.  Instead, they are simply disconnected.
         # Verify that the the number of ready() slots matches the number we attempted to save.
         ready_subslots = list(filter(Slot.ready, mss.slot))
-        self.assertEquals(len(ready_subslots), len(values))
+        self.assertEqual(len(ready_subslots), len(values))
 
         self.assertFalse(mss.dirty)
 

--- a/tests/test_utility/testCommandLineProcessing.py
+++ b/tests/test_utility/testCommandLineProcessing.py
@@ -67,6 +67,7 @@ class CommandLineHelperTests(unittest.TestCase):
             '(123)': [123],
             '[(1, 2)]': [[1, 2]],
             '[(1, 2), (3, 4)]': [[1, 2], [3, 4]],
+            '[(0, 0, 0), (0, None, None)]': [[0, 0, 0], [0, None, None]],
         }
 
         for value, expected in values_to_test.items():

--- a/tests/test_utility/testCommandLineProcessing.py
+++ b/tests/test_utility/testCommandLineProcessing.py
@@ -1,0 +1,83 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2017, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#                 http://ilastik.org/license/
+###############################################################################
+
+import unittest
+from ilastik.utility.commandLineProcessing import ParseListFromString
+import argparse
+import sys
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class Stdout2Log(object):
+    def write(self, msg):
+        logger.debug(msg)
+
+
+class CommandLineHelperTests(unittest.TestCase):
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+
+    def test_expected_failures(self):
+        self.parser.add_argument('this', action=ParseListFromString)
+
+        values_to_test = [
+            '123',
+            '{123}',
+            '[a, b]',
+            '[1',
+            '1]',
+            '',
+            '(1, 2, 3'
+        ]
+
+        stderr_original = sys.stderr
+
+        # redirect sdout, because it clogs the console with expected failure messages
+        sys.stderr = Stdout2Log()
+        for value in values_to_test:
+            self.assertRaises(SystemExit, self.parser.parse_args, [value])
+        sys.stderr = stderr_original
+
+    def test_allowed_string(self):
+        self.parser.add_argument('this', action=ParseListFromString)
+
+        values_to_test = {
+            '[123]': [123],
+            '(123)': [123],
+            '[(1, 2)]': [[1, 2]],
+            '[(1, 2), (3, 4)]': [[1, 2], [3, 4]],
+        }
+
+        for value, expected in values_to_test.items():
+            parsed = self.parser.parse_args([value]).this
+            self.assertEqual(parsed, expected)
+
+
+if __name__ == "__main__":
+    import sys
+    import nose
+    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
+    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
+    sys.argv.append("-v")
+    nose.run(defaultTest=__file__)


### PR DESCRIPTION
In this PR I removed all `eval` occurences in the code.

Rationale: `eval` is just not that safe and not really needed for our purposes.

This PR should be thoroughly reviewed, as I am not sure everything is tested - so a second pair of eyes would be nice.

* Conversion from strings representing lists is now mostly handled while parsing the arguments and based on `json.loads`-> `ilastik.utility.commandLineProcessing.ParseListFromString`
* in the two scripts residing in `/bin` I have changed the behaviour slightly. Single sumbers are not allowed anymore for `scale` and `offset`. Also I have made optional arguments `required=False`, rather than `nargs='?', default=None`. Behaviour should be the same.
