### PR TITLE
Enh silence headless mode startup

### DIFF
--- a/ilastik/headless_dummy_modules/PyQt5/__init__.py
+++ b/ilastik/headless_dummy_modules/PyQt5/__init__.py
@@ -6,6 +6,9 @@ Applet GUI classes should never be imported at module scope: they should be impo
 To help us developers keep good hygiene when it comes to GUI imports, this module is used to override PyQt5 in headless mode.
 (See ilastik_main.py)
 """
-from traceback import print_stack
-print_stack()
+# you can add this for debugging purposes. Since vigra tries to import pylab,
+# which in turn tries to import PyQt5 this will be hit in every headless run and
+# therefore produce noise that is unwanted
+# from traceback import print_stack
+# print_stack()
 raise Exception("Developer error: When ilastik is running in headless mode, you aren't allowed to import PyQt5.")

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -238,15 +238,12 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
     # Preserve pre-existing handlers
     for handler in original_root_handlers:
         logging.getLogger().addHandler(handler)
-    
+
     # Update from the user's customizations
     loggingHelpers.updateFromConfigFile()
-    
+
     # Capture warnings from the warnings module
     logging.captureWarnings(True)
-    
-    # Warnings module warnings are shown only once
-    warnings.filterwarnings("once")
 
     # Don't warn about pending deprecations (PyQt generates some of these)
     warnings.filterwarnings("ignore", category=PendingDeprecationWarning)

--- a/ilastik/shell/headless/headlessShell.py
+++ b/ilastik/shell/headless/headlessShell.py
@@ -31,14 +31,15 @@ class HeadlessShell(object):
     """
     For now, this class is just a stand-in for the GUI shell (used when running from the command line).
     """
-    
+
     def __init__(self, workflow_cmdline_args=None):
         self._workflow_cmdline_args = workflow_cmdline_args or []
         self.projectManager = None
 
     @property
     def workflow(self):
-        return self.projectManager.workflow
+        if self.projectManager is not None:
+            return self.projectManager.workflow
 
     @property
     def currentImageIndex(self):
@@ -159,9 +160,10 @@ class HeadlessShell(object):
         pass
 
     def closeCurrentProject(self):
-        self.projectManager._closeCurrentProject()
-        self.projectManager.cleanUp()
-        self.projectManager = None
+        if self.projectManager is not None:
+            self.projectManager._closeCurrentProject()
+            self.projectManager.cleanUp()
+            self.projectManager = None
 
-assert issubclass( HeadlessShell, ShellABC ), "HeadlessShell does not satisfy the generic shell interface!"
 
+assert issubclass(HeadlessShell, ShellABC), "HeadlessShell does not satisfy the generic shell interface!"

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -257,17 +257,19 @@ def _validate_arg_compatibility(parsed_args):
     if parsed_args.workflow is not None and parsed_args.new_project is None:
         sys.stderr.write(
             "The --workflow argument may only be used with the --new_project "
-            "argument.")
+            "argument. "
+            "Please invoke ilastik with --help for more information. Exiting.\n")
         sys.exit(1)
     if parsed_args.workflow is None and parsed_args.new_project is not None:
         sys.stderr.write(
             "No workflow specified.  The --new_project argument must be used "
-            "in conjunction with the --workflow argument.")
+            "in conjunction with the --workflow argument. "
+            "Please invoke ilastik with --help for more information. Exiting.\n")
         sys.exit(1)
     if parsed_args.project is not None and parsed_args.new_project is not None:
         sys.stderr.write(
             "The --project and --new_project settings cannot be used together."
-            " Choose one (or neither).")
+            " Choose one (or neither). Please invoke ilastik with --help for more information. Exiting.\n")
         sys.exit(1)
 
     if parsed_args.headless and \
@@ -275,8 +277,16 @@ def _validate_arg_compatibility(parsed_args):
             parsed_args.exit_on_failure):
         sys.stderr.write(
             "Some of the command-line options you provided are not supported "
-            "in headless mode.  Exiting.")
+            "in headless mode. Please invoke ilastik with --help for more information. Exiting.\n")
         sys.exit(1)
+
+    if parsed_args.headless and not parsed_args.project:
+        if not (parsed_args.new_project and parsed_args.workflow):
+            sys.stderr.write(
+                "You have to supply at least --project, or --new_project and workflow when invoking "
+                "ilastik in headless mode. "
+                "Please invoke ilastik with --help for more information. Exiting.\n")
+            sys.exit(1)
 
 
 def _import_opengm():


### PR DESCRIPTION
Just wanted to silence the printing of the stacktrace that was introduced by me (:-1: ) and ended up adding some extra.

Summary:
* disabled printing of stacktrace on headless startup
* make invoking headless without arguments exit gracefully
* removed those `numpy.dtype size changed` warnings that showed up starting up ilastik which fixes #1652