### PR TITLE
Fix show invisible test fail

### DIFF
--- a/tests/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
+++ b/tests/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
@@ -332,4 +332,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -308,4 +308,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/dataExport/testOpDataExport.py
+++ b/tests/test_applets/dataExport/testOpDataExport.py
@@ -101,5 +101,5 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)
         

--- a/tests/test_applets/dataSelection/testDataSelectionSerializer.py
+++ b/tests/test_applets/dataSelection/testDataSelectionSerializer.py
@@ -140,4 +140,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")
     sys.argv.append("--nologcapture")
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_applets/dataSelection/testOpDataSelection.py
@@ -1005,4 +1005,4 @@ class TestOpDataSelection_stack_along_parameter():
 
 if __name__ == "__main__":
     import nose
-    nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE': 1})
+    nose.main(defaultTest=__file__, env={'NOSE_NOCAPTURE': 1})

--- a/tests/test_applets/dataSelection/testOpDataSelectionGroup.py
+++ b/tests/test_applets/dataSelection/testOpDataSelectionGroup.py
@@ -163,4 +163,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/edgeTraining/testOpEdgeTraining.py
+++ b/tests/test_applets/edgeTraining/testOpEdgeTraining.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/featureSelection/testFeatureSelectionSerializer.py
+++ b/tests/test_applets/featureSelection/testFeatureSelectionSerializer.py
@@ -93,4 +93,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/featureSelection/testOpFeatureSelection.py
+++ b/tests/test_applets/featureSelection/testOpFeatureSelection.py
@@ -151,4 +151,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectClassification/testConvexHull.py
+++ b/tests/test_applets/objectClassification/testConvexHull.py
@@ -120,4 +120,4 @@ if __name__ == "__main__":
 
     import nose
 
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectClassification/testMissingValues.py
+++ b/tests/test_applets/objectClassification/testMissingValues.py
@@ -111,4 +111,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectClassification/testOperators.py
+++ b/tests/test_applets/objectClassification/testOperators.py
@@ -455,4 +455,4 @@ if __name__ == '__main__':
     # Don't set the logging level to DEBUG. Leave it alone.
     sys.argv.append("--nologcapture")
 
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectClassification/testPrediction.py
+++ b/tests/test_applets/objectClassification/testPrediction.py
@@ -373,4 +373,4 @@ if __name__ == '__main__':
     # Don't set the logging level to DEBUG. Leave it alone.
     sys.argv.append("--nologcapture")
 
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectClassification/testTransferLabels.py
+++ b/tests/test_applets/objectClassification/testTransferLabels.py
@@ -60,4 +60,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectCounting/testObjectCountingOperators.py
+++ b/tests/test_applets/objectCounting/testObjectCountingOperators.py
@@ -410,4 +410,4 @@ if __name__ == '__main__':
     # Don't set the logging level to DEBUG. Leave it alone.
     sys.argv.append("--nologcapture")
 
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/objectExtraction/testOperators.py
+++ b/tests/test_applets/objectExtraction/testOperators.py
@@ -216,4 +216,4 @@ if __name__ == '__main__':
     # Don't set the logging level to DEBUG. Leave it alone.
     sys.argv.append("--nologcapture")
 
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -273,4 +273,6 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    # nose.main will exit right after the tests are run with the correct return value
+    # (in contrast to nose.run)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -91,12 +91,12 @@ class TestPixelClassificationHeadless(object):
     @classmethod
     def create_random_data(cls):
         cls.SAMPLE_DATA = os.path.join(cls.data_dir, 'random_data.npy')
-        cls.data = numpy.random.random((2,200,200,5,1))
+        cls.data = numpy.random.random((2, 20, 20, 5, 1))
         cls.data *= 256
         numpy.save(cls.SAMPLE_DATA, cls.data.astype(numpy.uint8))
         
         cls.SAMPLE_MASK = os.path.join(cls.data_dir, 'mask.npy')
-        cls.data = numpy.ones((2,200,200,5,1))
+        cls.data = numpy.ones((2, 20, 20, 5, 1))
         numpy.save(cls.SAMPLE_MASK, cls.data.astype(numpy.uint8))
 
     @classmethod

