### PR TITLE
Fixes axes reordering for data that has no channel axis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ jobs:
     - restore_cache:
         keys:
         # This branch if available
-        - v1.31b3rc0-dep-{{ .Branch }}-
+        - v1.32b3rc0-dep-{{ .Branch }}-
         # Default branch if not
-        - v1.31b3rc0-dep-master-
+        - v1.32b3rc0-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.31b3rc0-dep-
+        - v1.32b3rc0-dep-
     - run: |
         if [[ ! -d ${CONDA_ROOT} ]]; then
             echo "Installing Miniconda...";
@@ -40,9 +40,9 @@ jobs:
         fi
     - run: |
         if [ ! -d ${TEST_ENV_PREFIX} ]; then
-            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge python=3.6 numpy=1.12 ilastik-dependencies-no-solvers;
+            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
         else
-            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge python=3.6 numpy=1.12 ilastik-dependencies-no-solvers;
+            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
         fi
     - run: rm -rf ${TEST_ENV_PREFIX}/ilastik-meta
     - run: git clone http://github.com/ilastik/ilastik-meta ${TEST_ENV_PREFIX}/ilastik-meta
@@ -53,7 +53,7 @@ jobs:
     - run: ln -s `pwd` ${TEST_ENV_PREFIX}/ilastik-meta/ilastik
     # Save dependency cache
     - save_cache:
-        key: v1.31b3rc0-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.32b3rc0-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /home/ubuntu/miniconda
     # Test

--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -684,9 +684,9 @@ class DataSelectionGui(QWidget):
             accepted = True
             while isinstance(ex, DatasetConstraintError) and accepted:
                 msg = (
-                    f"Can't use default properties for dataset:\n\n{filename}\n\nbecause it violates a constraint of "
+                    f"Can't use given properties for dataset:\n\n{filename}\n\nbecause it violates a constraint of "
                     f"the {ex.appletName} component.\n\n{ex.message}\n\nIf possible, fix this problem by adjusting "
-                    f"the applet settings and or the dataset properties in the next window(s). Hit 'cancel' to abort.")
+                    f"the applet settings and or the dataset properties in the next window(s).")
                 QMessageBox.warning(self, "Dataset Needs Correction", msg)
                 for dlg in ex.fixing_dialogs:
                     dlg()

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -454,7 +454,7 @@ class DatasetInfoEditorWidget(QDialog):
         # check if channel was added and not present in original:
         axistags = firstOp._NonTransposedImage.meta.getOriginalAxisKeys()
 
-        if 'c' not in axistags:
+        if 'c' not in axistags and len(newAxisOrder) == numaxes + 1:
             newAxisOrder = newAxisOrder.replace('c', '')
 
         try:

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -442,17 +442,12 @@ class DatasetInfoEditorWidget(QDialog):
         newAxisOrder = str(self.axesEdit.text())
         # Check for errors
         firstOp = list(self.tempOps.values())[0]
-        shape = firstOp._NonTransposedImage.meta.shape
-        original_shape = firstOp._NonTransposedImage.meta.original_shape
-        if original_shape is not None:
-            numaxes = len(original_shape)
-        else:
-            numaxes = len(shape)
 
         # This portion was added in order to handle the OpDataSelection adding
         # a channel axis when encountering data without one.
         # check if channel was added and not present in original:
         axistags = firstOp._NonTransposedImage.meta.getOriginalAxisKeys()
+        numaxes = len(axistags)
 
         if 'c' not in axistags and len(newAxisOrder) == numaxes + 1:
             newAxisOrder = newAxisOrder.replace('c', '')

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -452,9 +452,7 @@ class DatasetInfoEditorWidget(QDialog):
         # This portion was added in order to handle the OpDataSelection adding
         # a channel axis when encountering data without one.
         # check if channel was added and not present in original:
-        axistags = firstOp._NonTransposedImage.meta.original_axistags
-        if axistags is None:
-            axistags = firstOp._NonTransposedImage.meta.axistags
+        axistags = firstOp._NonTransposedImage.meta.getOriginalAxisKeys()
 
         if 'c' not in axistags:
             newAxisOrder = newAxisOrder.replace('c', '')

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -442,12 +442,22 @@ class DatasetInfoEditorWidget(QDialog):
         newAxisOrder = str(self.axesEdit.text())
         # Check for errors
         firstOp = list(self.tempOps.values())[0]
-        shape = firstOp.Image.meta.shape
-        original_shape = firstOp.Image.meta.original_shape
+        shape = firstOp._NonTransposedImage.meta.shape
+        original_shape = firstOp._NonTransposedImage.meta.original_shape
         if original_shape is not None:
             numaxes = len(original_shape)
         else:
             numaxes = len(shape)
