### PR TITLE
Fix pyqt5 headless import

### DIFF
--- a/ilastik/headless_dummy_modules/PyQt5/__init__.py
+++ b/ilastik/headless_dummy_modules/PyQt5/__init__.py
@@ -6,5 +6,6 @@ Applet GUI classes should never be imported at module scope: they should be impo
 To help us developers keep good hygiene when it comes to GUI imports, this module is used to override PyQt5 in headless mode.
 (See ilastik_main.py)
 """
+from traceback import print_stack
+print_stack()
 raise Exception("Developer error: When ilastik is running in headless mode, you aren't allowed to import PyQt5.")
-

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -56,11 +56,21 @@ parser.add_argument(
     '--hbp', help='Enable HBP-specific functionality.',
     action='store_true', default=False)
 
+
 def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     """
     init_logging: Skip logging config initialization by setting this to False.
                   (Useful when opening multiple projects in a Python script.)
     """
+    if parsed_args.headless:
+        # If any applet imports the GUI in headless mode, that's a mistake.
+        # To help developers catch such mistakes, we replace PyQt with a dummy
+        #  module, so we'll see import errors.
+        import ilastik
+        dummy_module_dir = os.path.join(
+            os.path.split(ilastik.__file__)[0], "headless_dummy_modules")
+        sys.path.insert(0, dummy_module_dir)
+
     this_path = os.path.dirname(__file__)
     ilastik_dir = os.path.abspath(
         os.path.join(this_path, "..%s.." % os.path.sep))
@@ -115,14 +125,6 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
 
     # Headless launch
     if parsed_args.headless:
-        # If any applet imports the GUI in headless mode, that's a mistake.
-        # To help developers catch such mistakes, we replace PyQt with a dummy
-        #  module, so we'll see import errors.
-        import ilastik
-        dummy_module_dir = os.path.join(os.path.split(ilastik.__file__)[
-                                        0], "headless_dummy_modules")
-        sys.path.insert(0, dummy_module_dir)
-
         # Run pre-init
         for f in preinit_funcs:
             f()


### PR DESCRIPTION
Fixes #1812

Moved replacing the `PyQt5` module with our dummy module to the beginning of `ilastik_main.py`.

I could pin down the offending `PyQt5` import to the following statement:

```python
    from lazyflow.utility.pathHelpers import PathComponents
```
Before, `PyQt5` was not in `sys.modules`, after, it was;

The delinquent seems to be `vigra`, which does the following in its `__init__`:

```python
    try:
        import pylab
    except Exception as e:
        pass
```

via some detours, this will import `PyQt5`.

I also added some traceback printing in order to ease tracking down causes for recurrence of this issue.

