### PR TITLE
remove 'import torch'

### DIFF
--- a/ilastik.py
+++ b/ilastik.py
@@ -23,7 +23,7 @@
 
 import sys
 import os
-import torch
+
 
 def _clean_paths( ilastik_dir ):
     # remove undesired paths from PYTHONPATH and add ilastik's submodules


### PR DESCRIPTION
pytorch should not be a general dependency of ilastik
(torch is also not needed in ilastik.py)