+
+        # This portion was added in order to handle the OpDataSelection adding
+        # a channel axis when encountering data without one.
+        # check if channel was added and not present in original:
+        axistags = firstOp._NonTransposedImage.meta.original_axistags
+        if axistags is None:
+            axistags = firstOp._NonTransposedImage.meta.axistags
+
+        if 'c' not in axistags:
+            newAxisOrder = newAxisOrder.replace('c', '')
 
         try:
             # Remove the event filter while this function executes because we don't 

--- a/ilastik/applets/featureSelection/featureSelectionGui.py
+++ b/ilastik/applets/featureSelection/featureSelectionGui.py
@@ -299,11 +299,15 @@ class FeatureSelectionGui(LayerViewerGui):
         for slot in self.parentApplet.topLevelOperator.FeatureListFilename:
             slot.disconnect()
 
-        # Slots need to be ready (they also should, as they have default values)
+        # The first time we open feature selection, the minimal set of features should be set. Afterwards, if the
+        # data input is changed, the feature selection dialog should appear, if adjustments are necessary
+        if not self.topLevelOperatorView.SelectionMatrix.ready():
+            self.topLevelOperatorView.SelectionMatrix.setValue(self.topLevelOperatorView.MinimalFeatures)
+
+        # Other slots need to be ready (they also should, as they have default values)
         assert self.topLevelOperatorView.FeatureIds.ready()
         assert self.topLevelOperatorView.Scales.ready()
         assert self.topLevelOperatorView.ComputeIn2d.ready(), self.topLevelOperatorView.ComputeIn2d.value
-        assert self.topLevelOperatorView.SelectionMatrix.ready()
 
         # Refresh the dialog data in case it has changed since the last time we were opened
         # (e.g. if the user loaded a project from disk)

--- a/ilastik/applets/featureSelection/opFeatureSelection.py
+++ b/ilastik/applets/featureSelection/opFeatureSelection.py
@@ -68,15 +68,14 @@ class OpFeatureSelectionNoCache(Operator):
     FeatureNames = FeatureNames
 
     MinimalFeatures = numpy.zeros((len(FeatureNames), len(defaultScales)), dtype=bool)
-    MinimalFeatures[0, 0] = True
 
     # Multiple input images
     InputImage = InputSlot()
 
     # The following input slots are applied uniformly to all input images
+    SelectionMatrix = InputSlot()  # A matrix of bools indicating which features to output
     FeatureIds = InputSlot(value=getFeatureIdOrder())   # The list of features to compute
     Scales = InputSlot(value=defaultScales)             # The list of scales to use when computing features
-    SelectionMatrix = InputSlot(value=MinimalFeatures)  # A matrix of bools indicating which features to output
     # A list of flags to indicate weather to use a 2d (xy) or a 3d filter for each scale in Scales
     ComputeIn2d = InputSlot(value=[])
     # The SelectionMatrix rows correspond to feature types in the order specified by the FeatureIds input.

--- a/ilastik/applets/featureSelection/opFeatureSelection.py
+++ b/ilastik/applets/featureSelection/opFeatureSelection.py
@@ -120,9 +120,7 @@ class OpFeatureSelectionNoCache(Operator):
     def setupOutputs(self):
         # drop non-channel singleton axes
         oldAxes = self.InputImage.meta.getAxisKeys()
-        # make sure channel axis is present
-        if 'c' not in oldAxes:
-            oldAxes.append('c')
+        assert 'c' in oldAxes
 
         self.opReorderOut.AxisOrder.setValue(oldAxes)
         self.opReorderLayers.AxisOrder.setValue(oldAxes)

--- a/tests/test_applets/featureSelection/testFeatureSelectionSerializer.py
+++ b/tests/test_applets/featureSelection/testFeatureSelectionSerializer.py
@@ -49,7 +49,7 @@ class TestFeatureSelectionSerializer(object):
             featureIds = operatorToSave.FeatureIds.value
 
             # All False (no features selected)
-            selectionMatrix = operatorToSave.SelectionMatrix.value.copy()
+            selectionMatrix = operatorToSave.MinimalFeatures
         
             # Change a few to True
             selectionMatrix[0,0] = True

--- a/tests/test_applets/featureSelection/testNewFeatureSelection.py
+++ b/tests/test_applets/featureSelection/testNewFeatureSelection.py
@@ -333,7 +333,7 @@ class TestCompareOpFeatureSelectionToOld():
             # make sure data is anisotropic in z
             data[z, z, 0] = 0
 
-        data = vigra.taggedView(data, 'zyx')
+        data = vigra.taggedView(data[None, ...], 'czyx')
         opFeatures.InputImage.setValue(data)
 
         res3d = opFeatures.OutputImage[:].wait()


### PR DESCRIPTION
I would recommend merging this one in favor of changing the hdf5 reader (for now). The code change is way more minimal and I also found, that the hdf5 reader is not the only one allowing for no channel axis.

fixes #1845

ToDo:

* [x] check whether this fixes #1848

checks against the `_NontransposedImage` axes (no channel added) whether a channel
has has been provided by the respective reader instance, or was later added.