### PR TITLE
Remove plugin specific slots from the OpTrackingBaseDataExport

### DIFF
--- a/ilastik/applets/dataExport/dataExportApplet.py
+++ b/ilastik/applets/dataExport/dataExportApplet.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+
+import argparse
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,16 +22,15 @@ from __future__ import absolute_import
 #		   http://ilastik.org/license.html
 ###############################################################################
 import os
-import argparse
-import json
 
 import numpy
 
 from ilastik.applets.base.applet import Applet
-from .opDataExport import OpDataExport
-from .dataExportSerializer import DataExportSerializer
 from ilastik.utility import OpMultiLaneWrapper
 from ilastik.utility.commandLineProcessing import ParseListFromString
+from .dataExportSerializer import DataExportSerializer
+from .opDataExport import OpDataExport
+
 
 class DataExportApplet( Applet ):
     """

--- a/ilastik/applets/tracking/base/opTrackingBaseDataExport.py
+++ b/ilastik/applets/tracking/base/opTrackingBaseDataExport.py
@@ -30,9 +30,10 @@ class OpTrackingBaseDataExport(OpDataExport):
     SelectedPlugin = InputSlot(value=None)
     SelectedExportSource = InputSlot(value=None)
 
-    # Optional BigDataViewer file path slot required by the Fiji-MaMuT plugin only
-    # Gets populated from within `PluginExportOptionsDlg`
-    BigDataViewerFilepath = InputSlot(value=None, optional=True)
+    # Slot containing plugin specific arguments. Holds a dictionary that can
+    # be populated from the `TrackingBaseDataExportGui` or when parsing
+    # the command line in `TrackingBaseDataExportApplet`
+    AdditionalPluginArguments = InputSlot(value={}, optional=True)
 
     def __init__(self, *args, **kwargs):
         super(OpTrackingBaseDataExport, self).__init__(*args, **kwargs)

--- a/ilastik/applets/tracking/base/opTrackingBaseDataExport.py
+++ b/ilastik/applets/tracking/base/opTrackingBaseDataExport.py
@@ -27,7 +27,7 @@ class OpTrackingBaseDataExport(OpDataExport):
 
     # These slots get populated from within ``TrackingBaseDataExportGui``
     # or when parsing the command line in ``TrackingBaseDataExportApplet``
-    SelectedPlugin = InputSlot(value=None)
+    SelectedPlugin = InputSlot(optional=True)
     SelectedExportSource = InputSlot(value=None)
 
     # Slot containing plugin specific arguments. Holds a dictionary that can

--- a/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
+++ b/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
@@ -69,12 +69,13 @@ class PluginExportOptionsDlg(QDialog):
         # connect the Ok cancel buttons
         def onOkClicked():
             if self.pluginName == 'Fiji-MaMuT':
-                if self._bdvFilepathSlot.ready():
+                if self._additionalPluginArgumentsSlot.ready() and \
+                        'bdvFilepath' in self._additionalPluginArgumentsSlot.value:
                     self.accept()
                 else:
                     msg = QMessageBox()
                     msg.setIcon(QMessageBox.Information)
-                    msg.setText(f"Please provide BigDataViewer file path")
+                    msg.setText("Please provide BigDataViewer file path")
                     msg.setWindowTitle("Fiji-MaMuT export")
                     msg.setStandardButtons(QMessageBox.Ok)
                     msg.exec_()
@@ -169,7 +170,7 @@ class PluginExportOptionsDlg(QDialog):
 
     def _initBdvFileSelection(self):
         # init BigDataViewer file selection widget
-        self._bdvFilepathSlot = self._topLevelOp.BigDataViewerFilepath
+        self._additionalPluginArgumentsSlot = self._topLevelOp.AdditionalPluginArguments
         self.bdvFileSelectButton.clicked.connect(self._browseForBdvFile)
         self._updateBdvWidget()
 
@@ -194,8 +195,8 @@ class PluginExportOptionsDlg(QDialog):
             # Re-configure the slot in case we changed the extension
             self._filepathSlot.setValue(file_path)
 
-        if self._bdvFilepathSlot.ready():
-            bdv_file_path = self._bdvFilepathSlot.value
+        if self._additionalPluginArgumentsSlot.ready():
+            bdv_file_path = self._additionalPluginArgumentsSlot.value.get('bdvFilepath')
             self.bdvFilepath.setText(bdv_file_path)
 
     def _browseForFilepath(self):
@@ -213,11 +214,13 @@ class PluginExportOptionsDlg(QDialog):
         self.filepathEdit.setText( exportPath )
 
     def _browseForBdvFile(self):
-        """Browse for BigDataViewer file"""
-        if self._bdvFilepathSlot.ready():
-            starting_dir = os.path.split(self._bdvFilepathSlot.value)[0]
-        else:
-            starting_dir = self._topLevelOp.WorkingDirectory.value
+        """Browse for BigDataViewer file and add the its path to the additionalPluginArgumentsSlot"""
+        starting_dir = self._topLevelOp.WorkingDirectory.value
+        additional_args_ready = self._additionalPluginArgumentsSlot.ready()
+        if additional_args_ready:
+            bdv_file_path = self._additionalPluginArgumentsSlot.value.get('bdvFilepath')
+            if bdv_file_path is not None:
+                starting_dir = os.path.split(bdv_file_path)[0]
 
         dlg = QFileDialog(self, "BigDataViewer File Location", starting_dir, "XML files (*.xml)")
         dlg.setAcceptMode(QFileDialog.AcceptOpen)
@@ -225,7 +228,12 @@ class PluginExportOptionsDlg(QDialog):
             return
 
         bdv_file_path = dlg.selectedFiles()[0]
-        self._bdvFilepathSlot.setValue(bdv_file_path)
+        if additional_args_ready:
+            additional_args = self._additionalPluginArgumentsSlot.value
+        else:
+            additional_args = {}
+        additional_args['bdvFilepath'] = bdv_file_path
+        self._additionalPluginArgumentsSlot.setValue(additional_args)
         self.bdvFilepath.setText(bdv_file_path)
 
 #**************************************************************************

--- a/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
+++ b/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
@@ -196,8 +196,10 @@ class PluginExportOptionsDlg(QDialog):
             self._filepathSlot.setValue(file_path)
 
         if self._additionalPluginArgumentsSlot.ready():
-            bdv_file_path = self._additionalPluginArgumentsSlot.value.get('bdvFilepath')
-            self.bdvFilepath.setText(bdv_file_path)
+            # handle additional arguments on a per-plugin basis
+            if self.pluginName == 'Fiji-MaMuT':
+                bdv_file_path = self._additionalPluginArgumentsSlot.value.get('bdvFilepath')
+                self.bdvFilepath.setText(bdv_file_path)
 
     def _browseForFilepath(self):
         starting_dir = os.path.expanduser("~")

--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -151,7 +151,12 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
             if parsed_args.export_source == OpTrackingBaseDataExport.PluginOnlyName:
                 opTrackingDataExport.SelectedPlugin.setValue(parsed_args.export_plugin)
                 if parsed_args.export_plugin == 'Fiji-MaMuT':
-                    opTrackingDataExport.BigDataViewerFilepath.setValue(parsed_args.big_data_viewer_xml_file)
+                    if opTrackingDataExport.AdditionalPluginArguments.ready():
+                        additional_plugin_args = opTrackingDataExport.AdditionalPluginArguments.value
+                    else:
+                        additional_plugin_args = {}
+                    additional_plugin_args['bdvFilepath'] = parsed_args.big_data_viewer_xml_file
+                    opTrackingDataExport.AdditionalPluginArguments.setValue(additional_plugin_args)
 
                 # if a plugin was selected, the only thing we need is the export name
                 if parsed_args.output_filename_format:

--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -31,7 +31,7 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
     This a specialization of the generic data export applet that
     provides a special viewer for tracking output.
     """
