### PR TITLE
Added timeout for gui test shutdown

### DIFF
--- a/tests/helpers/shellGuiTestCaseBase.py
+++ b/tests/helpers/shellGuiTestCaseBase.py
@@ -143,7 +143,13 @@ class ShellGuiTestCaseBase(object):
         finished = threading.Event()
         cls.shell.thunkEventHandler.post(teardown_impl)
         cls.shell.thunkEventHandler.post(finished.set)
-        finished.wait()
+        # Sometimes the GUI tests halt, which is an open problem
+        # in order not to block the CI we give here a super generous timeout
+        # (usually this takes no time at all) of 10 seconds
+        finished.wait(timeout=10.0)
+        if not finished.is_set():
+            # Raise an AssertionError if timeout occurred!
+            assert False, "Timeout hit while tearing down the shell!"
 
     @classmethod
     def exec_in_shell(cls, func):


### PR DESCRIPTION
__Problem__ was that some gui tests freeze for reasons I couldn't pin down yet.

This often led to our tests on the CIs timing out and thus, blocking this
resource.

With the timeout, the tests will continue at least, and save us some time there.
This is clearly not a solution to the problem, but a viable workaround, since this problem has been here for a long time.

For reference, the problem is rooted in these lines:
https://github.com/ilastik/ilastik/blob/68481f403fa330d680b374dae5cf653628ff49a6/tests/helpers/shellGuiTestCaseBase.py#L142-L146

There, the event `finished` is sometimes never set.

__Update__: Added tiny `nose` plugin that handles `ShutdownTimeout` Exceptions during `ShellGuiTestCaseBase.teardownClass`

such a shutdown timeout will show up in the nose test report like this:

```bash
# ....
T
----------------------------------------------------------------------
Ran n tests in d.ddds

OK (TIMEOUT=1)
```

Postprocessing of the test results should be employed in order to reveal these timeouts