### PR TITLE
Fixes 'Index Error' when adding new label to pixel 'Training' applet

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -104,10 +104,10 @@ class ThresholdTwoLevelsGui( LayerViewerGui ):
         self._showDebug = False
         
         self._updateGuiFromOperator()
-        self.topLevelOperatorView.InputImage.notifyReady( bind(self._updateGuiFromOperator) )
+        self.topLevelOperatorView.InputChannelColors.notifyReady( bind(self._updateGuiFromOperator) )
         self.__cleanup_fns.append( partial( self.topLevelOperatorView.InputImage.unregisterUnready, bind(self._updateGuiFromOperator) ) )
 
-        self.topLevelOperatorView.InputImage.notifyMetaChanged( bind(self._updateGuiFromOperator) )
+        self.topLevelOperatorView.InputChannelColors.notifyMetaChanged( bind(self._updateGuiFromOperator) )
         self.__cleanup_fns.append( partial( self.topLevelOperatorView.InputImage.unregisterMetaChanged, bind(self._updateGuiFromOperator) ) )
 
     def _connectCallbacks(self):
@@ -133,12 +133,6 @@ class ThresholdTwoLevelsGui( LayerViewerGui ):
 
         self._drawer.sigmaSpinBox_Z.setVisible(data_has_z_axis)
 
-        numChannels = 0
-        if op.InputImage.ready():
-            # Channel
-            channelIndex = op.InputImage.meta.axistags.index('c')
-            numChannels = op.InputImage.meta.shape[channelIndex]
-
         if op.InputChannelColors.ready():
             input_channel_colors = [QColor(r_g_b[0],r_g_b[1],r_g_b[2]) for r_g_b in op.InputChannelColors.value]
         else:
@@ -150,10 +144,10 @@ class ThresholdTwoLevelsGui( LayerViewerGui ):
         self._drawer.inputChannelComboBox.clear()
         self._drawer.coreChannelComboBox.clear()
         
-        for ichannel in range(numChannels):
+        for ichannel, color in enumerate(input_channel_colors):
             # make an icon
             pm = QPixmap(16, 16)
-            pm.fill(input_channel_colors[ichannel])
+            pm.fill(color)
             self._drawer.inputChannelComboBox.insertItem(ichannel, QIcon(pm), str(ichannel))
             self._drawer.coreChannelComboBox.insertItem(ichannel, QIcon(pm), str(ichannel))
 


### PR DESCRIPTION
The thresholding operator must update its GUI when new labels
are added to the pixel classification 'Training' applet. In order
to do that, the operator/applet was watching for changes in its
InputImage slot and it would try to update its widgets before its
InputChannelColors slot would be ready with the new label, causing
an "Index Error" when trying to find the new color of the new label.

This commit makes the applet watch instead for changes on the
InputChannelColors slot, so that it will always have the information
needed for updating the GUI when the watcher function fires.

## Reproducing the error

1- Create a Pixel + Object classification workflow;
2- Add your image;
3 - Select features;
4 - Training Applet -> Scribble around with 2 colors
5 - Thresholding  Applet -> Just open the applet
6 - Go back to the Training Applet -> Try to add a label

You'll be greeted with this lovely stack trace and a stuck "loading" mouse cursor:

