### PR TITLE
No need for raw data to run a project in headless

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -929,7 +929,6 @@ class AppletSerializer(with_metaclass(ABCMeta, object)):
         self.topGroupName = topGroupName
         self.serialSlots = maybe(slots, [])
         self.operator = operator
-        self.caresOfHeadless = False # should _deserializeFromHdf5 should be called with headless-argument?
         self._ignoreDirty = False
 
     def isDirty(self):
@@ -1053,10 +1052,7 @@ class AppletSerializer(with_metaclass(ABCMeta, object)):
                     self.progressSignal(inc)
 
                 # Call the subclass to do remaining work
-                if self.caresOfHeadless:
-                    self._deserializeFromHdf5(topGroup, groupVersion, hdf5File, projectFilePath, headless)
-                else:
-                    self._deserializeFromHdf5(topGroup, groupVersion, hdf5File, projectFilePath)
+                self._deserializeFromHdf5(topGroup, groupVersion, hdf5File, projectFilePath, headless)
             else:
                 self.initWithoutTopGroup(hdf5File, projectFilePath)
         finally:

--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -107,7 +107,7 @@ class BatchProcessingApplet(Applet):
             # Call customization hook
             self.dataExportApplet.prepare_for_entire_export()
 
-            batch_lane_index = len(self.dataSelectionApplet.topLevelOperator) - 1
+            batch_lane_index = len(self.dataSelectionApplet.topLevelOperator)
             for batch_dataset_index, role_input_datas in enumerate(datas_by_batch_index):
                 # Add a lane to the end of the workflow for batch processing
                 # (Expanding OpDataSelection by one has the effect of expanding the whole workflow.)
@@ -219,7 +219,6 @@ class BatchProcessingApplet(Applet):
 
         # Apply new settings for each role
         for role_index, data_for_role in enumerate(role_input_datas):
-            print(f">>> role_index {role_index}, data_for_role {data_for_role}")
             if not data_for_role:
                 continue
 

--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -107,7 +107,7 @@ class BatchProcessingApplet(Applet):
             # Call customization hook
             self.dataExportApplet.prepare_for_entire_export()
 
-            batch_lane_index = len(self.dataSelectionApplet.topLevelOperator)
+            batch_lane_index = len(self.dataSelectionApplet.topLevelOperator) - 1
             for batch_dataset_index, role_input_datas in enumerate(datas_by_batch_index):
                 # Add a lane to the end of the workflow for batch processing
                 # (Expanding OpDataSelection by one has the effect of expanding the whole workflow.)
@@ -219,6 +219,7 @@ class BatchProcessingApplet(Applet):
 
         # Apply new settings for each role
         for role_index, data_for_role in enumerate(role_input_datas):
+            print(f">>> role_index {role_index}, data_for_role {data_for_role}")
             if not data_for_role:
                 continue
 

--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -227,15 +227,16 @@ class BatchProcessingApplet(Applet):
                 info = data_for_role
             else:
                 # Copy the template info, but override filepath, etc.
-                default_info = DatasetInfo(data_for_role)
-                info = copy.copy(template_infos[role_index])
-                info.filePath = default_info.filePath
-                info.location = default_info.location
-                info.nickname = default_info.nickname
+                template_info = template_infos[role_index]
+                info = DatasetInfo.from_file_path(template_info, data_for_role)
 
+            # Force real data source when in headless mode.
+            # If raw data doesn't exist in headless mode, we use fake data reader
+            # (datasetInfo.realDataSource = False). Now we need to ensure that
+            # the flag is set to True for new image lanes.
+            info.realDataSource = True
             # Apply to the data selection operator
