### PR TITLE
Remove eventcapture submodule from ilastik

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/eventcapture"]
-	path = submodules/eventcapture
-	url = https://github.com/ilastik/eventcapture

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1741,13 +1741,6 @@ class IlastikShell(QMainWindow):
                     # But we're shutting down right now.
                     # Just block here for the save to complete before we continue to shut down.
                     saveThread.join()
-        try:
-            from eventcapture.eventRecordingApp import EventRecordingApp
-
-            if isinstance(QApplication.instance(), EventRecordingApp):
-                return QApplication.instance().recorder_control_window.confirmQuit()
-        except ImportError:
-            pass
         return True
 
     def closeAndQuit(self, quitApp=True):

--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -34,7 +34,7 @@ from . import splashScreen
 import ilastik.config
 shell = None
 
-def startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, preinit_funcs, postinit_funcs):
+def startShellGui(workflow_cmdline_args, preinit_funcs, postinit_funcs):
     """
     Create an application and launch the shell in it.
     """
@@ -53,13 +53,7 @@ def startShellGui(workflow_cmdline_args, eventcapture_mode, playback_args, prein
     if ilastik.config.cfg.getboolean("ilastik", "debug"):
         QApplication.setAttribute(Qt.AA_DontUseNativeMenuBar, True)
 
-    if eventcapture_mode is not None:
-        # Only use a special QApplication subclass if we are recording.
-        # Otherwise, it's a performance penalty for every event processed by Qt.
-        from eventcapture.eventRecordingApp import EventRecordingApp
-        app = EventRecordingApp.create_app(eventcapture_mode, **playback_args)
-    else:
-        app = QApplication([])
+    app = QApplication([])
     _applyStyleSheet(app)
 
     splashScreen.showSplashScreen()

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -116,8 +116,6 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
 
     faulthandler.enable()
     _init_excepthooks(parsed_args)
-    eventcapture_mode, playback_args = _prepare_test_recording_and_playback(
-        parsed_args)
 
     if ilastik_config.getboolean("ilastik", "debug"):
         message = 'Starting ilastik in debug mode from "%s".' % ilastik_dir
@@ -152,8 +150,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     # Normal launch
     else:
         from ilastik.shell.gui.startShellGui import startShellGui
-        sys.exit(startShellGui(workflow_cmdline_args, eventcapture_mode,
-                               playback_args, preinit_funcs, postinit_funcs))
+        sys.exit(startShellGui(workflow_cmdline_args, preinit_funcs, postinit_funcs))
 
 
 def _import_h5py_with_utf8_encoding():
@@ -381,34 +378,6 @@ def _prepare_auto_create_new_project(parsed_args):
         # This should work for both the IlastikShell and the HeadlessShell
         shell.createAndLoadNewProject(path, workflow_class)
     return createNewProject
-
-
-def _prepare_test_recording_and_playback(parsed_args):
-    if parsed_args.start_recording or parsed_args.playback_script:
-        # Disable the opengl widgets during recording and playback.
-        # Somehow they can cause random segfaults if used during recording
-        # playback.
-        import volumina
-        volumina.NO3D = True
-
-    # Enable test-case recording?
-    eventcapture_mode = None
-    playback_args = {}
-    if parsed_args.start_recording:
-        assert not parsed_args.playback_script is False, "Can't record and " \
-            "play back at the same time!  Choose one or the other"
-        eventcapture_mode = 'record'
-    elif parsed_args.playback_script is not None:
-        # Only import GUI modules in non-headless mode.
-        from PyQt5.QtWidgets import QApplication
-        eventcapture_mode = 'playback'
-        # See EventRecordingApp.create_app() for details
-        playback_args['playback_script'] = parsed_args.playback_script
-        playback_args['playback_speed'] = parsed_args.playback_speed
-        # Auto-exit on success?
-        if parsed_args.exit_on_success:
-            playback_args['finish_callback'] = QApplication.quit
-    return eventcapture_mode, playback_args
 
 
 def _init_excepthooks(parsed_args):

--- a/tests/launch_workflow.py
+++ b/tests/launch_workflow.py
@@ -103,4 +103,4 @@ workflowClass = Workflow.getSubclass(parsed_args.workflow)
 
 # Launch the GUI
 from ilastik.shell.gui.startShellGui import startShellGui
-sys.exit( startShellGui( workflowClass, *init_funcs ) )
+sys.exit(startShellGui(workflowClass, *init_funcs))


### PR DESCRIPTION
This is not something that's set in stone. It's more to start a discussion about what should be done with the `eventcapture` in ilastik. `eventcapture` is not compatible with `ilastik` atm, cause it uses legacy `PyQt4`. We have two options to consider, depending of whether or not we want to continue using `eventcapture` for GUI testing:
- we want to keep using it, then `eventcapture` needs to be ported to `PyQt5`
- we don't want to used it, thus remove it from ilastik dependencies (this PR). See also the discussion under https://github.com/ilastik/eventcapture/pull/1#issuecomment-360521605