### PR TITLE
Sync buttons in EdgeTrainingWithMulticut applet and fix lazy requesting for multiple lanes

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -91,7 +91,6 @@ class EdgeTrainingGui(LayerViewerGui):
             lane_dicts_ready = [(bool(dct.value) and dct.ready()) for dct in op.viewed_operator().EdgeLabelsDict]
             have_edges = any(lane_dicts_ready)
             self.live_update_button.setEnabled(have_edges)
-            self.live_update_button.setChecked(have_edges)
             return have_edges
 
         self.configure_gui_from_operator()
@@ -259,7 +258,6 @@ class EdgeTrainingGui(LayerViewerGui):
                 del new_labels[sp_id_pair]
 
         op.EdgeLabelsDict.setValue( new_labels )
-        [dct.setDirty() for dct in op.viewed_operator().EdgeLabelsDict]  # be sure to update all lanes
 
     def _handle_label_from_gt_clicked(self):
         def train_from_gt():
@@ -314,6 +312,7 @@ class EdgeTrainingGui(LayerViewerGui):
         self.__cleanup_fns.append(cleanup_fn)
 
     def update_probability_edges(self, *args):
+        op = self.topLevelOperatorView
         def _impl():
             op = self.topLevelOperatorView
             if not self.getLayerByName("Edge Probabilities"):

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -307,7 +307,6 @@ class EdgeTrainingGui(LayerViewerGui):
             pen.setColor(color)
             self.probability_pen_table.append(pen)
 
-        # When the edge edge labels are dirty, update the probability edge layer pens
         op = self.topLevelOperatorView
         op.ProbabilityPenTable.setValue(self.probability_pen_table)
 
@@ -324,8 +323,6 @@ class EdgeTrainingGui(LayerViewerGui):
         if not self.getLayerByName("Edge Probabilities") or len(args) == 0:
             return
         self.overwrite_edge_pens(args[0].value)
-
-        # req = Request(_impl).submit()
         # Now that we've trained the classifier, the workflow may wish to enable downstream applets.
         self.parentApplet.appletStateUpdateRequested()
 

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -90,7 +90,10 @@ class EdgeTrainingGui(LayerViewerGui):
         def enable_live_update_on_edges_available(*args, **kwargs):
             lane_dicts_ready = [(bool(dct.value) and dct.ready()) for dct in op.viewed_operator().EdgeLabelsDict]
             have_edges = any(lane_dicts_ready)
+            if not have_edges:
+                self.live_update_button.setChecked(False)
             self.live_update_button.setEnabled(have_edges)
+            self.configure_operator_from_gui()
             return have_edges
 
         self.configure_gui_from_operator()
@@ -258,6 +261,7 @@ class EdgeTrainingGui(LayerViewerGui):
                 del new_labels[sp_id_pair]
 
         op.EdgeLabelsDict.setValue( new_labels )
+        [slot.setDirty() for slot in op.viewed_operator().EdgeLabelsDict]  # set all the labels dirty, since they are used across lanes
 
     def _handle_label_from_gt_clicked(self):
         def train_from_gt():
@@ -284,7 +288,8 @@ class EdgeTrainingGui(LayerViewerGui):
         )
         if response == QMessageBox.Ok:
             op = self.topLevelOperatorView
-            op.EdgeLabelsDict.setValue({})
+            op.EdgeLabelsDict.setValue( {} )
+            [slot.setDirty() for slot in op.viewed_operator().EdgeLabelsDict]  # set all the labels dirty, since they are used across lanes
 
     def _handle_live_update_clicked(self, checked):
         if checked:

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -120,7 +120,7 @@ class EdgeTrainingGui(LayerViewerGui):
 
     def createDrawerControls(self):
         # Controls
