### PR TITLE
Closes #1325, #1340

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -787,6 +787,19 @@ class SerialDictSlot(SerialSlot):
         except AssertionError as e:
             warnings.warn('setValue() failed. message: {}'.format(e.message))
 
+class SerialFeatureNamesSlot(SerialDictSlot):
+    """Backwards compatible serializer for DictSlot containing feature names"""
+
+    def _getValue(self, subgroup, slot):
+        """Retrieves value for Slot "slot" from the h5 subgroup "subgroup"
+
+        Global feature names used to be saved into .ilp files under a '0' key.
+        That is no longer the case, so this method peels that extra level off when
+        it is present."""
+        if list(subgroup.keys()) == ['0']:
+            subgroup = subgroup['0']
+        return super()._getValue(subgroup, slot)
+
 class SerialClassifierFactorySlot(SerialSlot):
     def __init__(self, slot, name=None):
         super( SerialClassifierFactorySlot, self ).__init__( slot, name=name )

--- a/ilastik/applets/objectExtraction/objectExtractionSerializer.py
+++ b/ilastik/applets/objectExtraction/objectExtractionSerializer.py
@@ -30,7 +30,8 @@ from lazyflow.roi import getIntersectingBlocks, TinyVector, getBlockBounds, roiT
 from lazyflow.request import Request, RequestLock, RequestPool
 
 from ilastik.applets.base.appletSerializer import AppletSerializer,\
-    deleteIfPresent, getOrCreateGroup, SerialSlot, SerialBlockSlot, SerialDictSlot
+    deleteIfPresent, getOrCreateGroup, SerialSlot, SerialBlockSlot, \
+    SerialDictSlot, SerialFeatureNamesSlot
 from ilastik.utility.commandLineProcessing import convertStringToList
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class ObjectExtractionSerializer(AppletSerializer):
                             selfdepends=False,
                             shrink_to_bb=False,
                             compression_level=1),
-            SerialDictSlot(operator.Features),
+            SerialFeatureNamesSlot(operator.Features),
             SerialObjectFeaturesSlot(operator.BlockwiseRegionFeatures,
                                      operator.RegionFeaturesCacheInput,
                                      operator.RegionFeaturesCleanBlocks,

--- a/ilastik/applets/trackingFeatureExtraction/trackingFeatureExtractionSerializer.py
+++ b/ilastik/applets/trackingFeatureExtraction/trackingFeatureExtractionSerializer.py
@@ -1,5 +1,5 @@
 from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot,\
-    deleteIfPresent, getOrCreateGroup, SerialBlockSlot, SerialDictSlot
+    deleteIfPresent, getOrCreateGroup, SerialBlockSlot, SerialDictSlot, SerialFeatureNamesSlot
 from ilastik.applets.objectExtraction.objectExtractionSerializer import ObjectExtractionSerializer,\
     SerialObjectFeaturesSlot
 
@@ -17,8 +17,8 @@ class TrackingFeatureExtractionSerializer(AppletSerializer):
                             selfdepends=False,
                             shrink_to_bb=False,
                             compression_level=1),
-            SerialDictSlot(operator.FeatureNamesVigra),
-            SerialDictSlot(operator.FeatureNamesDivision),
+            SerialFeatureNamesSlot(operator.FeatureNamesVigra),
+            SerialFeatureNamesSlot(operator.FeatureNamesDivision),
             SerialObjectFeaturesSlot(operator.BlockwiseRegionFeaturesVigra,
                                      operator.RegionFeaturesCacheInputVigra,
                                      operator.RegionFeaturesCleanBlocksVigra,


### PR DESCRIPTION
Adds the SerialFeatureNameSlot deserializer class, which can handle the
old style of serializing global feature slots, which was to have them
stored under a '0' key.