### PR TITLE
#-1758 Object classification: 'Live Update' should be a button not a checkbox for consistency with the other workflows

### DIFF
--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -94,12 +94,9 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QCheckBox" name="checkInteractive">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
+        <widget class="QPushButton" name="checkInteractive">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1180,6 +1180,7 @@ class IlastikShell(QMainWindow):
         if ilastik_config.getboolean("ilastik", "debug"):
             self.menuBar().addMenu(self._debugMenu)
         self.menuBar().addMenu(self._helpMenu)
+        self.menuBar().addMenu(self._docButton)
 
     def getModelIndexFromDrawerIndex(self, drawerIndex):
         drawerTitleItem = self.appletBar.widget(drawerIndex)

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -33,6 +33,7 @@ import weakref
 import logging
 import platform
 import threading
+import webbrowser
 
 # SciPy
 import numpy
@@ -371,12 +372,14 @@ class IlastikShell(QMainWindow):
         if ilastik_config.getboolean("ilastik", "debug"):
             self._debugMenu = self._createDebugMenu()
         self._helpMenu = self._createHelpMenu()
+        self._docButton = self._createDocButton()
         self.menuBar().addMenu(self._projectMenu)
         if self._settingsMenu is not None:
             self.menuBar().addMenu(self._settingsMenu)
         if ilastik_config.getboolean("ilastik", "debug"):
             self.menuBar().addMenu(self._debugMenu)
         self.menuBar().addMenu(self._helpMenu)
+        self.menuBar().addMenu(self._docButton)
 
         assert self.thread() == QApplication.instance().thread()
         assert self.menuBar().thread() == self.thread()
@@ -625,6 +628,16 @@ class IlastikShell(QMainWindow):
         #self.startscreen.setParent(None)
         #del self.startscreen
         self.openProjectFile(path)
+
+    def _createDocButton(self):
+        pushButton = QMenu("&Check the docs!", self)
+        pushButton.setObjectName("docs_menu")
+        aboutIlastikPushAction = pushButton.addAction("&ilastik - Overview")
+        aboutIlastikPushAction.triggered.connect(self.on_pushButton_clicked)
+        return pushButton
+
+    def on_pushButton_clicked(self):
+        webbrowser.open('http://ilastik.org/documentation/', new=2)
 
     def _createHelpMenu(self):
         menu = QMenu("&Help", self)


### PR DESCRIPTION
Object classification: 'Live Update' should be a button not a checkbox for consistency with the other workflows. let me know your view
![liveupdate](https://user-images.githubusercontent.com/9729599/40514327-583ce264-5fc6-11e8-87fd-8462abf6d247.JPG)