--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -91,13 +91,10 @@ class TestPixelClassificationHeadless(object):
     @classmethod
     def create_random_data(cls):
         cls.SAMPLE_DATA = os.path.join(cls.data_dir, 'random_data.npy')
-        cls.data = numpy.random.random((2, 20, 20, 5, 1))
-        cls.data *= 256
-        numpy.save(cls.SAMPLE_DATA, cls.data.astype(numpy.uint8))
-        
+        numpy.save(cls.SAMPLE_DATA, numpy.random.randint(0, 256, (2, 20, 20, 5, 1), dtype=numpy.uint8))
+
         cls.SAMPLE_MASK = os.path.join(cls.data_dir, 'mask.npy')
-        cls.data = numpy.ones((2, 20, 20, 5, 1))
-        numpy.save(cls.SAMPLE_MASK, cls.data.astype(numpy.uint8))
+        numpy.save(cls.SAMPLE_MASK, numpy.ones((2, 20, 20, 5, 1), dtype=numpy.uint8))
 
     @classmethod
     def create_new_project(cls):
@@ -199,7 +196,7 @@ class TestPixelClassificationHeadless(object):
             assert "/volume/pred_volume" in f
             pred_shape = f["/volume/pred_volume"].shape
             # Assume channel is last axis
-            assert pred_shape[:-1] == self.data.shape[:-1], "Prediction volume has wrong shape: {}".format( pred_shape )
+            assert pred_shape[:-1] == (2, 20, 20, 5), "Prediction volume has wrong shape: {}".format( pred_shape )
             assert pred_shape[-1] == 2, "Prediction volume has wrong shape: {}".format( pred_shape )
         
     @timeLogged(logger)
@@ -225,7 +222,7 @@ class TestPixelClassificationHeadless(object):
         args.append( "--pipeline_result_drange=(0,2)" )
         args.append( "--export_drange=(0,255)" )
  
-        args.append( "--cutout_subregion=[(0,50,50,0,0), (1, 150, 150, 50, 1)]" )
+        args.append( "--cutout_subregion=[(0,10,10,0,0), (1, 20, 20, 5, 1)]" )
         args.append( self.SAMPLE_DATA )
  
         old_sys_argv = list(sys.argv)
@@ -257,7 +254,7 @@ class TestPixelClassificationHeadless(object):
             readData = opReorderAxes.Output[:].wait()
      
             # Check basic attributes
-            assert readData.shape[:-1] == self.data[0:1, 50:150, 50:150, 0:50, 0:1].shape[:-1] # Assume channel is last axis
+            assert readData.shape[:-1] == (1, 10, 10, 5), readData.shape[:-1]  # Assume channel is last axis
             assert readData.shape[-1] == 1, "Wrong number of channels.  Expected 1, got {}".format( readData.shape[-1] )
         finally:
             # Clean-up.

--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -91,12 +91,12 @@ class TestPixelClassificationHeadless(object):
     @classmethod
     def create_random_data(cls):
         cls.SAMPLE_DATA = os.path.join(cls.data_dir, 'random_data.npy')
-        cls.data = numpy.random.random((1,200,200,50,1))
+        cls.data = numpy.random.random((2,200,200,5,1))
         cls.data *= 256
         numpy.save(cls.SAMPLE_DATA, cls.data.astype(numpy.uint8))
         
         cls.SAMPLE_MASK = os.path.join(cls.data_dir, 'mask.npy')
-        cls.data = numpy.ones((1,200,200,50,1))
+        cls.data = numpy.ones((2,200,200,5,1))
         numpy.save(cls.SAMPLE_MASK, cls.data.astype(numpy.uint8))
 
     @classmethod

--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -68,9 +68,9 @@ class TestPixelClassificationHeadless(object):
             cls.using_random_data = False
         else:
             cls.using_random_data = True
-            cls.create_random_tst_data()
+            cls.create_random_data()
 
-        cls.create_new_tst_project()
+        cls.create_new_project()
 
         cls.ilastik_startup = imp.load_source( 'ilastik_startup', ilastik_entry_file_path )
 
@@ -89,7 +89,7 @@ class TestPixelClassificationHeadless(object):
                 pass
 
     @classmethod
-    def create_random_tst_data(cls):
+    def create_random_data(cls):
         cls.SAMPLE_DATA = os.path.join(cls.data_dir, 'random_data.npy')
         cls.data = numpy.random.random((1,200,200,50,1))
         cls.data *= 256