-            opDataSelectionBatchLaneView.DatasetGroup[role_index].setValue(
-                info)
+            opDataSelectionBatchLaneView.DatasetGroup[role_index].setValue(info)
 
         # Make sure nothing went wrong
         opDataExportBatchlaneView = self.dataExportApplet.topLevelOperator.getLane(

--- a/ilastik/applets/counting/countingSerializer.py
+++ b/ilastik/applets/counting/countingSerializer.py
@@ -288,7 +288,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
         """Not implemented. (See above.)"""
         pass
 
-    def deserializeFromHdf5(self, hdf5File, projectFilePath):
+    def deserializeFromHdf5(self, hdf5File, projectFilePath, headless=False):
         """If (and only if) the given hdf5Group is the root-level group of an
            ilastik 0.5 project, then the project is imported.  The pipeline is updated
            with the saved parameters and datasets."""
@@ -332,7 +332,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         assert False
 
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         # This deserializer is a special-case.
         # It doesn't make use of the serializer base class, which makes assumptions about the file structure.
         # Instead, if overrides the public serialize/deserialize functions directly

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -451,7 +451,7 @@ class DataSelectionSerializer( AppletSerializer ):
             filePath = pathData.externalPath
             if not os.path.exists(filePath):
                 if headless:
-                    if self._shouldRetrain():
+                    if self._shouldRetrain:
                         raise RuntimeError(
                             "Retrain was passed in headless mode, "
                             "but could not find data at " + filePath)
@@ -521,6 +521,7 @@ class DataSelectionSerializer( AppletSerializer ):
             This way we can avoid invalid state due to a partially loaded project. """ 
         self.topLevelOperator.DatasetGroup.resize( 0 )
 
+    @property
     def _shouldRetrain(self):
         """
         Check if '--retrain' flag was passed via workflow command line arguments

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -360,10 +360,11 @@ class OpDataSelection(Operator):
                     # Use fake reader: allows to run the project in a headless
                     # mode without the raw data
                     opReader = OpZeroDefault(parent=self)
-                    opReader.MetaInput.meta = MetaDict(shape=datasetInfo.laneShape,
-                                             dtype=datasetInfo.laneDtype,
-                                             drange=datasetInfo.drange,
-                                             axistags=datasetInfo.axistags)
+                    opReader.MetaInput.meta = MetaDict(
+                        shape=datasetInfo.laneShape,
+                        dtype=datasetInfo.laneDtype,
+                        drange=datasetInfo.drange,
+                        axistags=datasetInfo.axistags)
                     opReader.MetaInput.setValue(numpy.zeros(datasetInfo.laneShape, dtype=datasetInfo.laneDtype))
                 providerSlot = opReader.Output
             self._opReaders.append(opReader)

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -23,11 +23,10 @@ import numpy
 import os
 import uuid
 import vigra
-import warnings
+import copy
 
 from lazyflow.graph import Operator, InputSlot, OutputSlot, OperatorWrapper
 from lazyflow.metaDict import MetaDict
-from lazyflow.utility.jsonConfig import RoiTuple
 from lazyflow.operators.ioOperators import (
     OpStreamingHdf5Reader, OpStreamingHdf5SequenceReaderS, OpInputDataReader
 )
@@ -84,6 +83,9 @@ class DatasetInfo(object):
         # Necessary in headless mode in order to recover the shape of the raw data
         self.laneShape = None
         self.laneDtype = None
+        # A flag indicating whether the dataset is backed by a real source (e.g. file)
+        # or by the fake provided (e.g. in headless mode when raw data are not necessary)
+        self.realDataSource = True
         self.subvolume_roi = None
         self.location = Location.FileSystem
         self.display_mode = 'default'  # choices: default, grayscale, rgba, random-colortable, binary-mask.
@@ -207,19 +209,6 @@ class DatasetInfo(object):
     def datasetId(self):
         return self._datasetId
 
-    DatasetInfoSchema = \
-        {
-            "_schema_name": "dataset-info",
-            "_schema_version": 0.1,
-
-            "filepath": str,
-            "drange": tuple,
-            "nickname": str,
-            "axistags": str,
-            "original_axistags": str,
-            "subvolume_roi": RoiTuple()
-        }
-
     def __str__(self):
         s = "{ "
         s += "filepath: {},\n".format(self.filePath)
@@ -252,6 +241,18 @@ class DatasetInfo(object):
             self.axistags = vigra.defaultAxistags(namespace.axistags)
         self.subvolume_roi = namespace.subvolume_roi or self.subvolume_roi
 
+    @classmethod
+    def from_file_path(cls, instance, file_path):
+        """
+        Creates a shallow copy of a given DatasetInfo instance
+        with filePath and related attributes overridden
+        """
+        default_info = cls(file_path)
+        result = copy.copy(instance)
+        result.filePath = default_info.filePath
+        result.location = default_info.location
+        result.nickname = default_info.nickname
+        return result
 
 class OpDataSelection(Operator):
     """
@@ -347,20 +348,17 @@ class OpDataSelection(Operator):
                 opReader.Input.setValue(preloaded_array)
                 providerSlot = opReader.Output
             else:
-                workflow = self.parent.parent.parent.parent
-                headless = False
-                if(hasattr(workflow, '_headless')):
-                    headless = workflow._headless
-
-                if not headless:
-                # Use a normal (filesystem) reader
+                if datasetInfo.realDataSource:
+                    # Use a normal (filesystem) reader
                     opReader = OpInputDataReader(parent=self)
                     if datasetInfo.subvolume_roi is not None:
-                        opReaderReal.SubVolumeRoi.setValue(datasetInfo.subvolume_roi)
+                        opReader.SubVolumeRoi.setValue(datasetInfo.subvolume_roi)
                     opReader.WorkingDirectory.setValue(self.WorkingDirectory.value)
                     opReader.SequenceAxis.setValue(datasetInfo.sequenceAxis)
                     opReader.FilePath.setValue(datasetInfo.filePath)
                 else:
+                    # Use fake reader: allows to run the project in a headless
+                    # mode without the raw data
                     opReader = OpZeroDefault(parent=self)
                     opReader.MetaInput.meta = MetaDict(shape=datasetInfo.laneShape,
                                              dtype=datasetInfo.laneDtype,

--- a/ilastik/applets/featureSelection/featureSelectionSerializer.py
+++ b/ilastik/applets/featureSelection/featureSelectionSerializer.py
@@ -86,7 +86,7 @@ class FeatureSelectionSerializer(AppletSerializer):
         self._dirty = False
 
     @timeLogged(logger, logging.DEBUG)
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         try:
             scales = topGroup['Scales'].value
             scales = list(map(float, scales))
@@ -162,7 +162,7 @@ class Ilastik05FeatureSelectionDeserializer(AppletSerializer):
         # This class is only for DEserialization
         pass
 
-    def deserializeFromHdf5(self, hdf5File, filePath):
+    def deserializeFromHdf5(self, hdf5File, filePath, headless=False):
         # Check the overall file version
         ilastikVersion = hdf5File["ilastikVersion"].value
 
@@ -237,7 +237,7 @@ class Ilastik05FeatureSelectionDeserializer(AppletSerializer):
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         assert False
 
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         # This deserializer is a special-case.
         # It doesn't make use of the serializer base class, which makes assumptions about the file structure.
         # Instead, if overrides the public serialize/deserialize functions directly

--- a/ilastik/applets/fillMissingSlices/fillMissingSlicesSerializer.py
+++ b/ilastik/applets/fillMissingSlices/fillMissingSlicesSerializer.py
@@ -39,7 +39,7 @@ class FillMissingSlicesSerializer(AppletSerializer):
         for s in self._operator.innerOperators:
             s.resetDirty()
 
-    def _deserializeFromHdf5(self, topGroup, version, h5file, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, version, h5file, projectFilePath, headless=False):
         svm = self._operator.OverloadDetector.setValue(
             self._getDataset(topGroup, 'SVM'))
         for s in self._operator.innerOperators:

--- a/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
@@ -53,7 +53,7 @@ class PixelClassificationSerializer(AppletSerializer):
         super(PixelClassificationSerializer, self).__init__(projectFileGroupName, slots, operator)
         
     
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         """
         Override from AppletSerializer.
         Implement any additional deserialization that wasn't already accomplished by our list of serializable slots.
@@ -133,7 +133,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
         """Not implemented. (See above.)"""
         pass
 
-    def deserializeFromHdf5(self, hdf5File, projectFilePath):
+    def deserializeFromHdf5(self, hdf5File, projectFilePath, headless=False):
         """If (and only if) the given hdf5Group is the root-level group of an
            ilastik 0.5 project, then the project is imported.  The pipeline is updated
            with the saved parameters and datasets."""
@@ -195,7 +195,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         assert False
 
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         # This deserializer is a special-case.
         # It doesn't make use of the serializer base class, which makes assumptions about the file structure.
         # Instead, if overrides the public serialize/deserialize functions directly

--- a/ilastik/applets/predictionViewer/predictionViewerSerializer.py
+++ b/ilastik/applets/predictionViewer/predictionViewerSerializer.py
@@ -30,7 +30,7 @@ class PredictionViewerSerializer(AppletSerializer):
     def serializeToHdf5(self, hdf5File, projectFilePath):
         pass
     
-    def deserializeFromHdf5(self, hdf5File, projectFilePath):
+    def deserializeFromHdf5(self, hdf5File, projectFilePath, headless=False):
         try:
             predictionGroup = hdf5File[self._predictionGroupName]
         except:

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsSerializer.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsSerializer.py
@@ -43,7 +43,7 @@ class ThresholdTwoLevelsSerializer(AppletSerializer):
 
         super(self.__class__, self).__init__(projectFileGroupName, slots, operator)
 
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         """
         Override from AppletSerializer.
         Implement any additional deserialization that wasn't already accomplished by our list of serializable slots.

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -429,7 +429,7 @@ class ProjectManager(object):
                     for serializer in aplt.dataSerializers:
                         assert serializer.base_initialized, "AppletSerializer subclasses must call AppletSerializer.__init__ upon construction."
                         serializer.ignoreDirty = True
-                                            
+
                         if serializer.caresOfHeadless:
                             serializer.deserializeFromHdf5(self.currentProjectFile, projectFilePath, self._headless)
                         else:

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -430,11 +430,8 @@ class ProjectManager(object):
                         assert serializer.base_initialized, "AppletSerializer subclasses must call AppletSerializer.__init__ upon construction."
                         serializer.ignoreDirty = True
 
-                        if serializer.caresOfHeadless:
-                            serializer.deserializeFromHdf5(self.currentProjectFile, projectFilePath, self._headless)
-                        else:
-                            serializer.deserializeFromHdf5(self.currentProjectFile, projectFilePath)
-    
+                        serializer.deserializeFromHdf5(self.currentProjectFile, projectFilePath, self._headless)
+
                         serializer.ignoreDirty = False
                 logger.debug('Deserializing applet "{}" took {} seconds'.format( aplt.name, timer.seconds() ))
             

--- a/ilastik/workflows/carving/carvingSerializer.py
+++ b/ilastik/workflows/carving/carvingSerializer.py
@@ -107,7 +107,7 @@ class CarvingSerializer( AppletSerializer ):
 
             logger.info( "saved seeds" )
         
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         obj = topGroup["objects"]
         for imageIndex, opCarving in enumerate( self._o.innerOperators ):
             mst = opCarving._mst 

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -30,8 +30,7 @@ class PreprocessingSerializer( AppletSerializer ):
     def __init__(self, preprocessingTopLevelOperator, *args, **kwargs):
         super(PreprocessingSerializer, self).__init__(*args, **kwargs)
         self._o = preprocessingTopLevelOperator 
-        self.caresOfHeadless = True
-        
+
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
         preproc = topGroup
         
@@ -62,7 +61,7 @@ class PreprocessingSerializer( AppletSerializer ):
             
             opPre._unsavedData = False
             
-    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath,headless = False):
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         
         assert "sigma" in list(topGroup.keys())
         assert "filter" in list(topGroup.keys())


### PR DESCRIPTION
Motivation:
unfortunately in order to run workflows in headless mode the raw data that the models were trained on has to be available. this has been quite uncomfortable for the users especially when the raw data has significant size (GBs) and has to be carry around in order to run tasks in headless.

Current solution:
- if we're in headless and the raw data exists the flow is the same as before
- if we're in headless and the raw data does not exists, tell the `opDataSelection` to fake the raw data and we are able to proceed with the batch
- if we're in headless, raw data does not exists and `--retrain` was passed -> we inform the user that retraining is not possible

Faking the raw data is possible, due to additional attributes to the lane metadata (`DatasetInfo`) serialized to the project file. The serialization is backward compatible, however because the 'old' project files lack the necessary metadata headless mode without raw data won't work (it obviously still work if the raw data is present, see 1st point above).

TODO:
- [x] Ensure backward compatibility
- [x] Extensive manual tests (different workflows, different dimensionality of raw data, multiple image lanes)
- [x] Write unit tests 
- [x] Write integration testes

Original issue: https://github.com/ilastik/ilastik/issues/1441