### PR TITLE
Test all workflows in headless mode with blank project files

### DIFF
--- a/tests/test_workflows/test_all/testAllHeadless.py
+++ b/tests/test_workflows/test_all/testAllHeadless.py
@@ -71,8 +71,11 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
 
         # Start up the ilastik.py entry script as if we had launched it from the command line
         parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+
         shell = ilastik_main.main(
             parsed_args=parsed_args, workflow_cmdline_args=workflow_cmdline_args, init_logging=False)
+
+        shell.closeCurrentProject()
 
         # now check if the project file has been created:
         assert os.path.exists(project_file), f"Project File {project_file} creation not successful"
@@ -114,5 +117,7 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
         shell = ilastik_main.main(
             parsed_args=parsed_args, workflow_cmdline_args=workflow_cmdline_args, init_logging=False)
+
+        shell.closeCurrentProject()
 
         # no errors -> everything should be cool

--- a/tests/test_workflows/test_all/testAllHeadless.py
+++ b/tests/test_workflows/test_all/testAllHeadless.py
@@ -1,0 +1,35 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2017, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+"""Basic tests that can be applied to _all_ workflows in headless mode
+
+This is meant as a sanity check to make sure that workflows can be at least
+started after changes are committed.
+
+Also this can be used as a basis for further headless-mode testing.
+"""
+from ilastik.workflow import getAvailableWorkflows
+
+
+class TestHeadlessWorkflowStartupProjectCreation(object):
+    """Start a headless shell and create a project for each workflow"""
+    @classmethod
+    def setupClass(cls):
+        cls.workflow_list = list(getAvailableWorkflows())

--- a/tests/test_workflows/test_all/testAllHeadless.py
+++ b/tests/test_workflows/test_all/testAllHeadless.py
@@ -37,6 +37,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def generate_project_file_name(temp_dir, workflow_name):
+    project_file_name = os.path.join(
+        temp_dir,
+        f'test_project_{"_".join(workflow_name.split())}.ilp'
+    )
+    return project_file_name
+
+
 class TestHeadlessWorkflowStartupProjectCreation(object):
     """Start a headless shell and create a project for each workflow"""
     @classmethod
@@ -56,10 +64,8 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         """
         workflow_class, workflow_name, display_name = workflow_class_tuple
         logger.debug(f'starting {workflow_name}')
-        project_file = os.path.join(
-            temp_dir,
-            f'test_project_{"_".join(workflow_name.split())}.ilp'
-        )
+        project_file = generate_project_file_name(temp_dir, workflow_name)
+
         args = [
             '--headless',
             f'--new_project={project_file}',
@@ -97,10 +103,7 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         """
         workflow_class, workflow_name, display_name = workflow_class_tuple
         logger.debug(f'starting {workflow_name}')
-        project_file = os.path.join(
-            temp_dir,
-            f'test_project_{"_".join(workflow_name.split())}.ilp'
-        )
+        project_file = generate_project_file_name(temp_dir, workflow_name)
 
         self.create_project_file(workflow_class, project_file)
         assert os.path.exists(project_file), f"Project File {project_file} creation not successful"


### PR DESCRIPTION
The code in this PR tests all workflows that are discovered with `ilastik.workflows.getAvailableWorkflows()`.

The tests are very basic:
* a blank project file is created for each workflow using `ilastik.shell.projectManager.ProjectManager`
* this project file is then opened in the headless shell.

Any unexpected errors (uncaught exceptions) will make this test fail.

Furthermore, project file creation via the command line is also tested.

Currently, the ObjectClassificationWorkflow will complain about `Couldn't obtain a classifier from your project file` and `Was not able to understand the batch mode command-line arguments.`. Those messages are properly caught errors, and should be okay for our purpose.

Open to suggestions to improve this test @akreshuk @chaubold 