### PR TITLE
Code cleanup in "Pixel Classification: and "Object Classification"

### DIFF
--- a/ilastik/utility/__init__.py
+++ b/ilastik/utility/__init__.py
@@ -25,3 +25,4 @@ from .operatorSubView import OperatorSubView
 from .opMultiLaneWrapper import OpMultiLaneWrapper
 from .log_exception import log_exception
 from .autocleaned_tempdir import autocleaned_tempdir
+from .slot_name_enum import SlotNameEnum

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,47 +1,48 @@
 import enum
+from typing import List, Tuple
 from itertools import chain
 
 class SlotNameEnum(enum.IntEnum):
+    """A map from slot names to their indices within a multislot
+
+    Do note that the ENUM_NAMEs that you pick matter, as they determine
+    the human readable version that you get from instances of this enum:
+
+    e.g a value defined like so:
+        MY_DATA_SLOT = 123
+    will have its slotName rendered as
+        'My Data Slot'
+    """
+
     @property
-    def socketName(self):
+    def slotName(self) -> str:
+        """A 'Human Readable Slot Name' str based on its ENUM_SLOT_NAME"""
         return self.name.replace('_', ' ').title()
 
     @classmethod
-    def asNameList(cls):
-        return [item.socketName for item in cls]
+    def asNameList(cls) -> List[str]:
+        return [item.slotName for item in cls]
 
     @classmethod
-    def getFirst(cls):
+    def getFirst(cls) -> int:
         return list(cls)[0]
 
     @classmethod
-    def getLast(cls):
+    def getLast(cls) -> int:
         return list(cls)[-1]
 
     @classmethod
-    def getNext(cls):
+    def getNext(cls) -> int:
         return cls.getLast() + 1
 
     @classmethod
-    def getPairs(cls):
+    def getPairs(cls) -> List[Tuple[str, int]]:
         return [(item.name, item.value) for item in cls]
 
     @classmethod
-    def getKeys(cls):
-        return [item.name for item in cls]
+    def extendedWithEnum(cls, extra_enum: 'SlotNameEnum', unique: bool=False) -> 'SlotNameEnum':
+        """Crates a new SlotNameEnum combining the keys from cls and extra_enum"""
 