-        feature_selection_button = QPushButton(text="Select Features",
+        self.feature_selection_button = QPushButton(text="Select Features",
                                                icon=QIcon(ilastikIcons.AddSel),
                                                toolTip="Select edge/superpixel features to use for classification.",
                                                clicked=self._open_feature_selection_dlg)
@@ -146,7 +146,7 @@ class EdgeTrainingGui(LayerViewerGui):
         label_layout.setSpacing(1)
 
         layout = QVBoxLayout()
-        layout.addWidget(feature_selection_button)
+        layout.addWidget(self.feature_selection_button)
         layout.setSpacing(1)
         layout.addLayout(label_layout)
         layout.addWidget(self.live_update_button)
@@ -340,6 +340,7 @@ class EdgeTrainingGui(LayerViewerGui):
             op = self.topLevelOperatorView
             self.train_from_gt_button.setEnabled( op.GroundtruthSegmentation.ready() )
             self.live_update_button.setChecked( not op.FreezeClassifier.value )
+            self.feature_selection_button.setEnabled(op.FreezeClassifier.value)
             self._handle_live_update_clicked(not op.FreezeClassifier.value)
             if op.FreezeClassifier.value:
                 self.live_update_button.setIcon(QIcon(ilastikIcons.Play))

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -90,6 +90,8 @@ class EdgeTrainingGui(LayerViewerGui):
 
         # Initialize everything with the operator's initial values
         self.configure_gui_from_operator()
+        # Make sure, Live Update is unchecked on init. It might have been checked by previous function.
+        self.live_update_button.setChecked(False)
 
     def createDrawerControls(self):
         op = self.topLevelOperatorView

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -402,10 +402,18 @@ class OpPredictEdgeProbabilities(Operator):
         classifier = self.EdgeClassifier.value
 
         # Classifier can be None if no labels have been selected
-        if classifier is None or len(classifier.known_classes) < 2:
+        if classifier is None or len(classifier.known_classes) == 0:
             result[0] = np.zeros((len(edge_features_df),), dtype=np.float32)
             return
 
+        if len(classifier.known_classes) == 1:
+            if classifier.known_classes[0] == 2:
+                result[0] = np.ones((len(edge_features_df),), dtype=np.float32)
+                return
+            else:
+                result[0] = np.zeros((len(edge_features_df),), dtype=np.float32)
+                return
+        
         logger.info("Predicting edge probabilities...")
         feature_matrix = edge_features_df.iloc[:, 2:].values  # Discard [sp1, sp2]
         assert feature_matrix.dtype == np.float32, "Unexpected feature dtype: {}".format(feature_matrix.dtype)

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -122,10 +122,9 @@ class OpEdgeTraining(Operator):
 
                     def insertSlot(a, b, position, finalsize):
                         a.insertSlot(position, finalsize)
+                    s1.notifyInserted( partial(insertSlot, s2 ) )
 
-                    s1.notifyInserted(partial(insertSlot, s2))
-
-                    def removeSlot(a, b, position, finalsize):
+                    def removeSlot( a, b, position, finalsize ):
                         a.removeSlot(position, finalsize)
 
                     s1.notifyRemoved(partial(removeSlot, s2))
@@ -280,8 +279,9 @@ class OpComputeEdgeFeatures(Operator):
             edge_feature_dfs.append(edge_features_df)
 
         # Could use join() or merge() here, but we know the rows are already in the right order, and concat() should be faster.
-        all_edge_features_df = pd.DataFrame(rag.edge_ids, columns=["sp1", "sp2"])
-        all_edge_features_df = pd.concat([all_edge_features_df] + edge_feature_dfs, axis=1, copy=False)
+        all_edge_features_df = pd.DataFrame( rag.edge_ids, columns=['sp1', 'sp2'] )
+        all_edge_features_df = pd.concat([all_edge_features_df] + edge_feature_dfs, axis=1, copy=False)\
+            .astype(np.float32)  # in case there sre no features selected, dtype will be uint32 as it is in the rag.
         result[0] = all_edge_features_df
 
     def propagateDirty(self, slot, subindex, roi):

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -238,8 +238,12 @@ class OpCreatePens(Operator):
 
     def execute(self, slot, subindex, roi, result):
         if slot.name == 'Edges':
+            # This is just a dummy hand-through such that we can set the edge pobability layer dirty
+            # withouth setting the superpixels dirty when, in fact they aren't.
+            # the hook in edgeTrainingGui for dirtyness of pens should only be executed
+            # when Edges are requested
             self.Pens.setDirty()
-            return self.Superpixels.value
+            return self.Superpixels.get(roi).wait()  # execute is already be wrapped by a request object.This should be okay
         elif slot.name == 'Pens':
             edge_probs = self.EdgeProbabilitiesDict.value
             probability_pen_table = self.ProbabilityPenTable.value

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -134,4 +134,3 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingGui):
         EdgeTrainingGui.configure_operator_from_gui(self)
         MulticutGuiMixin.configure_operator_from_gui(self)
         self.configure_gui_from_operator()
