### PR TITLE
Allow 2D images to be loaded from H5 files

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -697,7 +697,7 @@ class DataSelectionGui(QWidget):
         return ( dlg_state == QDialog.Accepted )
 
     @classmethod
-    def getPossibleInternalPaths(cls, absPath, min_ndim=3, max_ndim=5):
+    def getPossibleInternalPaths(cls, absPath, min_ndim=2, max_ndim=5):
         datasetNames = []
         # Open the file as a read-only so we can get a list of the internal paths
         with h5py.File(absPath, 'r') as f:


### PR DESCRIPTION
fixed #1662 
Loading data from .h5 files was limited to data with 3 to 5 
dimensions. In this PR I have changed the lower limit to 2 dimensions. 
Side effect: Also non-image data (e.g. tables) might now show up in 
the imge selection dialog when loading from .h5 files with multiple 
datasets.