### PR TITLE
[on hold] Enhancements to command line help

### DIFF
--- a/ilastik/utility/commandLineProcessing.py
+++ b/ilastik/utility/commandLineProcessing.py
@@ -98,3 +98,16 @@ if __name__ == '__main__':
 
     # this will raise
     args = parser.parse_args(["(0, 1"])
+
+
+def format_workflow_usage(workflow_class):
+    """Returns usage format string for specific workflow
+
+    In order to suppress the auto-magic of argparse
+    """
+    # TODO: do this properly, there seems to be a lot of fuss around workflow
+    # names in the code. See Workflow.getWorkflowName, workflow.getAvailableWorkflows ...
+    workflow_name = workflow_class.workflowName
+
+    usage = f"ilastik.py ... [{workflow_name}-options]"
+    return usage

--- a/ilastik/workflow.py
+++ b/ilastik/workflow.py
@@ -131,6 +131,16 @@ class Workflow( Operator ):
     def postprocessClusterSubResult(self, roi, result, blockwise_fileset):
         pass
 
+    @classmethod
+    def getWorkflowCmdlineParser(cls):
+        """Return workflow comandline Argparser
+
+        If the workflow consumes command line args, provide the parser here, in
+        your subclass.
+        This enables displaying the command line help for individual workflows.
+        """
+        return None
+
     ##################
     # Public methods #
     ##################

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -30,6 +30,7 @@ import numpy
 import h5py
 
 from ilastik.workflow import Workflow
+from ilastik.utility.commandLineProcessing import format_workflow_usage
 from ilastik.applets.dataSelection import DataSelectionApplet, DatasetInfo
 from ilastik.applets.featureSelection import FeatureSelectionApplet
 from ilastik.applets.pixelClassification import PixelClassificationApplet
@@ -72,6 +73,23 @@ class ObjectClassificationWorkflow(Workflow):
     workflowName = "Object Classification Workflow Base"
     defaultAppletIndex = 0 # show DataSelection by default
 
