### PR TITLE
#1758 replace object classification checkbox liveupdate to button

### DIFF
--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -94,12 +94,9 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QCheckBox" name="checkInteractive">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
+        <widget class="QPushButton" name="checkInteractive">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>


### PR DESCRIPTION
replaced object classification checkbox live update to button
![liveupdate](https://user-images.githubusercontent.com/9729599/40566387-ff8e3654-608d-11e8-82a1-b0bc86cfd9b1.JPG)