-

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -35,10 +35,10 @@ class OpEdgeTrainingWithMulticut(Operator):
 
     def __init__(self, *args, **kwargs):
         super(OpEdgeTrainingWithMulticut, self).__init__(*args, **kwargs)
+        
+        opEdgeTraining = OpEdgeTraining( parent=self )
 
-        opEdgeTraining = OpEdgeTraining(parent=self)
-
-        opEdgeTraining.EdgeLabelsDict.connect(self.EdgeLabelsDict)
+        opEdgeTraining.EdgeLabelsDict.connect( self.EdgeLabelsDict )
 
         # This is necessary because OpEdgeTraining occasionally calls self.EdgeLabelsDict.setValue()
         opEdgeTraining.EdgeLabelsDict.backpropagate_values = True

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -31,47 +31,48 @@ class OpEdgeTrainingWithMulticut(Operator):
     NaiveSegmentation = OutputSlot(level=1)
     Edges = OutputSlot(level=1)  # just superpixels handed through to keep dirtyness of edge-changes at at the output
     Pens = OutputSlot(level=1)
+
     # Multicut Output
     Output = OutputSlot(level=1)  # Pixelwise output (not RAG, etc.)
     EdgeLabelDisagreementDict = OutputSlot(level=1)
 
     def __init__(self, *args, **kwargs):
         super(OpEdgeTrainingWithMulticut, self).__init__(*args, **kwargs)
-        
-        opEdgeTraining = OpEdgeTraining( parent=self )
 
-        opEdgeTraining.EdgeLabelsDict.connect( self.EdgeLabelsDict )
+        opEdgeTraining = OpEdgeTraining(parent=self)
+
+        opEdgeTraining.EdgeLabelsDict.connect(self.EdgeLabelsDict)
 
         # This is necessary because OpEdgeTraining occasionally calls self.EdgeLabelsDict.setValue()
         opEdgeTraining.EdgeLabelsDict.backpropagate_values = True
 
-        opEdgeTraining.FeatureNames.connect( self.FeatureNames )
-        opEdgeTraining.FreezeClassifier.connect( self.FreezeClassifier )
-        opEdgeTraining.RawData.connect( self.RawData )
-        opEdgeTraining.VoxelData.connect( self.VoxelData )
-        opEdgeTraining.Superpixels.connect( self.Superpixels )
-        opEdgeTraining.GroundtruthSegmentation.connect( self.GroundtruthSegmentation )
+        opEdgeTraining.FeatureNames.connect(self.FeatureNames)
+        opEdgeTraining.FreezeClassifier.connect(self.FreezeClassifier)
+        opEdgeTraining.RawData.connect(self.RawData)
+        opEdgeTraining.VoxelData.connect(self.VoxelData)
+        opEdgeTraining.Superpixels.connect(self.Superpixels)
+        opEdgeTraining.GroundtruthSegmentation.connect(self.GroundtruthSegmentation)
         opEdgeTraining.ProbabilityPenTable.connect(self.ProbabilityPenTable)
 
