### PR TITLE
Fixes display of channels in thresholding

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -133,13 +133,19 @@ class ThresholdTwoLevelsGui( LayerViewerGui ):
 
         self._drawer.sigmaSpinBox_Z.setVisible(data_has_z_axis)
 
+        numChannels = 0
+        if op.InputImage.ready():
+            # Channel
+            channelIndex = op.InputImage.meta.axistags.index('c')
+            numChannels = op.InputImage.meta.shape[channelIndex]
+
         if op.InputChannelColors.ready():
             input_channel_colors = [QColor(r_g_b[0],r_g_b[1],r_g_b[2]) for r_g_b in op.InputChannelColors.value]
         else:
             if self._defaultInputChannelColors is None:
                 self._defaultInputChannelColors = colortables.default16_new[1:]
 
-            input_channel_colors = list(map(QColor, self._defaultInputChannelColors))
+            input_channel_colors = list(map(QColor, self._defaultInputChannelColors[0:numChannels]))
 
         self._drawer.inputChannelComboBox.clear()
         self._drawer.coreChannelComboBox.clear()


### PR DESCRIPTION
#1912 fixed the index error in the combined pixel+object classification workflow.
I didn't properly check for side-effects when merging it.
Apparently there were some in the regular Object Classification workflow, which would display 14 channels per default:

![2018-12-19-17 41 49-screenshot](https://user-images.githubusercontent.com/24434157/50234325-b4469800-03b5-11e9-9da4-2a72840daec8.png)


This commit fixes this...