-    def __init__(self, workflow, title, default_export_filename=''):
+    def __init__(self, workflow, title, is_batch=False, default_export_filename=''):
         self.export_op = None
         self._default_export_filename = default_export_filename
 
@@ -45,7 +45,7 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
         ]
         self._serializers = [DataExportSerializer(self.topLevelOperator, title, extra_serial_slots)]
 
-        super(TrackingBaseDataExportApplet, self).__init__(workflow, title)
+        super(TrackingBaseDataExportApplet, self).__init__(workflow, title, isBatch=is_batch)
 
     @property
     def dataSerializers(self):

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -159,8 +159,15 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
         if len(availableExportPlugins) > 0:
             self._includePluginOnlyOption()
 
-        super(TrackingBaseDataExportGui, self)._initAppletDrawerUic()
-        self.topLevelOperator.SelectedExportSource.setValue(self.drawer.inputSelectionCombo.currentText())
+        super()._initAppletDrawerUic()
+
+        def _handleDirty(slot, roi):
+            sourceName = slot.value
+            selectionNames = self.topLevelOperator.SelectionNames.value
+            index = selectionNames.index(sourceName)
+            self.drawer.inputSelectionCombo.setCurrentIndex(index)
+
+        self.topLevelOperator.SelectedExportSource.notifyDirty(_handleDirty)
 
         if len(availableExportPlugins) > 0:
             self.topLevelOperator.SelectedPlugin.setValue(availableExportPlugins[0])

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -613,7 +613,7 @@ class OpConservationTracking(Operator):
 
         return opRelabeledRegionFeatures
 
