### PR TITLE
Fixed parser argument docs

### DIFF
--- a/ilastik/applets/dataExport/dataExportApplet.py
+++ b/ilastik/applets/dataExport/dataExportApplet.py
@@ -114,20 +114,24 @@ class DataExportApplet( Applet ):
         arg_parser = starting_parser or argparse.ArgumentParser()
         arg_parser.add_argument(
             '--cutout_subregion',
-            help='Subregion to export (start,stop), e.g. [(0,0,0,0,0), (1,100,200,20,3)]',
+            help=(
+                'Subregion to export (start,stop), e.g. [(0,0,0,0,0),(1,100,200,20,3)]. '
+                'Note, that the subregion has to be specified in 5D with the axisorder '
+                '(t,c,z,y,x).'
+            ),
             required=False,
             action=ParseListFromString,
         )
 
         arg_parser.add_argument(
             '--pipeline_result_drange',
-            help='Pipeline result data range (min,max) BEFORE normalization, e.g. (0.0, 1.0)',
+            help='Pipeline result data range (min,max) BEFORE normalization, e.g. (0.0,1.0)',
             required=False,
             action=ParseListFromString,
         )
         arg_parser.add_argument(
             '--export_drange',
-            help='Exported data range (min,max) AFTER normalization, e.g. (0, 255)',
+            help='Exported data range (min,max) AFTER normalization, e.g. (0,255)',
             required=False,
             action=ParseListFromString,
         )


### PR DESCRIPTION
See https://github.com/ilastik/ilastik/issues/1422

Due to a bug in cpython (https://bugs.python.org/issue22433) the argument parser will misinterpret arguments with spaces in them, even if enclosed in quotes.

e.g. the following command-line will fail

```bash
python ilastik.py --headless --project MyProject.ilp --raw_data blah.h5 --prediction_maps blah_export.h5 --cutout_subregion "[[0,None,None,None,None],[1,None,None,None, None]]"
```

because of the space in the `--cutout_subregion` argument it is treated as a default positional.

This commit just ensures the command line argument help does not send any mixed messages.