### PR TITLE
fix carving import

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -578,7 +578,8 @@ class CarvingGui(LabelingGui):
 
         lut = numpy.zeros(op.MST.value.nodeNum+1, dtype=numpy.int32)
         for name, label in self._shownObjects3D.iteritems():
-            objectSupervoxels = op.MST.value.objects[name]
+            objectSupervoxels = op.MST.value.object_lut[name]
+
             lut[objectSupervoxels] = label
 
         if self._showSegmentationIn3D:

--- a/ilastik/workflows/carving/carvingSerializer.py
+++ b/ilastik/workflows/carving/carvingSerializer.py
@@ -35,8 +35,18 @@ class CarvingSerializer( AppletSerializer ):
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         obj = getOrCreateGroup(topGroup, "objects")
         for imageIndex, opCarving in enumerate( self._o.innerOperators ):
-            mst = opCarving._mst 
-            for name in opCarving._dirtyObjects:
+            mst = opCarving._mst
+
+            # Populate a list of objects to save:
+            objects_to_save = set(list(mst.object_names.keys()))
+            objects_already_saved = set(list(topGroup["objects"]))
+            # 1.) all objects that are in mst.object_names that are not in saved
+            objects_to_save = objects_to_save.difference(objects_already_saved)
+
+            # 2.) add opCarving._dirtyObjects:
+            objects_to_save = objects_to_save.union(opCarving._dirtyObjects)
+
+            for name in objects_to_save:
                 logger.info( "[CarvingSerializer] serializing %s" % name )
                
                 if name in obj and name in mst.object_seeds_fg_voxels: 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -516,7 +516,6 @@ class OpCarving(Operator):
         self._mst.bg_priority[name] = self.BackgroundPriority.value
         self._mst.no_bias_below[name] = self.NoBiasBelow.value
 
-        self._mst.objects[name] = numpy.where(sVseg == 2)
         self._mst.object_lut[name] = numpy.where(sVseg == 2)
 
      


### PR DESCRIPTION
fixes issue #1657
see also PR #1658

this is the carving fix for the python-2 side

Before serializing the objects, it is first checked, which objects are already present in the h5 file.

All objects in `opCarving._dirtyObjects` are still processed (old behaviour),
but additionally all objects not present in the file are also saved.