-    def exportPlugin(self, filename, plugin, checkOverwriteFiles=False, bdvFilepathSlot=None):
+    def exportPlugin(self, filename, plugin, checkOverwriteFiles=False, additionalPluginArgumentsSlot=None):
         with_divisions = self.Parameters.value["withDivisions"] if self.Parameters.ready() else False
         with_merger_resolution = self.Parameters.value["withMergerResolution"] if self.Parameters.ready() else False
 
@@ -664,7 +664,7 @@ class OpConservationTracking(Operator):
                              objectFeaturesSlot=object_feature_slot,
                              labelImageSlot=label_image_slot,
                              rawImageSlot=self.RawImage,
-                             bdvFilepathSlot=bdvFilepathSlot):
+                             additionalPluginArgumentsSlot=additionalPluginArgumentsSlot):
             raise RuntimeError('Exporting tracking solution with plugin failed')
         else:
             return True

--- a/ilastik/plugins.py
+++ b/ilastik/plugins.py
@@ -206,12 +206,14 @@ class TrackingExportFormatPlugin(IPlugin):
         return long_name
 
 
+# Helper class used to pass the necessary context information to the export plugin
 PluginExportContext = namedtuple('PluginExportContext',
-                                 ['objectFeaturesSlot',
-                                  'labelImageSlot',
-                                  'rawImageSlot',
-                                  'additionalPluginArgumentsSlot']
-                                 )
+                                 [
+                                     'objectFeaturesSlot',
+                                     'labelImageSlot',
+                                     'rawImageSlot',
+                                     'additionalPluginArgumentsSlot'
+                                 ])
 
 ###############
 # the manager #

--- a/ilastik/plugins.py
+++ b/ilastik/plugins.py
@@ -161,7 +161,7 @@ class TrackingExportFormatPlugin(IPlugin):
         ''' Check whether the files we want to export (when appending the base filename) are already present '''
         return False
 
-    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, labelImageSlot, rawImageSlot, bdvFilepathSlot):
+    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, labelImageSlot, rawImageSlot, additionalPluginArgumentsSlot):
         """Export the tracking solution stored in the hypotheses graph's "value" and "divisionValue"
         attributes (or the "lineageId" and "trackId" attribs). See https://github.com/chaubold/hytra for more details.
 
@@ -171,7 +171,8 @@ class TrackingExportFormatPlugin(IPlugin):
             output of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
         :param labelImageSlot (lazyflow.graph.InputSlot): labeled image slot
         :param rawImageSlot (lazyflow.graph.InputSlot): raw image slot
-        :param bdvFilepathSlot (lazyflow.graph.InputSlot): BigDataViewer file path slot
+        :param additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): slot containing a dictionary
+            with plugin specific arguments
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins.py
+++ b/ilastik/plugins.py
@@ -161,17 +161,18 @@ class TrackingExportFormatPlugin(IPlugin):
         ''' Check whether the files we want to export (when appending the base filename) are already present '''
         return False
 
-    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, labelImageSlot, rawImageSlot, additionalPluginArgumentsSlot):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """Export the tracking solution stored in the hypotheses graph's "value" and "divisionValue"
         attributes (or the "lineageId" and "trackId" attribs). See https://github.com/chaubold/hytra for more details.
 
         :param filename: string of the file where to save the result (or folder where to put the export files)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll
+        :param pluginExportContext (ilastik.plugins.PluginExportContext): instance of PluginExportContext containing data necessary for the export such as:
+            - objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll
             output of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-        :param labelImageSlot (lazyflow.graph.InputSlot): labeled image slot
-        :param rawImageSlot (lazyflow.graph.InputSlot): raw image slot
-        :param additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): slot containing a dictionary
+            - labelImageSlot (lazyflow.graph.InputSlot): labeled image slot
+            - rawImageSlot (lazyflow.graph.InputSlot): raw image slot
+            - additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): slot containing a dictionary
             with plugin specific arguments
 
         :returns: True on success, False otherwise
@@ -203,6 +204,14 @@ class TrackingExportFormatPlugin(IPlugin):
             long_name = name
 
         return long_name
+
+
+PluginExportContext = namedtuple('PluginExportContext',
+                                 ['objectFeaturesSlot',
+                                  'labelImageSlot',
+                                  'rawImageSlot',
+                                  'additionalPluginArgumentsSlot']
+                                 )
 
 ###############
 # the manager #

--- a/ilastik/plugins.py
+++ b/ilastik/plugins.py
@@ -167,13 +167,15 @@ class TrackingExportFormatPlugin(IPlugin):
 
         :param filename: string of the file where to save the result (or folder where to put the export files)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param pluginExportContext (ilastik.plugins.PluginExportContext): instance of PluginExportContext containing data necessary for the export such as:
-            - objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll
-            output of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+        :param pluginExportContext ilastik.plugins.PluginExportContext: instance of PluginExportContext containing
+            data necessary for the export such as:
+
+            - objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll output of
+                ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
             - labelImageSlot (lazyflow.graph.InputSlot): labeled image slot
             - rawImageSlot (lazyflow.graph.InputSlot): raw image slot
             - additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): slot containing a dictionary
-            with plugin specific arguments
+                with plugin specific arguments
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_contour_export.py
+++ b/ilastik/plugins_default/tracking_contour_export.py
@@ -30,7 +30,7 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
+            labelImageSlot (required here) as well as objectFeaturesSlot, rawImageSlot, additionalPluginArgumentsSlot
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_contour_export.py
+++ b/ilastik/plugins_default/tracking_contour_export.py
@@ -18,7 +18,7 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename + '.outline')
 
-    def export(self, filename, hypothesesGraph, *, labelImageSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """
         Export the contours and corresponding IDs for all objects on the video
         
@@ -29,14 +29,15 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
 
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-        :param kwargs: dict containing additional context info
+        :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
 
         :returns: True on success, False otherwise
         """
         
         contoursDict = {}
 
+        labelImageSlot = pluginExportContext.labelImageSlot
         tIndex = labelImageSlot.meta.axistags.index('t')
         tMax = labelImageSlot.meta.shape[tIndex] 
        

--- a/ilastik/plugins_default/tracking_contours_with_head_export.py
+++ b/ilastik/plugins_default/tracking_contours_with_head_export.py
@@ -31,8 +31,8 @@ class TrackingContoursBodyPartsPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-            - rawImageSlot: lazyflow.graph.InputSlot, raw image slot
+            labelImageSlot (required here), rawImageSlot (required here)
+            as well as objectFeaturesSlot, additionalPluginArgumentsSlot
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_contours_with_head_export.py
+++ b/ilastik/plugins_default/tracking_contours_with_head_export.py
@@ -20,7 +20,7 @@ class TrackingContoursBodyPartsPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename + '.contours')
 
