### PR TITLE
`SerialPickledValueSlot` replaced with `SerialPickleableSlot`

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -643,24 +643,6 @@ class SerialClassifierSlot(SerialSlot):
         # retrained.)
         self.cache.forceValue( classifier )
 
-class SerialPickledValueSlot(SerialSlot):
-    """
-    For storing value slots whose data is a python object (not an array or a simple number).
-    """
-    def __init__(self, slot):
-        super(SerialPickledValueSlot, self).__init__(slot)
-    
-    @staticmethod
-    def _saveValue(group, name, value):
-        group.create_dataset(name, data=numpy.void(pickle.dumps(value, 0)))
-
-    @staticmethod
-    def _getValue(subgroup, slot):
-        val = subgroup[()]
-        if isinstance(val, numpy.void):
-            val = val.tobytes()
-        slot.setValue(pickle.loads(val, encoding='latin1'))
-
 
 class SerialCountingSlot(SerialSlot):
     """For saving a random forest classifier."""

--- a/ilastik/applets/objectClassification/objectClassificationSerializer.py
+++ b/ilastik/applets/objectClassification/objectClassificationSerializer.py
@@ -22,7 +22,7 @@ import warnings
 
 from ilastik.applets.base.appletSerializer import \
   AppletSerializer, SerialSlot, SerialDictSlot, \
-  SerialClassifierSlot, SerialListSlot, SerialPickledValueSlot
+  SerialClassifierSlot, SerialListSlot, SerialPickleableSlot
 
 class SerialDictSlotWithoutDeserialization(SerialDictSlot):
     
@@ -44,6 +44,7 @@ class ObjectClassificationSerializer(AppletSerializer):
     # would call setValue() on a connected slot
 
     def __init__(self, topGroupName, operator):
+        self.VERSION = 1  # Make sure to bump the version in case you make any changes in the serialization
         serialSlots = [
             SerialDictSlot(operator.SelectedFeatures),
             SerialListSlot(operator.LabelNames),
@@ -57,7 +58,7 @@ class ObjectClassificationSerializer(AppletSerializer):
                            operator.InputProbabilities,
                            transform=int),
             SerialSlot(operator.MaxNumObj),
