### PR TITLE
Fix json export of object classification labels

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -226,7 +226,7 @@ class ObjectClassificationGui(LabelingGui):
         if ilastik_config.getboolean("ilastik", "debug"):
             m.addAction("Export All Label Info").triggered.connect( self.exportLabelInfo )
             m.addAction("Import New Label Info").triggered.connect( self.importLabelInfo )
-        return [m]
+        return [m] if len(m.actions()) > 0 else []
 
     def exportLabelInfo(self):
         file_path, _filter = QFileDialog.getSaveFileName(parent=self, caption="Export Label Info as JSON", filter="*.json")

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -607,7 +607,6 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
         """
         import json
         import collections
-        from functools import partial
 
         logger.info("Exporting label information as json to: {}".format( file_path ))
 
@@ -636,8 +635,8 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
                 json_data_this_time = collections.OrderedDict()
                 bounding_boxes = collections.OrderedDict()
                 # Convert from numpy array to list (for json)
-                bounding_boxes["Coord<Minimum>"] = list(map( partial(map, int), min_coords ))
-                bounding_boxes["Coord<Maximum>"] = list(map( partial(map, int), max_coords ))
+                bounding_boxes["Coord<Minimum>"] = min_coords.tolist()
+                bounding_boxes["Coord<Maximum>"] = max_coords.tolist()
                 
                 json_data_this_time["bounding_boxes"] = bounding_boxes
                 json_data_this_time["labels"] = list(map(int, labels))


### PR DESCRIPTION
Correctly serializes labels to be encoded as JSON. Also hides the
'Export' menu entry when not in --debug mode, instead of allowing
it to show up without any sub-menu entries.

It's worth noting, though, that the ex/importing of labels still
has some issues; exporting labels, clearing and then re-importing
may not reproduce the exact same labels in many cases.