### PR TITLE
Added sort parameter explicitly

### DIFF
--- a/ilastik/shell/gui/variableImportanceDialog.py
+++ b/ilastik/shell/gui/variableImportanceDialog.py
@@ -64,7 +64,7 @@ class VariableImportanceDialog(QDialog):
             table.resizeColumnsToContents()  
             
             table.setSortingEnabled(True)
-            table.sortByColumn(3) # Sort by overall importance
+            table.sortByColumn(3, Qt.DescendingOrder)  # Sort by overall importance
 
             layout.addWidget(table, 1, 0, 3, 2)  
             


### PR DESCRIPTION
seems to be a qt4->qt5 transition quirk, sortByColumn expects a parameter specifiing the order.

fixes #1705 -> at least the feature importance part

I have also grepped over all files, no related issues to expect.