### PR TITLE
fix error in counting workflow on box deletion

### DIFF
--- a/ilastik/widgets/boxListModel.py
+++ b/ilastik/widgets/boxListModel.py
@@ -219,6 +219,8 @@ class BoxListModel(ListModel):
                 return Qt.ItemIsEnabled | Qt.ItemIsSelectable
             else:
                 return Qt.NoItemFlags
+        else:
+            return Qt.NoItemFlags
 
     def removeRow(self, position, parent=QModelIndex()):
         self.boxRemoved.emit(position)


### PR DESCRIPTION
Summary ;):
* `BoxListModel.flags` returns `Qt.NoItemFlags` per default

I have also looked around all ilastik and befriended repos: we should be fine. Everywhere else there are default cases that return some kind of `Qt.ItemFlags` thing.

Fixes #1637