@@ -100,7 +100,7 @@ class TestPixelClassificationHeadless(object):
         numpy.save(cls.SAMPLE_MASK, cls.data.astype(numpy.uint8))
 
     @classmethod
-    def create_new_tst_project(cls):
+    def create_new_project(cls):
         # Instantiate 'shell'
         shell = HeadlessShell(  )
         

--- a/tests/test_applets/pixelClassification/testPixelClassificationSerializer.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationSerializer.py
@@ -240,5 +240,5 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)
 

--- a/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraFluo-N2DH-SIM-01.py
+++ b/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraFluo-N2DH-SIM-01.py
@@ -226,4 +226,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithDivisions.py
+++ b/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithDivisions.py
@@ -236,4 +236,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithMergers.py
+++ b/tests/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithMergers.py
@@ -237,4 +237,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/thresholdMasking/testThreholdMaskingSerializer.py
+++ b/tests/test_applets/thresholdMasking/testThreholdMaskingSerializer.py
@@ -70,5 +70,5 @@ class TestThresholdMaskingSerializer(object):
 
 if __name__ == "__main__":
     import nose
-    nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE' : 1})
+    nose.main(defaultTest=__file__, env={'NOSE_NOCAPTURE' : 1})
 

--- a/tests/test_applets/thresholdTwoLevels/testOpAnisotropicGaussianSmoothing.py
+++ b/tests/test_applets/thresholdTwoLevels/testOpAnisotropicGaussianSmoothing.py
@@ -97,5 +97,5 @@ class TestOpAnisotropicGaussianSmoothing5d(unittest.TestCase):
 
 if __name__ == "__main__":
     import nose
-    nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE': 1})
+    nose.main(defaultTest=__file__, env={'NOSE_NOCAPTURE': 1})
 

--- a/tests/test_applets/thresholdTwoLevels/testOpGraphcutSegment.py
+++ b/tests/test_applets/thresholdTwoLevels/testOpGraphcutSegment.py
@@ -203,4 +203,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_applets/thresholdTwoLevels/testOpLabeledThreshold.py
+++ b/tests/test_applets/thresholdTwoLevels/testOpLabeledThreshold.py
@@ -117,5 +117,5 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)
 

--- a/tests/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
+++ b/tests/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
@@ -798,5 +798,5 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)
 

--- a/tests/test_utility/testCommandLineProcessing.py
+++ b/tests/test_utility/testCommandLineProcessing.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
     sys.argv.append("-v")
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_utility/testOperatorSubView.py
+++ b/tests/test_utility/testOperatorSubView.py
@@ -176,4 +176,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_workflows/axesOrderPreservation/testAxesOrderPreservation.py
+++ b/tests/test_workflows/axesOrderPreservation/testAxesOrderPreservation.py
@@ -718,4 +718,4 @@ if __name__ == "__main__":
     sys.argv.append("--debug")
     # Don't set the logging level to DEBUG.  Leave it alone.
     sys.argv.append("--nologcapture")
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)

--- a/tests/test_workflows/dataConversion/testDataConversionWorkflow.py
+++ b/tests/test_workflows/dataConversion/testDataConversionWorkflow.py
@@ -154,4 +154,4 @@ if __name__ == "__main__":
     import nose
     sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
     sys.argv.append("--nologcapture")  # Don't set the logging level to DEBUG.  Leave it alone.
-    nose.run(defaultTest=__file__)
+    nose.main(defaultTest=__file__)


### PR DESCRIPTION
This is a bit of a bummer:

`tests/test_applets/pixelClassification/testPixelClassificationHeadless.py` has been failing silently for a while now, but it went unnoticed, because of the way the test has been invoked. This commit makes sure that a test failure is reflected in the return value.

Summary:

basically just changed `nose.run` to `nose.main`. The only difference between those functions is that `nose.run` returns `True` if all tests pass and `False` if tests fail. One would have to handle the return value explicitly. `nose.main` will exit after test execution with a proper return value indicating successful test runs with `0` and failures with `1`

About the failing test:

@FynnBe one of your commits (8080c81c6a99122f6754aa8b0548d1554d80fc45) brought that failure to light (did not cause it as far as I can tell, but now some old code runs, that hasn't run before). Would you mind looking into that?