### PR TITLE
Fixes Object classification h5 table export

### DIFF
--- a/bin/labelcounts.py
+++ b/bin/labelcounts.py
@@ -74,8 +74,8 @@ if __name__ == "__main__":
         try:
             label_names = f['PixelClassification/LabelNames'].value
         except KeyError:
-            label_names = map( lambda n: "Label {}".format(n), list(range(num_bins)) )[1:]
-        
+            label_names = [f"Label {n}" for n in range(1, num_bins)]
+
         for image_index, img_bins in enumerate(bins_by_image):
             print_bincounts( label_names, img_bins, "Image #{}".format( image_index+1 ) )
         

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -241,7 +241,7 @@ def create_slicing(axistags, dimensions, margin, feature_table):
                   min(maxz[i] + margin, dimensions[3])),
             slice(None)
         ]
-        yield map(slicing.__getitem__, indices)[:5 - excludes], oid
+        yield [slicing[x] for x in indices][:5 - excludes], oid
         oid += 1
 
 


### PR DESCRIPTION
Problem was related to the python 3 switch, see #1673

In the two changed files, `map` was used and immediately subscripted, which of course resulted in an error, as map returns an iterator.

I've replaced the `map` with list comprehensions, where it is subscripted afterwards. 

fixes #1673

not related to https://github.com/ilastik/ilastik/issues/1671