-    def export(self, filename, hypothesesGraph, *, labelImageSlot, rawImageSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """
         Export the contours, head index, and corresponding IDs for all objects on the video.
         
@@ -30,15 +30,18 @@ class TrackingContoursBodyPartsPlugin(TrackingExportFormatPlugin):
 
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-        :param rawImageSlot: lazyflow.graph.InputSlot, raw image slot
-        :param kwargs: dict containing additional context info
+        :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
+            - rawImageSlot: lazyflow.graph.InputSlot, raw image slot
 
         :returns: True on success, False otherwise
         """
         
         headIndsDict = {}
         contoursDict = {}
+
+        labelImageSlot = pluginExportContext.labelImageSlot
+        rawImageSlot = pluginExportContext.rawImageSlot
 
         cIndex = labelImageSlot.meta.axistags.index('c')
         tIndex = labelImageSlot.meta.axistags.index('t')

--- a/ilastik/plugins_default/tracking_csv_export.py
+++ b/ilastik/plugins_default/tracking_csv_export.py
@@ -13,19 +13,19 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename + '.csv')
 
-    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """
         Export the features of all objects together with their tracking information into a table
 
         :param filename: string of the FILE where to save the resulting CSV file
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
-               of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-        :param kwargs: dict, additional contextual info
+        :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+            - objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+            of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
 
         :returns: True on success, False otherwise
         """
-        features = objectFeaturesSlot([]).wait()  # this is a dict of structure: {frame: {category: {featureNames}}}
+        features = pluginExportContext.objectFeaturesSlot([]).wait()  # this is a dict of structure: {frame: {category: {featureNames}}}
         graph = hypothesesGraph._graph
         headers = ['frame', 'labelimageId', 'trackId', 'lineageId', 'parentTrackId', 'mergerLabelId']
         formats = ['%d'] * len(headers)

--- a/ilastik/plugins_default/tracking_csv_export.py
+++ b/ilastik/plugins_default/tracking_csv_export.py
@@ -20,8 +20,7 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FILE where to save the resulting CSV file
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
-            of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+            objectFeaturesSlot (required here) as well as labelImageSlot, rawImageSlot, additionalPluginArgumentsSlot
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -16,14 +16,14 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename)
 