+    @classmethod
+    def getWorkflowCmdlineParser(cls):
+        usage = format_workflow_usage(cls)
+        parser = argparse.ArgumentParser(usage=usage)
+        parser.add_argument(
+            '--fillmissing',
+            help="use 'fill missing' applet with chosen detection method",
+            choices=['classic', 'svm', 'none'],
+            default='none')
+        parser.add_argument(
+            '--nobatch',
+            help="do not append batch applets",
+            action='store_true',
+            default=False)
+
+        return parser
+
     def __init__(self, shell, headless,
                  workflow_cmdline_args,
                  project_creation_args,
@@ -84,10 +102,7 @@ class ObjectClassificationWorkflow(Workflow):
         self.stored_object_classifier = None
 
         # Parse workflow-specific command-line args
-        parser = argparse.ArgumentParser()
-        parser.add_argument('--fillmissing', help="use 'fill missing' applet with chosen detection method", choices=['classic', 'svm', 'none'], default='none')
-        parser.add_argument('--nobatch', help="do not append batch applets", action='store_true', default=False)
-
+        parser = self.getWorkflowCmdlineParser()
         parsed_creation_args, unused_args = parser.parse_known_args(project_creation_args)
 
         self.fillMissing = parsed_creation_args.fillmissing

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -54,14 +54,22 @@ parser.add_argument('--fullscreen', help='Show Window in fullscreen mode.',
                     action='store_true', default=False)
 
 parser.add_argument(
-    '--start_recording', help='Open the recorder controls and immediately '
-    'start recording', action='store_true', default=False)
-parser.add_argument('--playback_script',
-                    help='An event recording to play back after the main '
-                    'window has opened.', required=False)
-parser.add_argument('--playback_speed',
-                    help='Speed to play the playback script.', default=1.0,
-                    type=float)
+    '--start_recording',
+    # help='Open the recorder controls and immediately start recording',
+    help=argparse.SUPPRESS,
+    action='store_true',
+    default=False)
+parser.add_argument(
+    '--playback_script',
+    # help='An event recording to play back after the main window has opened.',
+    help=argparse.SUPPRESS,
+    required=False)
+parser.add_argument(
+    '--playback_speed',
+    # help='Speed to play the playback script.',
+    help=argparse.SUPPRESS,
+    default=1.0,
+    type=float)
 parser.add_argument(
     '--exit_on_failure',
     help='Immediately call exit(1) if an unhandled exception occurs.',


### PR DESCRIPTION
This one is primarily for discussion and is motivated by #1507 

All workflows define their own parser for workflow specific arguments. Right now we cannot really show this information from the command line. At the moment, the user needs to read our docs (which might be outdated), or read the source code in order to find out about these options. Wouldn't it be nice to write something like `ilastik.py --extended_help` and get command line flags of all available workflows?

This is an incomplete implementation in order to have something to discuss. I didn't go to subparsers/subcommands as this is not really what we are doing with the workflow-specific args. Also the workflow might be implicitly given by the project file.

**Some implementation details**:
* The workflow base-class has now a classemethod `getWorkflowCmdParser` that generates the parser.
* In the specific workflows, the parser creation needs to be moved there, see `PixelClassificationWorkflow` and `ObjectClassificationWorkflow` as an example.

**User Interface**:
* `python ilastik.py --extended_help` : will show all available workflow help messages (all that have been altered so far)
* `python ilastik.py --extended_help --workflow <WORKFLOW_NAME>` will show the message only for the specified workflow

I would appreciate opinions/suggestions before I further proceed with this one



** example output:**

```
$: python ilastik.py --extended_help
usage: ilastik.py [-h] [--headless] [--project PROJECT] [--readonly READONLY]
                  [--new_project NEW_PROJECT] [--workflow WORKFLOW]
                  [--clean_paths] [--redirect_output REDIRECT_OUTPUT]
                  [--debug] [--logfile LOGFILE] [--process_name PROCESS_NAME]
                  [--configfile CONFIGFILE] [--fullscreen] [--start_recording]
                  [--playback_script PLAYBACK_SCRIPT]
                  [--playback_speed PLAYBACK_SPEED] [--exit_on_failure]
                  [--exit_on_success] [--hbp] [--extended_help]

start an ilastik workflow

optional arguments:
  -h, --help            show this help message and exit
  --headless            Don't start the ilastik gui.
  --project PROJECT     A project file to open on startup.
  --readonly READONLY   Open all projects in read-only mode, to ensure you
                        don't accidentally make changes.
  --new_project NEW_PROJECT
                        Create a new project with the specified name. Must
                        also specify --workflow.
  --workflow WORKFLOW   When used with --new_project, specifies the workflow
                        to use. When used with --extended_help, workflow-
                        specific options will be shown.
  --clean_paths         Remove ilastik-unrelated directories from PATH and
                        PYTHONPATH.
  --redirect_output REDIRECT_OUTPUT
                        A filepath to redirect stdout to
  --debug               Start ilastik in debug mode.
  --logfile LOGFILE     A filepath to dump all log messages to.
  --process_name PROCESS_NAME
                        A process name (used for logging purposes).
  --configfile CONFIGFILE
                        A custom path to a user config file for expert ilastik
                        settings.
  --fullscreen          Show Window in fullscreen mode.
  --start_recording     Open the recorder controls and immediately start
                        recording
  --playback_script PLAYBACK_SCRIPT
                        An event recording to play back after the main window
                        has opened.
  --playback_speed PLAYBACK_SPEED
                        Speed to play the playback script.
  --exit_on_failure     Immediately call exit(1) if an unhandled exception
                        occurs.
  --exit_on_success     Quit the app when the playback is complete.
  --hbp                 Enable HBP-specific functionality.
  --extended_help

## Workflow-specific command line options


### Pixel Classification specific command line options:

usage: ilastik.py ... [Pixel Classification-options]

optional arguments:
  -h, --help            show this help message and exit
  --print-labels-by-slice
                        Print the number of labels for each Z-slice of each
                        image.
  --label-search-value LABEL_SEARCH_VALUE
                        If provided, only this value is considered when using
                        --print-labels-by-slice
  --generate-random-labels
                        Add random labels to the project file.
  --random-label-value RANDOM_LABEL_VALUE
                        The label value to use injecting random labels
  --random-label-count RANDOM_LABEL_COUNT
                        The number of random labels to inject via --generate-
                        random-labels
  --retrain             Re-train the classifier based on labels stored in
                        project file, and re-save.
  --tree-count TREE_COUNT
                        Number of trees for Vigra RF classifier.
  --variable-importance-path VARIABLE_IMPORTANCE_PATH
                        Location of variable-importance table.
  --label-proportion LABEL_PROPORTION
                        Proportion of feature-pixels used to train the
                        classifier.


### IIBoost Synapse Detection specific command line options:

usage: ilastik.py ... [IIBoost Synapse Detection-options]

optional arguments:
  -h, --help            show this help message and exit
  --print-labels-by-slice
                        Print the number of labels for each Z-slice of each
                        image.
  --label-search-value LABEL_SEARCH_VALUE
                        If provided, only this value is considered when using
                        --print-labels-by-slice
  --generate-random-labels
                        Add random labels to the project file.
  --random-label-value RANDOM_LABEL_VALUE
                        The label value to use injecting random labels
  --random-label-count RANDOM_LABEL_COUNT
                        The number of random labels to inject via --generate-
                        random-labels
  --retrain             Re-train the classifier based on labels stored in
                        project file, and re-save.
  --tree-count TREE_COUNT
                        Number of trees for Vigra RF classifier.
  --variable-importance-path VARIABLE_IMPORTANCE_PATH
                        Location of variable-importance table.
  --label-proportion LABEL_PROPORTION
                        Proportion of feature-pixels used to train the
                        classifier.


### Object Classification (from pixel classification) specific command line options:

usage: ilastik.py ... [Object Classification (from pixel classification)-options]

optional arguments:
  -h, --help            show this help message and exit
  --fillmissing {classic,svm,none}
                        use 'fill missing' applet with chosen detection method
  --nobatch             do not append batch applets


### Object Classification (from prediction image) specific command line options:

usage: ilastik.py ... [Object Classification (from prediction image)-options]

optional arguments:
  -h, --help            show this help message and exit
  --fillmissing {classic,svm,none}
                        use 'fill missing' applet with chosen detection method
  --nobatch             do not append batch applets


### Object Classification (from binary image) specific command line options:

usage: ilastik.py ... [Object Classification (from binary image)-options]

optional arguments:
  -h, --help            show this help message and exit
  --fillmissing {classic,svm,none}
                        use 'fill missing' applet with chosen detection method
  --nobatch             do not append batch applets



````
fixes #1507 