-        self.Rag.connect( opEdgeTraining.Rag )
-        self.EdgeProbabilities.connect( opEdgeTraining.EdgeProbabilities )
-        self.EdgeProbabilitiesDict.connect( opEdgeTraining.EdgeProbabilitiesDict )
-        self.NaiveSegmentation.connect( opEdgeTraining.NaiveSegmentation )
+        self.Rag.connect(opEdgeTraining.Rag)
+        self.EdgeProbabilities.connect(opEdgeTraining.EdgeProbabilities)
+        self.EdgeProbabilitiesDict.connect(opEdgeTraining.EdgeProbabilitiesDict)
+        self.NaiveSegmentation.connect(opEdgeTraining.NaiveSegmentation)
         self.Edges.connect(opEdgeTraining.Edges)
         self.Pens.connect(opEdgeTraining.Pens)
 
-        opMulticut = OpMultiLaneWrapper( OpMulticut, parent=self )
-        opMulticut.Beta.connect( self.Beta )
-        opMulticut.SolverName.connect( self.SolverName )
-        opMulticut.FreezeCache.connect( self.FreezeCache )        
-        opMulticut.RawData.connect( self.RawData )
-        opMulticut.Superpixels.connect( opEdgeTraining.Superpixels )
-        opMulticut.Rag.connect( opEdgeTraining.Rag )
-        opMulticut.EdgeProbabilities.connect( opEdgeTraining.EdgeProbabilities )
-        opMulticut.EdgeProbabilitiesDict.connect( opEdgeTraining.EdgeProbabilitiesDict )
+        opMulticut = OpMultiLaneWrapper(OpMulticut, parent=self)
+        opMulticut.Beta.connect(self.Beta)
+        opMulticut.SolverName.connect(self.SolverName)
+        opMulticut.FreezeCache.connect(self.FreezeCache)
+        opMulticut.RawData.connect(self.RawData)
+        opMulticut.Superpixels.connect(opEdgeTraining.Superpixels)
+        opMulticut.Rag.connect(opEdgeTraining.Rag)
+        opMulticut.EdgeProbabilities.connect(opEdgeTraining.EdgeProbabilities)
+        opMulticut.EdgeProbabilitiesDict.connect(opEdgeTraining.EdgeProbabilitiesDict)
 
-        self.Output.connect( opMulticut.Output )
-        self.EdgeLabelDisagreementDict.connect( opMulticut.EdgeLabelDisagreementDict )
+        self.Output.connect(opMulticut.Output)
+        self.EdgeLabelDisagreementDict.connect(opMulticut.EdgeLabelDisagreementDict)
 
         self.opEdgeTraining = opEdgeTraining
         self.opMulticut = opMulticut

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -22,13 +22,15 @@ class OpEdgeTrainingWithMulticut(Operator):
     VoxelData = InputSlot(level=1)
     Superpixels = InputSlot(level=1)
     GroundtruthSegmentation = InputSlot(level=1, optional=True)
+    ProbabilityPenTable = InputSlot(level=1)
 
     # EdgeTraining outputs
     Rag = OutputSlot(level=1)
     EdgeProbabilities = OutputSlot(level=1)
     EdgeProbabilitiesDict = OutputSlot(level=1)  # A dict of id_pair -> probabilities
     NaiveSegmentation = OutputSlot(level=1)
-
+    Edges = OutputSlot(level=1)  # just superpixels handed through to keep dirtyness of edge-changes at at the output
+    Pens = OutputSlot(level=1)
     # Multicut Output
     Output = OutputSlot(level=1)  # Pixelwise output (not RAG, etc.)
     EdgeLabelDisagreementDict = OutputSlot(level=1)
@@ -43,30 +45,33 @@ class OpEdgeTrainingWithMulticut(Operator):
         # This is necessary because OpEdgeTraining occasionally calls self.EdgeLabelsDict.setValue()
         opEdgeTraining.EdgeLabelsDict.backpropagate_values = True
 
