### PR TITLE
fixed loading of multiple datasets

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -597,20 +597,18 @@ class DataSelectionGui(QWidget):
         # Resize the slot if necessary            
         if len( opTop.DatasetGroup ) < endingLane+1:
             opTop.DatasetGroup.resize( endingLane+1 )
-        
-        ret_val = False
+
         # Configure each subslot
         for laneIndex, info in zip(list(range(startingLane, endingLane+1)), infos):
             try:
                 self.topLevelOperator.DatasetGroup[laneIndex][roleIndex].setValue( info )
-                ret_val = True
             except DatasetConstraintError as ex:
                 return_val = [False]
                 # Give the user a chance to fix the problem
                 self.handleDatasetConstraintError(info, info.filePath, ex, roleIndex, laneIndex, return_val)
                 if return_val[0]:
                     # Successfully repaired graph.
-                    ret_val = True
+                    continue
                 else:
                     # Not successfully repaired.  Roll back the changes
                     opTop.DatasetGroup.resize(originalSize)
@@ -626,7 +624,7 @@ class DataSelectionGui(QWidget):
                 opTop.DatasetGroup.resize( originalSize )
                 return False
 
-        return ret_val
+        return True
 
     def _reconfigureDatasetLocations(self, roleIndex, startingLane, endingLane):
         """


### PR DESCRIPTION
A user made me aware that selecting multiple (n) datasets in dataselection applet (add new -> add separate image(s)) resulted in a single added image and (n-1) empty added lanes.
I fixed this by not returning directly when a dataset is successfully added. This is the "old", working behaviour.
Furthermore, I made sure, that each path returns the correct value.

@FynnBe , since this could potentially mess with your new filter resizing dialog thing, is there something I should test other than the following (which I have already confirmed works):

* loaded a 3D dataset (big), selcted all the filters, then added another one with `10` `z`-slices only. The dialog appears and lets me modify the selected filters appropriately.