-    def export(self, filename, hypothesesGraph, *, labelImageSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """
         Export the tracking model and result
 
         :param filename: string of the FOLDER where to save the result (will be filled with a res_track.txt and segmentation masks for each frame)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-        :param kwargs: dict, additional contextual info
+        :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
 
         :returns: True on success, False otherwise
         """
@@ -73,7 +73,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         # load images, relabel, and export relabeled result
         logger.debug("Saving relabeled images")
 
-        labelImage = labelImageSlot([]).wait()
+        labelImage = pluginExportContext.labelImageSlot([]).wait()
         labelImage = np.swapaxes(labelImage, 1, 3) # do we need that?
         for timeframe in range(labelImage.shape[0]):
             labelFrame = labelImage[timeframe, ...]

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -23,7 +23,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FOLDER where to save the result (will be filled with a res_track.txt and segmentation masks for each frame)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
+            labelImageSlot (required here) as well as objectFeaturesSlot, rawImageSlot, additionalPluginArgumentsSlot
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_h5_event_export.py
+++ b/ilastik/plugins_default/tracking_h5_event_export.py
@@ -91,18 +91,19 @@ else:
             ''' Check whether the files we want to export are already present '''
             return os.path.exists(filename)
     
-        def export(self, filename, hypothesesGraph, *, labelImageSlot, **kwargs):
+        def export(self, filename, hypothesesGraph, pluginExportContext):
             """Export the tracking solution stored in the hypotheses graph as a sequence of H5 files,
             one per frame, containing the label image of that frame and which objects were part
             of a move or a division.
     
             :param filename: string of the FOLDER where to save the result
             :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-            :param labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-            :param kwargs: dict, additional contextual info
+            :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+                - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
 
             :returns: True on success, False otherwise
             """
+            labelImageSlot = pluginExportContext.labelImageSlot
             traxelIdPerTimestepToUniqueIdMap, uuidToTraxelMap = hypothesesGraph.getMappingsBetweenUUIDsAndTraxels()
             timesteps = [t for t in traxelIdPerTimestepToUniqueIdMap.keys()]
     

--- a/ilastik/plugins_default/tracking_h5_event_export.py
+++ b/ilastik/plugins_default/tracking_h5_event_export.py
@@ -99,7 +99,7 @@ else:
             :param filename: string of the FOLDER where to save the result
             :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
             :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-                - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
+                labelImageSlot (required here) as well as objectFeaturesSlot, rawImageSlot, additionalPluginArgumentsSlot
 
             :returns: True on success, False otherwise
             """

--- a/ilastik/plugins_default/tracking_json_export.py
+++ b/ilastik/plugins_default/tracking_json_export.py
@@ -26,7 +26,7 @@ else:
 
             :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
             :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-            :param pluginExportContext: additional contextual info
+            :param pluginExportContext: additional contextual info (here to adhere to the interface)
 
             :returns: True on success, False otherwise
             """

--- a/ilastik/plugins_default/tracking_json_export.py
+++ b/ilastik/plugins_default/tracking_json_export.py
@@ -20,13 +20,13 @@ else:
             ''' Check whether the files we want to export are already present '''
             return os.path.exists(filename + '_graph.json') or os.path.exists(filename + '_result.json')
 
-        def export(self, filename, hypothesesGraph, **kwargs):
+        def export(self, filename, hypothesesGraph, pluginExportContext):
             """
             Export the tracking model and result
 
             :param filename: string of the FILE where to save the result (will be appended with _graph.json and _result.json)
             :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-            :param kwargs: dict, additional contextual info
+            :param pluginExportContext: additional contextual info
 
             :returns: True on success, False otherwise
             """

--- a/ilastik/plugins_default/tracking_mamut_export.py
+++ b/ilastik/plugins_default/tracking_mamut_export.py
@@ -38,7 +38,7 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename + '_mamut.xml') or os.path.exists(filename + '_bdv.xml') or os.path.exists(filename + '_raw.h5')
 
-    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, bdvFilepathSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, additionalPluginArgumentsSlot, **kwargs):
         """Export the tracking solution stored in the hypotheses graph to MaMuT XML file.
         Creates an _mamut.xml file that contains the tracks for visualization and proof-reading in MaMuT.
 
@@ -46,7 +46,8 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll
             output of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-        :param bdvFilepathSlot (lazyflow.graph.InputSlot): BigDataViewer file path slot
+        :param additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): additional arguments passed to the plugin
+            in this it provides BigDataViewer file path
         :param kwargs: dict containing additional context info
 
         :returns: True on success, False otherwise
@@ -146,7 +147,9 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
                 featureDict['LabelimageId'] = label
                 builder.addSpot(frame, 'track-{}'.format(trackId), graph.node[node]['id'], xpos, ypos, zpos, radius, featureDict)
 
-        bigDataViewerFile = bdvFilepathSlot.value
+        additional_plugin_args = additionalPluginArgumentsSlot.value
+        assert 'bdvFilepath' in additional_plugin_args, "'bdvFilepath' must be present in 'additionalPluginArgumentsSlot'"
+        bigDataViewerFile = additional_plugin_args['bdvFilepath']
         builder.setBigDataViewerImagePath(os.path.dirname(bigDataViewerFile), os.path.basename(bigDataViewerFile))
         builder.writeToFile(filename + '_mamut.xml')
 

--- a/ilastik/plugins_default/tracking_mamut_export.py
+++ b/ilastik/plugins_default/tracking_mamut_export.py
@@ -45,10 +45,8 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FILE where to save the result (*_mamut.xml file)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - objectFeaturesSlot (lazyflow.graph.InputSlot): connected to the RegionFeaturesAll
-            output of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-            - additionalPluginArgumentsSlot (lazyflow.graph.InputSlot): additional arguments passed to the plugin
-            in this it provides BigDataViewer file path
+            objectFeaturesSlot (required here), additionalPluginArgumentsSlot (required here)
+            as well as rawImageSlot, labelImageSlot
 
         :returns: True on success, False otherwise
         """