```
INFO ilastik_main: Starting ilastik in debug mode from "/home/tomaz/source".
Starting ilastik in debug mode from "/home/tomaz/source".
INFO lazyflow.operators.filterOperators: Using fast filters.
WARNING __init__.py(11): UserWarning: init: Could not import tiktorch classifier
WARNING cross_validation.py(41): DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
WARNING 2018-12-11 14:46:36,993 opConservationTracking 8383 140681514862400 Could not find any ILP solver
WARNING 2018-12-11 14:46:36,999 opStructuredTracking 8383 140681514862400 Could not find any ILP solver
WARNING 2018-12-11 14:46:37,000 structuredTrackingWorkflow 8383 140681514862400 Could not find any learning solver. Tracking will use flow-based solver (DPCT). Learning for tracking will be disabled!
WARNING stype.py(181): UserWarning: ArrayLike.isCompatible: FIXME here
INFO OpenGL.acceleratesupport: No OpenGL_accelerate module loaded: No module named 'OpenGL_accelerate'
WARNING tiling.py(356): UserWarning: FIXME: This is a slow way to look for the items we want.
_TilesCache._layerCache should be a dict-of-dict-of-dict for faster lookup!
INFO lazyflow.classifiers.parallelVigraRfLazyflowClassifier: Training took, 0.020683 seconds
INFO lazyflow.classifiers.parallelVigraRfLazyflowClassifier: Training complete. Average OOB: 0.00025826446280991736
ERROR 2018-12-11 14:47:11,048 log_exception 8383 140681514862400 Traceback (most recent call last):
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/labeling/labelingGui.py", line 648, in _addNewLabel
    self._labelingSlots.labelNames.setValue( operator_names, check_changed=False )
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1238, in setValue
    self.setDirty(slice(None))
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 980, in setDirty
    self._sig_dirty(self, roi)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/utility/orderedSignal.py", line 77, in __call__
    f(*args, **kw)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/pixelClassification/opPixelClassification.py", line 171, in _updateNumClasses
    self.opPredictionPipeline.NumClasses.setValue( numClasses )
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1218, in setValue
    s.setValue(self._value)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1232, in setValue
    self._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  [Previous line repeated 1 more time]
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1443, in _changed
    self._sig_changed(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/utility/orderedSignal.py", line 77, in __call__
    f(*args, **kw)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/utility/bind.py", line 64, in __call__
    self.f(*(self.bound_args + args[0:self.numUnboundArgs]))
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/utility/gui/threadRouter.py", line 76, in routed
    val = func(*args, **kwargs)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py", line 156, in _updateGuiFromOperator
    pm.fill(input_channel_colors[ichannel])
IndexError: list index out of range

ERROR 2018-12-11 14:47:11,048 log_exception 8383 140681514862400 Logged the above exception just in case PyQt loses it.
ERROR 2018-12-11 14:47:11,049 excepthooks 8383 140681514862400 Unhandled exception in thread: 'MainThread'
ERROR 2018-12-11 14:47:11,049 excepthooks 8383 140681514862400 Traceback (most recent call last):
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/utility/bind.py", line 64, in __call__
    self.f(*(self.bound_args + args[0:self.numUnboundArgs]))
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/labeling/labelingGui.py", line 648, in _addNewLabel
    self._labelingSlots.labelNames.setValue( operator_names, check_changed=False )
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1238, in setValue
    self.setDirty(slice(None))
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 980, in setDirty
    self._sig_dirty(self, roi)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/utility/orderedSignal.py", line 77, in __call__
    f(*args, **kw)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/pixelClassification/opPixelClassification.py", line 171, in _updateNumClasses
    self.opPredictionPipeline.NumClasses.setValue( numClasses )
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1218, in setValue
    s.setValue(self._value)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 118, in call_in_setup_context
    return func(self, *args, **kwargs)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1232, in setValue
    self._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  [Previous line repeated 1 more time]
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1439, in _changed
    self._configureOperator(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1453, in _configureOperator
    self.operator._setupOutputs()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/operator.py", line 482, in _setupOutputs
    oslot._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1433, in _changed
    c._changed()
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/slot.py", line 1443, in _changed
    self._sig_changed(self)
  File "/home/tomaz/miniconda3/envs/ilastik-py3/ilastik-meta/lazyflow/lazyflow/utility/orderedSignal.py", line 77, in __call__
    f(*args, **kw)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/utility/bind.py", line 64, in __call__
    self.f(*(self.bound_args + args[0:self.numUnboundArgs]))
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/utility/gui/threadRouter.py", line 76, in routed
    val = func(*args, **kwargs)
  File "/home/tomaz/source/ilastik-meta/ilastik/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py", line 156, in _updateGuiFromOperator
    pm.fill(input_channel_colors[ichannel])
IndexError: list index out of range
```