### PR TITLE
Always instantiate the CacheMemoryManager on start

### DIFF
--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -97,6 +97,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     preinit_funcs = []
     # Must be first (or at least before vigra).
     preinit_funcs.append(_import_opengm)
+    preinit_funcs.append(_instantiate_cache_manager)
 
     lazyflow_config_fn = _prepare_lazyflow_config(parsed_args)
     if lazyflow_config_fn:
@@ -287,6 +288,14 @@ def _import_opengm():
         import opengm # noqa
     except ImportError:
         pass
+
+
+def _instantiate_cache_manager():
+    """Ensure that the CacheMemoryManager thread is started during setup.
+    """
+    import lazyflow
+    from lazyflow.operators.cacheMemoryManager import CacheMemoryManager
+    CacheMemoryManager()
 
 
 def _prepare_lazyflow_config(parsed_args):

--- a/tests/test_workflows/test_all/testAllHeadless.py
+++ b/tests/test_workflows/test_all/testAllHeadless.py
@@ -120,7 +120,16 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
         shell = ilastik_main.main(
             parsed_args=parsed_args, workflow_cmdline_args=workflow_cmdline_args, init_logging=False)
+        
+        self.check_cache_manager_started()
 
         shell.closeCurrentProject()
 
         # no errors -> everything should be cool
+
+    def check_cache_manager_started(self):
+        import lazyflow
+        from lazyflow.operators.cacheMemoryManager import CacheMemoryManager
+        assert CacheMemoryManager.instance, "CacheMemoryManager was not instantiated: caches will not be purged"
+        assert CacheMemoryManager.instance.is_alive(), "CacheMemoryManager was not started: caches will not be purged"
+


### PR DESCRIPTION
Previously, the manager would only be instantiated on startup in
specific circumstances (when a refresh interval is explicitly set).
Therefore, for some headless workflows, the cache purging thread was
never started and the caches would grow uncontrollably.

Now it is always instantiated with the default interval (which can then
be changed later).