-    @classmethod
-    def extendedWithKeys(cls, new_keys, new_enum_name=None):
-        new_enum_name = new_enum_name or cls.__name__ + "Extended"
-        new_values_start = cls.getNext()
-        new_values_end = new_values_start + len(new_keys)
-
-        new_pairs = list(zip(new_keys, range(new_values_start, new_values_end)))
-        return enum.unique(SlotNameEnum(new_enum_name,
-                                        chain(cls.getPairs(), new_pairs)))
-
-    @classmethod
-    def extendedWithEnum(cls, extra_enum, unique=False):
         wrapper = enum.unique if unique else lambda x: x
         return wrapper(SlotNameEnum(extra_enum.__name__,
                                     chain(cls.getPairs(),

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,7 +1,44 @@
 import enum
+from itertools import chain
 
 class SlotNameEnum(enum.IntEnum):
+    @property
+    def socketName(self):
+        return self.name.replace('_', ' ').title()
+
     @classmethod
     def asNameList(cls):
-        return [item.name.replace('_', ' ').title() for item in cls]
+        return [item.socketName for item in cls]
+
+    @classmethod
+    def getFirst(cls):
+        return list(cls)[0]
+
+    @classmethod
+    def getLast(cls):
+        return list(cls)[-1]
+
+    @classmethod
+    def getPairs(cls):
+        return [(item.name, item.value) for item in cls]
+
+    @classmethod
+    def getKeys(cls):
+        return [item.name for item in cls]
+
+    @classmethod
+    def extendWithKeys(cls, new_enum_name, new_keys):
+        new_values_start = cls.getLast() + 1
+        new_values_end = new_values_start + len(new_keys)
+
+        new_pairs = list(zip(new_keys, range(new_values_start, new_values_end)))
+        return enum.unique(SlotNameEnum(new_enum_name,
+                                        chain(cls.getPairs(), new_pairs)))
+
+    @classmethod
+    def extendedWithEnum(cls, extra_enum, unique=False):
+        wrapper = enum.unique if unique else lambda x: x
+        return wrapper(SlotNameEnum(extra_enum.__name__,
+                                    chain(cls.getPairs(),
+                                          extra_enum.getPairs())))
 

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -19,6 +19,10 @@ class SlotNameEnum(enum.IntEnum):
         return list(cls)[-1]
 
     @classmethod
+    def getNext(cls):
+        return cls.getLast() + 1
+
+    @classmethod
     def getPairs(cls):
         return [(item.name, item.value) for item in cls]
 
@@ -27,8 +31,9 @@ class SlotNameEnum(enum.IntEnum):
         return [item.name for item in cls]
 
     @classmethod
-    def extendWithKeys(cls, new_enum_name, new_keys):
-        new_values_start = cls.getLast() + 1
+    def extendedWithKeys(cls, new_keys, new_enum_name=None):
+        new_enum_name = new_enum_name or cls.__name__ + "Extended"
+        new_values_start = cls.getNext()
         new_values_end = new_values_start + len(new_keys)
 
         new_pairs = list(zip(new_keys, range(new_values_start, new_values_end)))

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,0 +1,7 @@
+import enum
+
+class SlotNameEnum(enum.IntEnum):
+    @classmethod
+    def asNameList(cls):
+        return [item.name.replace('_', ' ').title() for item in cls]
+

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -200,11 +200,11 @@ class ObjectClassificationWorkflow(Workflow):
         exportImageArgGroup.add_argument(
             "--export_object_prediction_img", dest="export_source",
             action="store_const",
-            const=self.ExportNames.OBJECT_PREDICTIONS.socketName)
+            const=self.ExportNames.OBJECT_PREDICTIONS.slotName)
         exportImageArgGroup.add_argument(
             "--export_object_probability_img", dest="export_source",
             action="store_const",
-            const=self.ExportNames.OBJECT_PROBABILITIES.socketName)
+            const=self.ExportNames.OBJECT_PROBABILITIES.slotName)
         return parser, exportImageArgGroup
 
     @property
@@ -562,7 +562,7 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         exportImageArgGroup.add_argument(
             "--export_pixel_probability_img", dest="export_source",
             action="store_const",
-            const=self.ExportNames.PIXEL_PROBABILITIES.socketName)
+            const=self.ExportNames.PIXEL_PROBABILITIES.slotName)
         return parser, exportImageArgGroup
 
     def prepareForNewLane(self, laneIndex):

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -419,7 +419,8 @@ class ObjectClassificationWorkflow(Workflow):
         busy = False
         self._shell.enableProjectChanges( not busy )
 
-    def _inputReady(self, nRoles):
+    def _inputReady(self):
+        nRoles = len(self.InputImageRoles)
         slot = self.dataSelectionApplet.topLevelOperator.ImageGroup
         if len(slot) > 0:
             input_ready = True
@@ -659,7 +660,7 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         Overridden from Workflow base class
         Called when an applet has fired the :py:attr:`Applet.appletStateUpdateRequested`
         """
-        input_ready = self._inputReady(1)
+        input_ready = self._inputReady()
         cumulated_readyness = input_ready
 
         cumulated_readyness &= not self.batchProcessingApplet.busy # Nothing can be touched while batch mode is executing.
@@ -723,7 +724,7 @@ class ObjectClassificationWorkflowBinary(ObjectClassificationWorkflow):
         Overridden from Workflow base class
         Called when an applet has fired the :py:attr:`Applet.appletStateUpdateRequested`
         """
-        input_ready = self._inputReady(2)
+        input_ready = self._inputReady()
 
         super(ObjectClassificationWorkflowBinary, self).handleAppletStateUpdateRequested(upstream_ready=input_ready)
 