--- a/ilastik/plugins_default/tracking_mwt_export.py
+++ b/ilastik/plugins_default/tracking_mwt_export.py
@@ -20,28 +20,29 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
         ''' Check whether the files we want to export are already present '''
         return os.path.exists(filename + '.outline')
 
-    def export(self, filename, hypothesesGraph, *, objectFeaturesSlot, labelImageSlot, **kwargs):
+    def export(self, filename, hypothesesGraph, pluginExportContext):
         """
         Export the Multi-Worm-Tracker .summary and .blobs files.
 
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
-        :param objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
-               of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-        :param labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-        :param kwargs: dict, additional contextual info
+        :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
+            - objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
+            of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
+            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
 
         :returns: True on success, False otherwise
         """
         # Get object features
-        features = objectFeaturesSlot([]).wait()
+        features = pluginExportContext.objectFeaturesSlot([]).wait()
         
         contoursDict = {}
         
         summaryDict = {}
-        
+
+        labelImageSlot = pluginExportContext.labelImageSlot
         tIndex = labelImageSlot.meta.axistags.index('t')
-        tMax = labelImageSlot.meta.shape[tIndex] 
+        tMax = labelImageSlot.meta.shape[tIndex]
        
         # Method to compute contours for single frame (called in parallel by a request parallel)
         def compute_dicts_for_frame(tIndex, t, labelImageSlot, hypothesesGraph, contoursDict): 

--- a/ilastik/plugins_default/tracking_mwt_export.py
+++ b/ilastik/plugins_default/tracking_mwt_export.py
@@ -27,10 +27,9 @@ class TrackingContourExportFormatPlugin(TrackingExportFormatPlugin):
         :param filename: string of the FILE where to save the result (different .xml files were)
         :param hypothesesGraph: hytra.core.hypothesesgraph.HypothesesGraph filled with a solution
         :param pluginExportContext: instance of ilastik.plugins.PluginExportContext containing:
-            - objectFeaturesSlot: lazyflow.graph.InputSlot, connected to the RegionFeaturesAll output
-            of ilastik.applets.trackingFeatureExtraction.opTrackingFeatureExtraction.OpTrackingFeatureExtraction
-            - labelImageSlot: lazyflow.graph.InputSlot, labeled image slot
-
+            objectFeaturesSlot (required here),  labelImageSlot (required here)
+            as well as  rawImageSlot, additionalPluginArgumentsSlot
+            
         :returns: True on success, False otherwise
         """
         # Get object features

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -369,7 +369,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
         if self.dataExportApplet.topLevelOperator.SelectedExportSource.value == OpTrackingBaseDataExport.PluginOnlyName:
             logger.info("Export source plugin selected!")
             selectedPlugin = self.dataExportApplet.topLevelOperator.SelectedPlugin.value
-            bdvFilepathSlot = self.dataExportApplet.topLevelOperator.BigDataViewerFilepath
+            additionalPluginArgumentsSlot = self.dataExportApplet.topLevelOperator.AdditionalPluginArguments
 
             exportPluginInfo = pluginManager.getPluginByName(selectedPlugin, category="TrackingExportFormats")
             if exportPluginInfo is None:
@@ -393,7 +393,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
 
                 self.dataExportApplet.progressSignal(-1)
                 exportStatus = self.trackingApplet.topLevelOperator.getLane(lane_index).exportPlugin(
-                    filename, exportPlugin, checkOverwriteFiles, bdvFilepathSlot)
+                    filename, exportPlugin, checkOverwriteFiles, additionalPluginArgumentsSlot)
                 self.dataExportApplet.progressSignal(100)
 
                 if not exportStatus:

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -445,7 +445,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
         if self.dataExportTrackingApplet.topLevelOperator.SelectedExportSource.value == OpTrackingBaseDataExport.PluginOnlyName:
             logger.info("Export source plugin selected!")
             selectedPlugin = self.dataExportTrackingApplet.topLevelOperator.SelectedPlugin.value
-            bdvFilepathSlot = self.dataExportTrackingApplet.topLevelOperator.BigDataViewerFilepath
+            additionalPluginArgumentsSlot = self.dataExportTrackingApplet.topLevelOperator.AdditionalPluginArguments
 
             exportPluginInfo = pluginManager.getPluginByName(selectedPlugin, category="TrackingExportFormats")
             if exportPluginInfo is None:
@@ -469,7 +469,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
 
                 self.dataExportTrackingApplet.progressSignal(-1)
                 exportStatus = self.trackingApplet.topLevelOperator.getLane(lane_index).exportPlugin(
-                    filename, exportPlugin, checkOverwriteFiles, bdvFilepathSlot)
+                    filename, exportPlugin, checkOverwriteFiles, additionalPluginArgumentsSlot)
                 self.dataExportTrackingApplet.progressSignal(100)
 
                 if not exportStatus:

--- a/tests/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
+++ b/tests/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
@@ -1,0 +1,47 @@
+import os
+
+import h5py
+from lazyflow.graph import Graph
+from lazyflow.operator import Operator
+
+import ilastik
+from ilastik.applets.tracking.base.trackingBaseDataExportApplet import TrackingBaseDataExportApplet
+
+
+class OpFake(Operator):
+    def __init__(self, *args, **kwargs):
+        super(OpFake, self).__init__(*args, **kwargs)
+
+
+class TestTrackingBaseDataExportAppletSerialization(object):
+    ilastik_tests_file_path = os.path.join(os.path.split(os.path.realpath(ilastik.__file__))[0], "../tests/")
+    TEST_PROJECT_FILE = os.path.join(ilastik_tests_file_path, 'test_tracking_project.ilp')
+
+    def tearDown(self):
+        os.remove(self.TEST_PROJECT_FILE)
+
+    def testAppletSerialization(self):
+        g = Graph()
+        op = OpFake(graph=g)
+        dataExportApplet = TrackingBaseDataExportApplet(op, "Tracking Result Export")
+        dataExportSerializer = dataExportApplet.dataSerializers[0]
+
+        with h5py.File(self.TEST_PROJECT_FILE) as testProject:
+            opTrackingBaseDataExport = dataExportApplet.topLevelOperator
+            opTrackingBaseDataExport.SelectedPlugin.setValue('Fiji-MaMuT')
+            opTrackingBaseDataExport.SelectedExportSource.setValue('Plugin')
+            opTrackingBaseDataExport.AdditionalPluginArguments.setValue({'bdvFilePath': '/tmp/bdv.xml'})
+
+            dataExportSerializer.serializeToHdf5(testProject, self.TEST_PROJECT_FILE)
+
+        # check serialized values
+        with h5py.File(self.TEST_PROJECT_FILE) as testProject:
+            assert testProject["Tracking Result Export/SelectedPlugin"].value.decode() == 'Fiji-MaMuT'
+            assert testProject["Tracking Result Export/SelectedExportSource"].value.decode() == 'Plugin'
+            assert testProject["Tracking Result Export/AdditionalPluginArguments/bdvFilePath"].value.decode() == '/tmp/bdv.xml'
+
+
+if __name__ == "__main__":
+    import nose
+
+    nose.main(defaultTest=__file__)


### PR DESCRIPTION
As suggested by @akreshuk we should avoid adding plugin specific state to the `OpTrackingBaseDataExport`. This PR replaces Fiji-MaMuT specific `BigDataViewerFilepath` slots with a more generic `AdditionalPluginArguments` holding a dictionary with additional context information that can be used by the plugins, e.g. user input.

Additional changes:
* Add missing serialization to `TrackingBaseDataExportApplet`
* Refactor `TrackingExportFormatPlugin.export` interface to be consistent among its implementations and got rid of the `kwargs`

