### PR TITLE
Always reorder axes in data-selection applet

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -459,12 +459,17 @@ class OpDataSelection(Operator):
 
                 output_order = sorted(candidate_orders, key=len)[0]  # the shortest one
                 output_order = "".join(output_order)
+            else:
+                # No forced axisorder is supplied. Use original axisorder as
+                # output order: it is assumed by the export-applet, that the
+                # an OpReorderAxes operator is added in the beginning
+                output_order = "".join([x for x in providerSlot.meta.axistags.keys()])
 
-                op5 = OpReorderAxes(parent=self)
-                op5.AxisOrder.setValue(output_order)
-                op5.Input.connect(providerSlot)
-                providerSlot = op5.Output
-                self._opReaders.append(op5)
+            op5 = OpReorderAxes(parent=self)
+            op5.AxisOrder.setValue(output_order)
+            op5.Input.connect(providerSlot)
+            providerSlot = op5.Output
+            self._opReaders.append(op5)
 
             # If the channel axis is missing, add it as last axis
             if 'c' not in providerSlot.meta.axistags:

--- a/ilastik/workflows/examples/dataConversion/dataConversionWorkflow.py
+++ b/ilastik/workflows/examples/dataConversion/dataConversionWorkflow.py
@@ -18,7 +18,6 @@
 # on the ilastik web site at:
 #		   http://ilastik.org/license.html
 ###############################################################################
-import sys
 import logging
 logger = logging.getLogger(__name__)
 
@@ -30,6 +29,7 @@ from ilastik.applets.dataExport.dataExportApplet import DataExportApplet
 from ilastik.applets.batchProcessing import BatchProcessingApplet
 
 RAW_DATA_ROLE_INDEX = 0
+
 
 class DataConversionWorkflow(Workflow):
     """
@@ -64,10 +64,12 @@ class DataConversionWorkflow(Workflow):
         self._applets = []
 
         # Instantiate DataSelection applet
-        self.dataSelectionApplet = DataSelectionApplet(self, 
-                                                       "Input Data", 
-                                                       "Input Data", 
-                                                       supportIlastik05Import=True)
+        self.dataSelectionApplet = DataSelectionApplet(
+            self,
+            "Input Data",
+            "Input Data",
+            supportIlastik05Import=True,
+            forceAxisOrder=None)
 
         # Configure global DataSelection settings
         role_names = ["Input Data"]


### PR DESCRIPTION
The export applet requires the `meta.original_axistags` to be set. This is done when axes are reordered, usually, because `forceAxisTags` is set to something.
This PR enforces that the reorderAxesOperator is always added to the chain. From what I read in the code of OpDataSelection, this seems to be assumed.  