@@ -772,7 +773,7 @@ class ObjectClassificationWorkflowPrediction(ObjectClassificationWorkflow):
         Overridden from Workflow base class
         Called when an applet has fired the :py:attr:`Applet.appletStateUpdateRequested`
         """
-        input_ready = self._inputReady(2)
+        input_ready = self._inputReady()
         cumulated_readyness = input_ready
         cumulated_readyness &= not self.batchProcessingApplet.busy # Nothing can be touched while batch mode is executing.
         self._shell.setAppletEnabled(self.thresholdingApplet, cumulated_readyness)

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -56,12 +56,6 @@ from ilastik.utility import SlotNameEnum
 import logging
 logger = logging.getLogger(__name__)
 
-EXPORT_SELECTION_PREDICTIONS = 0
-EXPORT_SELECTION_PROBABILITIES = 1
-EXPORT_SELECTION_BLOCKWISE_PREDICTIONS = 2
-EXPORT_SELECTION_BLOCKWISE_PROBABILITIES = 3
-EXPORT_SELECTION_PIXEL_PROBABILITIES = 4
-
 # Constants for pointcloud generation on cluster
 CSV_FORMAT = { 'delimiter' : '\t', 'lineterminator' : '\n' }
 OUTPUT_COLUMNS = ["x_px", "y_px", "z_px", 

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -270,8 +270,8 @@ class ObjectClassificationWorkflow(Workflow):
         opObjClassification.ComputedFeatureNames.connect(opObjExtraction.Features)
 
         # Data Export connections
-        opDataExport.RawData.connect( opData.ImageGroup[0] )
-        opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[0] )
+        opDataExport.RawData.connect( opData.ImageGroup[self.InputImageRoles.RAW_DATA] )
+        opDataExport.RawDatasetInfo.connect( opData.DatasetGroup[self.InputImageRoles.RAW_DATA] )
         opDataExport.Inputs.resize(len(self.ExportNames))
         opDataExport.Inputs[self.ExportNames.OBJECT_PREDICTIONS].connect( opObjClassification.UncachedPredictionImages )
         opDataExport.Inputs[self.ExportNames.OBJECT_PROBABILITIES].connect( opObjClassification.ProbabilityChannelImage )
@@ -339,7 +339,7 @@ class ObjectClassificationWorkflow(Workflow):
         #        We should assert that the user isn't using the blockwise slot.
         settings, selected_features = self.objectClassificationApplet.topLevelOperator.get_table_export_settings()
         if settings:
-            raw_dataset_info = self.dataSelectionApplet.topLevelOperator.DatasetGroup[lane_index][0].value
+            raw_dataset_info = self.dataSelectionApplet.topLevelOperator.DatasetGroup[lane_index][self.InputImageRoles.RAW_DATA].value
             if raw_dataset_info.location == DatasetInfo.Location.FileSystem:
                 filename_suffix = raw_dataset_info.nickname
             else:

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -72,7 +72,7 @@ class ObjectClassificationWorkflow(Workflow):
     def ExportNames(self):
         @enum.unique
         class ExportNames(SlotNameEnum):
-            OBJECT_PREDICTIONS = 0,
+            OBJECT_PREDICTIONS = 0
             OBJECT_PROBABILITIES = enum.auto()
             BLOCKWISE_OBJECT_PREDICTIONS = enum.auto()
             BLOCKWISE_OBJECT_PROBABILITIES = enum.auto()

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -108,9 +108,6 @@ class PixelClassificationWorkflow(Workflow):
         self.dataSelectionApplet = self.createDataSelectionApplet()
         opDataSelection = self.dataSelectionApplet.topLevelOperator
 
-        # see role constants, above
-        opDataSelection.DatasetRoles.setValue(self.Roles.asNameList())
-
         self.featureSelectionApplet = self.createFeatureSelectionApplet()
 
         self.pcApplet = self.createPixelClassificationApplet()
@@ -161,12 +158,14 @@ class PixelClassificationWorkflow(Workflow):
         for perm in itertools.permutations('tzyx', 4):
             c_at_end.append(''.join(perm) + 'c')
 
-        return DataSelectionApplet(self,
+        appl = DataSelectionApplet(self,
                                    "Input Data",
                                    "Input Data",
                                    supportIlastik05Import=True,
                                    instructionText=data_instructions,
                                    forceAxisOrder=c_at_end)
+        appl.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
+        return appl
 
     def createFeatureSelectionApplet(self):
         """


### PR DESCRIPTION
Removes many of the magic constants used throughout the workflow code, substituting them for Enums. This should improve readability and prevent a few bugs when changing the names, order or number of data input slots as well as export slots.

Also removes much duplicated code from the object workflows and moves specific code into the correct ObjectWorkflow child class.

Finally, moves some argument verification responsibilities into ArgumentParser.

There is still much work to be done, but we have to start somewhere =)