-        opEdgeTraining.FeatureNames.connect(self.FeatureNames)
-        opEdgeTraining.FreezeClassifier.connect(self.FreezeClassifier)
-        opEdgeTraining.RawData.connect(self.RawData)
-        opEdgeTraining.VoxelData.connect(self.VoxelData)
-        opEdgeTraining.Superpixels.connect(self.Superpixels)
-        opEdgeTraining.GroundtruthSegmentation.connect(self.GroundtruthSegmentation)
+        opEdgeTraining.FeatureNames.connect( self.FeatureNames )
+        opEdgeTraining.FreezeClassifier.connect( self.FreezeClassifier )
+        opEdgeTraining.RawData.connect( self.RawData )
+        opEdgeTraining.VoxelData.connect( self.VoxelData )
+        opEdgeTraining.Superpixels.connect( self.Superpixels )
+        opEdgeTraining.GroundtruthSegmentation.connect( self.GroundtruthSegmentation )
+        opEdgeTraining.ProbabilityPenTable.connect(self.ProbabilityPenTable)
 
-        self.Rag.connect(opEdgeTraining.Rag)
-        self.EdgeProbabilities.connect(opEdgeTraining.EdgeProbabilities)
-        self.EdgeProbabilitiesDict.connect(opEdgeTraining.EdgeProbabilitiesDict)
-        self.NaiveSegmentation.connect(opEdgeTraining.NaiveSegmentation)
+        self.Rag.connect( opEdgeTraining.Rag )
+        self.EdgeProbabilities.connect( opEdgeTraining.EdgeProbabilities )
+        self.EdgeProbabilitiesDict.connect( opEdgeTraining.EdgeProbabilitiesDict )
+        self.NaiveSegmentation.connect( opEdgeTraining.NaiveSegmentation )
+        self.Edges.connect(opEdgeTraining.Edges)
+        self.Pens.connect(opEdgeTraining.Pens)
 
-        opMulticut = OpMultiLaneWrapper(OpMulticut, parent=self)
-        opMulticut.Beta.connect(self.Beta)
-        opMulticut.SolverName.connect(self.SolverName)
-        opMulticut.FreezeCache.connect(self.FreezeCache)
-        opMulticut.RawData.connect(self.RawData)
-        opMulticut.Superpixels.connect(opEdgeTraining.Superpixels)
-        opMulticut.Rag.connect(opEdgeTraining.Rag)
-        opMulticut.EdgeProbabilities.connect(opEdgeTraining.EdgeProbabilities)
-        opMulticut.EdgeProbabilitiesDict.connect(opEdgeTraining.EdgeProbabilitiesDict)
+        opMulticut = OpMultiLaneWrapper( OpMulticut, parent=self )
+        opMulticut.Beta.connect( self.Beta )
+        opMulticut.SolverName.connect( self.SolverName )
+        opMulticut.FreezeCache.connect( self.FreezeCache )        
+        opMulticut.RawData.connect( self.RawData )
+        opMulticut.Superpixels.connect( opEdgeTraining.Superpixels )
+        opMulticut.Rag.connect( opEdgeTraining.Rag )
+        opMulticut.EdgeProbabilities.connect( opEdgeTraining.EdgeProbabilities )
+        opMulticut.EdgeProbabilitiesDict.connect( opEdgeTraining.EdgeProbabilitiesDict )
 
-        self.Output.connect(opMulticut.Output)
-        self.EdgeLabelDisagreementDict.connect(opMulticut.EdgeLabelDisagreementDict)
+        self.Output.connect( opMulticut.Output )
+        self.EdgeLabelDisagreementDict.connect( opMulticut.EdgeLabelDisagreementDict )
 
         self.opEdgeTraining = opEdgeTraining
         self.opMulticut = opMulticut

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -83,10 +83,11 @@ class MulticutGuiMixin(object):
     def _after_init(self):
         self.configure_gui_from_operator()
         op = self.__topLevelOperatorView
-        def configure_update_handlers( qt_signal, op_slot ):
-            qt_signal.connect( self.configure_operator_from_gui )
+
+        def configure_update_handlers(qt_signal, op_slot):
+            qt_signal.connect(self.configure_operator_from_gui)
             op_slot.notifyDirty(self.configure_gui_from_operator, defer=True)