-            SerialPickledValueSlot(operator.ExportSettings)
+            SerialPickleableSlot(operator.ExportSettings, self.VERSION, None)
         ]
 
         super(ObjectClassificationSerializer, self ).__init__(topGroupName,

--- a/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
@@ -21,7 +21,7 @@
 from builtins import range
 import numpy
 import vigra
-from ilastik.applets.base.appletSerializer import AppletSerializer, SerialClassifierSlot, SerialBlockSlot, SerialListSlot, SerialClassifierFactorySlot, SerialPickledValueSlot
+from ilastik.applets.base.appletSerializer import AppletSerializer, SerialClassifierSlot, SerialBlockSlot, SerialListSlot, SerialClassifierFactorySlot, SerialPickleableSlot
 
 import logging
 logger = logging.getLogger(__name__) 
@@ -32,13 +32,14 @@ class PixelClassificationSerializer(AppletSerializer):
 
     """
     def __init__(self, operator, projectFileGroupName):
+        self.VERSION = 1
         self._serialClassifierSlot =  SerialClassifierSlot(operator.Classifier,
                                                            operator.classifier_cache,
                                                            name="ClassifierForests")
         slots = [SerialListSlot(operator.LabelNames),
                  SerialListSlot(operator.LabelColors, transform=lambda x: tuple(x.flat)),
                  SerialListSlot(operator.PmapColors, transform=lambda x: tuple(x.flat)),
-                 SerialPickledValueSlot(operator.Bookmarks),
+                 SerialPickleableSlot(operator.Bookmarks, self.VERSION),
                  SerialBlockSlot(operator.LabelImages,
                                  operator.LabelInputs,
                                  operator.NonzeroLabelBlocks,

--- a/ilastik/applets/tracking/base/trackingSerializer.py
+++ b/ilastik/applets/tracking/base/trackingSerializer.py
@@ -18,22 +18,22 @@
 # on the ilastik web site at:
 #		   http://ilastik.org/license.html
 ###############################################################################
-from ilastik.applets.base.appletSerializer import AppletSerializer,\
-    SerialDictSlot, SerialSlot, SerialHdf5BlockSlot, SerialPickleableSlot, SerialPickledValueSlot
+from ilastik.applets.base.appletSerializer import (
+    AppletSerializer, SerialDictSlot, SerialPickleableSlot)
 
 import hytra
 
 class TrackingSerializer(AppletSerializer):
-    VERSION = 1 # Make sure to bump the version in case you make any changes in the serialization
-    
+    VERSION = 1  # Make sure to bump the version in case you make any changes in the serialization
+
     def __init__(self, mainOperator, projectFileGroupName):
         # Serialization for the new pipeline (HyTra)
         slots = [SerialDictSlot(mainOperator.Parameters, selfdepends=True),
                  SerialDictSlot(mainOperator.FilteredLabels, transform=str, selfdepends=True),
-                 SerialPickledValueSlot(mainOperator.ExportSettings),                     
+                 SerialPickleableSlot(mainOperator.ExportSettings, self.VERSION, None),
                  SerialPickleableSlot(mainOperator.HypothesesGraph, self.VERSION, None),
                  SerialPickleableSlot(mainOperator.ResolvedMergers, self.VERSION, None)
                  ]
 
         super( TrackingSerializer, self ).__init__( projectFileGroupName, slots=slots )
-        
+

--- a/ilastik/applets/tracking/manual/manualTrackingSerializer.py
+++ b/ilastik/applets/tracking/manual/manualTrackingSerializer.py
@@ -19,7 +19,7 @@
 #		   http://ilastik.org/license.html
 ###############################################################################
 from ilastik.applets.base.appletSerializer import AppletSerializer,\
-    SerialSlot, deleteIfPresent, getOrCreateGroup, SerialPickledValueSlot
+    SerialSlot, deleteIfPresent, getOrCreateGroup, SerialPickleableSlot
 
 class SerialDivisionsSlot(SerialSlot):
     def serialize(self, group):
@@ -91,13 +91,14 @@ class SerialLabelsSlot(SerialSlot):
         self.dirty = False
         
 class ManualTrackingSerializer(AppletSerializer):
-    
+
     def __init__(self, operator, projectFileGroupName):
+        self.VERSION = 1  # Make sure to bump the version in case you make any changes in the serialization
         slots = [ #SerialSlot(operator.TrackImage),
                    SerialDivisionsSlot(operator.Divisions),
                    SerialLabelsSlot(operator.Labels)]
                     
                    # FIXME: ExportSettings can't be serialized because it is technically a level-1 slot.
-                   #SerialPickledValueSlot(operator.ExportSettings)
+                   #SerialPickleableSlot(operator.ExportSettings, version=self.VERSION)
     
         super(ManualTrackingSerializer, self ).__init__(projectFileGroupName, slots=slots)

--- a/ilastik/applets/tracking/structured/structuredTrackingSerializer.py
+++ b/ilastik/applets/tracking/structured/structuredTrackingSerializer.py
@@ -18,18 +18,19 @@
 # on the ilastik web site at:
 #		   http://ilastik.org/license.html
 ###############################################################################
-from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot, SerialDictSlot, SerialPickledValueSlot
+from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot, SerialDictSlot, SerialPickleableSlot
 
 class StructuredTrackingSerializer(AppletSerializer):
 
     def __init__(self, topLevelOperator, projectFileGroupName):
+        self.VERSION = 1  # Make sure to bump the version in case you make any changes in the serialization
         try:
             slots = [ SerialDictSlot(topLevelOperator.Parameters, selfdepends=True),
                       SerialDictSlot(topLevelOperator.FilteredLabels, transform=str, selfdepends=True),
-                      SerialPickledValueSlot(topLevelOperator.ExportSettings),
-                      SerialPickledValueSlot(topLevelOperator.HypothesesGraph),
-                      SerialPickledValueSlot(topLevelOperator.LearningHypothesesGraph),
-                      SerialPickledValueSlot(topLevelOperator.ResolvedMergers),
+                      SerialPickleableSlot(topLevelOperator.ExportSettings, version=self.VERSION),
+                      SerialPickleableSlot(topLevelOperator.HypothesesGraph, version=self.VERSION),
+                      SerialPickleableSlot(topLevelOperator.LearningHypothesesGraph, version=self.VERSION),
+                      SerialPickleableSlot(topLevelOperator.ResolvedMergers, version=self.VERSION),
                       SerialSlot(topLevelOperator.DivisionWeight),
                       SerialSlot(topLevelOperator.DetectionWeight),
                       SerialSlot(topLevelOperator.TransitionWeight),
@@ -40,8 +41,8 @@ class StructuredTrackingSerializer(AppletSerializer):
         except:
             slots = [ SerialDictSlot(topLevelOperator.Parameters, selfdepends=True),
                       SerialDictSlot(topLevelOperator.FilteredLabels, transform=str, selfdepends=True),
-                      SerialPickledValueSlot(topLevelOperator.ExportSettings),
-                      SerialPickledValueSlot(topLevelOperator.ResolvedMergers),
+                      SerialPickleableSlot(topLevelOperator.ExportSettings, version=self.VERSION),
+                      SerialPickleableSlot(topLevelOperator.ResolvedMergers, version=self.VERSION),
                       SerialSlot(topLevelOperator.DivisionWeight),
                       SerialSlot(topLevelOperator.DetectionWeight),
                       SerialSlot(topLevelOperator.TransitionWeight),


### PR DESCRIPTION
In `appletSerializer.py`, we had two classes that were doing basically the same thing: `SerialPickledValueSlot` and `SerialPickleableSlot`. Both were used in the code-base without an apparent reason. Since `SerialPickleableSlot` was already a bit nicer, I have ditched `SerialPickledValueSlot`. Furthermore, I changed all occurrences of `SerialPickledValueSlot` to `SerialPickleableSlot`.

I have also improved the error handling in `SerialPickleableSlot` which often failed unnecessarily.