### PR TITLE
Adapts Autocontext workflow for arbitrary dtype input

### DIFF
--- a/ilastik/applets/pixelClassification/opPixelClassification.py
+++ b/ilastik/applets/pixelClassification/opPixelClassification.py
@@ -565,8 +565,10 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
 
     def setupOutputs(self):
         input_dtype = self.InputImage.meta.dtype
-        if isinstance(input_dtype, numpy.dtype):
-            input_dtype = input_dtype.type
+
+        # When from other libraries, the dtype could also be
+        # numpy.dtype('uint8'), which would not be the same as numpy.uint8
+        assert not isinstance(input_dtype, np.dtype)
 
         if  np.dtype(input_dtype).kind in np.typecodes['AllInteger']:
             # For integer dtype scale accoring to dtype min and max to maximize

--- a/ilastik/applets/pixelClassification/opPixelClassification.py
+++ b/ilastik/applets/pixelClassification/opPixelClassification.py
@@ -570,7 +570,7 @@ class OpPredictionPipeline(OpPredictionPipelineNoCache):
         # numpy.dtype('uint8'), which would not be the same as numpy.uint8
         assert not isinstance(input_dtype, np.dtype)
 
-        if  np.dtype(input_dtype).kind in np.typecodes['AllInteger']:
+        if  np.dtype(input_dtype).char in np.typecodes['AllInteger']:
             # For integer dtype scale accoring to dtype min and max to maximize
             # precision
             dtype_info = np.iinfo(input_dtype)

--- a/ilastik/utility/slottools.py
+++ b/ilastik/utility/slottools.py
@@ -1,0 +1,67 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2019, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#        http://ilastik.org/license.html
+###############################################################################
+import numpy
+import typing
+
+
+class DtypeConvertFunction:
+    """Data-type conversion and rescaling function class
+
+    Simple callable class that converts between dtypes.
+
+    This class was needed in order to be able to check functions for equality.
+    When using this function as an input for OpPixelOperator.Function, changing
+    the input value to the same conversion function will not result in
+    dirtyness.
+    """
+
+    def __init__(self, dtype: numpy.dtype):
+        """
+        Args:
+            dtype (numpy.dtype): dtype to which this functions __call__ will
+              convert.
+        """
+        # When from other libraries, the dtype could also be
+        # numpy.dtype('uint8'), which would not be the same as numpy.uint8
+        assert not isinstance(dtype, numpy.dtype)
+        self._dtype = dtype
+
+        if numpy.dtype(dtype).char in numpy.typecodes['AllInteger']:
+            # For integer dtype scale according to dtype min and max to maximize precision
+            dtype_info = numpy.iinfo(dtype)
+            min_val = dtype_info.min
+            max_val = dtype_info.max
+            self._fun = lambda x: ((max_val - min_val) * x - min_val).astype(dtype)
+        else:
+            # For floating points, just coerce it to the new floating point dtype.
+            self._fun = lambda x: x.astype(dtype)
+
+    def __eq__(self, other: typing.Any) -> bool:
+        if other is None:
+            return False
+        if not isinstance(other, DtypeConvertFunction):
+            return False
+        if self._dtype == other._dtype:
+            return True
+        return False
+
+    def __call__(self, val: numpy.ndarray) -> numpy.ndarray:
+        return self._fun(val)

--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -243,13 +243,14 @@ class NewAutocontextWorkflowBase(Workflow):
         opDataExport = self.dataExportApplet.topLevelOperator.getLane(laneIndex)
         
         def checkConstraints(*_):
-            if (opData.Image.meta.dtype in [np.uint8, np.uint16]) == False:
-                msg = "The Autocontext Workflow only supports 8-bit images (UINT8 pixel type)\n"\
-                      "or 16-bit images (UINT16 pixel type)\n"\
-                      "Your image has a pixel type of {}.  Please convert your data to UINT8 and try again."\
-                      .format( str(np.dtype(opData.Image.meta.dtype)) )
-                raise DatasetConstraintError( "Autocontext Workflow", msg, unfixable=True )
-                
+            # if (opData.Image.meta.dtype in [np.uint8, np.uint16]) == False:
+            #    msg = "The Autocontext Workflow only supports 8-bit images (UINT8 pixel type)\n"\
+            #          "or 16-bit images (UINT16 pixel type)\n"\
+            #          "Your image has a pixel type of {}.  Please convert your data to UINT8 and try again."\
+            #          .format( str(np.dtype(opData.Image.meta.dtype)) )
+            #    raise DatasetConstraintError( "Autocontext Workflow", msg, unfixable=True )
+            pass
+
         opData.Image.notifyReady( checkConstraints )
         
         # Input Image -> Feature Op


### PR DESCRIPTION
In our lab we are using Ilastik with uint16 images. Unfortunately, the `autocontext` workflow was only working with `uint8` so far. Towards making this workflow compatible with our data, I modified  `opPixelClassfication` to also produce an uint16 probabilities output (by adding an `PredictionProbabilitiesUint16`). I further modified the `newAutocontextWorkflow` to also tolerate `uint16` input and dynamically select between the pixel classification`PredictionProbabilitiesUint8` and  `PredictionProbabilitiesUint16` output slot depending on the input dtype. 

This was tested by assembling and running a 2 stage Autocontext once with uint8 and uint16 as well as running the existing tests sucessfully.

Based on the existing tests it is not really clear to me how to best add a test for such a modification. Thus any help in this direction would be appreciated.
In general: I am really new to the Ilastik codebase so please let me know if things were done appropriately.