-            self.__cleanup_fns.append( partial( op_slot.unregisterDirty, self.configure_gui_from_operator ) )
+            self.__cleanup_fns.append(partial(op_slot.unregisterDirty, self.configure_gui_from_operator))
 
         # set the hooks after we initialized everything that might be needed by them
         configure_update_handlers(self.beta_box.valueChanged, op.Beta)
@@ -110,8 +111,13 @@ class MulticutGuiMixin(object):
         drawer_layout.setSpacing(1)
 
         # Beta
-        beta_box = QDoubleSpinBox(decimals=2, minimum=0.01, maximum=0.99, singleStep=0.1,
-                                  toolTip="Bias parameter for the multicut optimization.")
+        beta_box = QDoubleSpinBox(
+            decimals=2,
+            minimum=0.01,
+            maximum=0.99,
+            singleStep=0.1,
+            toolTip="Bias parameter for the multicut optimization.",
+        )
         beta_layout = control_layout("Beta", beta_box)
         drawer_layout.addLayout(beta_layout)
         self.beta_box = beta_box
@@ -122,17 +128,19 @@ class MulticutGuiMixin(object):
         )
         for solver_name in AVAILABLE_SOLVER_NAMES:
             solver_name_combo.addItem(solver_name)
-        drawer_layout.addLayout( control_layout( "Solver", solver_name_combo ) )
+        drawer_layout.addLayout(control_layout("Solver", solver_name_combo))
         self.solver_name_combo = solver_name_combo
 
         button_layout = QHBoxLayout()
 
         # Live Multicut Button
-        live_multicut_button = QPushButton(text="Live Multicut",
-                                           checkable=True,
-                                           clicked = self._auto_show_multicut_layer,
-                                           icon=QIcon(ilastikIcons.Play))
-        
+        live_multicut_button = QPushButton(
+            text="Live Multicut",
+            checkable=True,
+            clicked = self._auto_show_multicut_layer,
+            icon=QIcon(ilastikIcons.Play)
+        )
+
         button_layout.addWidget(live_multicut_button)
         self.live_multicut_button = live_multicut_button
 
@@ -156,12 +164,18 @@ class MulticutGuiMixin(object):
         mgr = ShortcutManager()
         ActionInfo = ShortcutManager.ActionInfo
         shortcut_group = "Multicut"
-        mgr.register( "u", ActionInfo( shortcut_group,
-                                       "UpdateMulticut",
-                                       "Run the multicut optimization using the current edge probabilities",
-                                       update_button.click,
-                                       update_button,
-                                       update_button ) )
+        mgr.register(
+            "u",
+            ActionInfo(
+                shortcut_group,
+                "UpdateMulticut",
+                "Run the multicut optimization using the current edge probabilities",
+                update_button.click,
+                update_button,
+                update_button,
+            ),
+        )
+
         return drawer
 
     def __init_probability_colortable(self):
@@ -265,8 +279,8 @@ class MulticutGuiMixin(object):
             return False
         with self.set_updating():
             op = self.__topLevelOperatorView
-            self.update_button.setEnabled( op.FreezeCache.value )
-            self.live_multicut_button.setChecked( not op.FreezeCache.value )
+            self.update_button.setEnabled(op.FreezeCache.value)
+            self.live_multicut_button.setChecked(not op.FreezeCache.value)
             self._auto_show_multicut_layer(not op.FreezeCache.value)
             if op.FreezeCache.value:
                 self.live_multicut_button.setIcon(QIcon(ilastikIcons.Play))
@@ -399,6 +413,7 @@ class MulticutGuiMixin(object):
     def setupLayers(self):
         layers = []
         op = self.__topLevelOperatorView
+        ActionInfo = ShortcutManager.ActionInfo
 
         mc_disagreement_layer = self.create_multicut_disagreement_layer()
         if mc_disagreement_layer:


### PR DESCRIPTION
This fixes #1858, fixes #2085 and fixes #1842. 
- "Live Predict" and "Live Multicut" buttons are now synced with each other and across lanes.
- Having only red labeled edges does result in a edge training prediction with all edges predicted a 0 proba
- Requests are issued only for slots in currently active lane.