### PR TITLE
Refactor startup script and command-line parsing

### DIFF
--- a/bin/train_headless.py
+++ b/bin/train_headless.py
@@ -132,7 +132,7 @@ def generate_trained_project_file( new_project_path,
     
     # Manually configure the arguments to ilastik, as if they were parsed from the command line.
     # (Start with empty args and fill in below.)
-    ilastik_args = ilastik_main.parser.parse_args([])
+    ilastik_args = ilastik_main.parse_args([])
     ilastik_args.new_project = new_project_path
     ilastik_args.headless = True
     ilastik_args.workflow = 'Pixel Classification'

--- a/examples/example_python_client.py
+++ b/examples/example_python_client.py
@@ -20,7 +20,7 @@ os.environ["LAZYFLOW_TOTAL_RAM_MB"] = "2000"
 
 # Programmatically set the command-line arguments directly into the argparse.Namespace object
 # Provide your project file, and don't forget to specify headless.
-args = ilastik_main.parser.parse_args([])
+args = ilastik_main.parse_args([])
 args.headless = True
 args.project = '/Users/bergs/MyProject.ilp' # REPLACE WITH YOUR PROJECT FILE
 

--- a/ilastik.py
+++ b/ilastik.py
@@ -63,15 +63,12 @@ def main():
         ilastik_dir = os.path.abspath(os.path.join(this_path, "..%s.." % os.path.sep))
         _clean_paths( ilastik_dir )
 
+    # Allow to start-up by double-clicking a project file.
+    if len(sys.argv) == 2 and sys.argv[1].endswith('.ilp'):
+        sys.argv.insert(1, '--project')
+
     import ilastik_main
     parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
-    
-    # allow to start-up by double-clicking an '.ilp' file
-    if len(workflow_cmdline_args) == 1 and \
-       workflow_cmdline_args[0].endswith('.ilp') and \
-       parsed_args.project is None:
-            parsed_args.project = workflow_cmdline_args[0]
-            workflow_cmdline_args = []
 
     hShell = ilastik_main.main(parsed_args, workflow_cmdline_args)
     # in headless mode the headless shell is returned and its project manager still has an open project file

--- a/ilastik.py
+++ b/ilastik.py
@@ -64,7 +64,7 @@ def main():
         _clean_paths( ilastik_dir )
 
     import ilastik_main
-    parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+    parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
     
     # allow to start-up by double-clicking an '.ilp' file
     if len(workflow_cmdline_args) == 1 and \

--- a/ilastik.py
+++ b/ilastik.py
@@ -73,51 +73,9 @@ def main():
             parsed_args.project = workflow_cmdline_args[0]
             workflow_cmdline_args = []
 
-    # DEVELOPERS:
-    # Provide your command-line args here. See examples below.
-    
-    ## Auto-open an existing project
-    #parsed_args.project='/Users/bergs/MyProject.ilp'
-    #parsed_args.project='/magnetic/data/multicut-testdata/2d/MyMulticut2D.ilp'
-    #parsed_args.project = '/Users/bergs/MyMulticutProject.ilp'
-    #parsed_args.project = '/magnetic/data/multicut-testdata/chris-256/MyMulticutProject-chris256.ilp'
-    #parsed_args.project = '/magnetic/data/flyem/fib25-neuroproof-validation/fib25-multicut/mc-training/mc-training-with-corrected-gt.ilp'
-
-    ## Headless-mode options
-    #parsed_args.headless = True
-    #parsed_args.debug = True
-
-    ## Override lazyflow environment settings
-    #os.environ["LAZYFLOW_THREADS"] = "0"
-    #os.environ["LAZYFLOW_TOTAL_RAM_MB"] = "8192"
-
-    ## Provide workflow-specific args
-    #workflow_cmdline_args += ["--retrain"]
-
-    ## Provide batch inputs (for headless mode)
-    #workflow_cmdline_args += ["/magnetic/data/cells/001cell.png",
-    #                          "/magnetic/data/cells/002cell.png",
-    #                          "/magnetic/data/cells/003cell.png" ]
-
-    # Create a new project from scratch (instead of opening existing project)
-    #parsed_args.new_project='/Users/bergs/MyProject.ilp'
-    #parsed_args.workflow = 'Pixel Classification'
-    #parsed_args.workflow = 'Object Classification (from pixel classification)'
-    #parsed_args.workflow = 'Carving'
-
     hShell = ilastik_main.main(parsed_args, workflow_cmdline_args)
     # in headless mode the headless shell is returned and its project manager still has an open project file
     hShell.closeCurrentProject()
 
 if __name__ == "__main__":
-    # Examples:
-    # python ilastik.py --headless --project=MyProject.ilp --output_format=hdf5 raw_input.h5/volumes/data
-
-    ## Multicut headless test
-    #sys.argv += "--headless".split()
-    #sys.argv += "--project=/magnetic/data/multicut-testdata/chris-256/MyMulticutProject-chris256.ilp".split()
-    #sys.argv += "--raw_data /magnetic/data/multicut-testdata/chris-256/grayscale-256.h5/grayscale".split()
-    #sys.argv += "--probabilities /magnetic/data/multicut-testdata/chris-256/final-membranes-256.h5/membranes".split()
-    #sys.argv += "--superpixels /magnetic/data/multicut-testdata/chris-256/watershed-256.h5/watershed".split()
-
     main()

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -982,7 +982,7 @@ if __name__ == "__main__":
             f['zeros'].attrs['axistags'] = tags.toJSON()
         
         import ilastik_main
-        parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+        parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
         parsed_args.new_project = test_project_path
         parsed_args.workflow = "Pixel Classification"
         parsed_args.headless = True
@@ -1002,7 +1002,7 @@ if __name__ == "__main__":
 
     def open_test_files():
         import ilastik_main
-        parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+        parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
         parsed_args.project = test_project_path
         parsed_args.headless = True
     

--- a/ilastik/workflows/pixelClassification/pixelClassificationClusterized.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationClusterized.py
@@ -97,7 +97,7 @@ background_thread.daemon = True
 background_thread.start()
 
 def runWorkflow(cluster_args):
-    ilastik_main_args = ilastik_main.parser.parse_args([])
+    ilastik_main_args = ilastik_main.parse_args([])
     # Copy relevant args from cluster cmdline options to ilastik_main cmdline options
     ilastik_main_args.headless = True
     ilastik_main_args.project = cluster_args.project

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -1,60 +1,141 @@
-from __future__ import print_function
-import sys
+import argparse
+import faulthandler
+import logging
 import os
+import sys
+from typing import (
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import ilastik.config
 from ilastik.config import cfg as ilastik_config
 
-import argparse
-import faulthandler
-import logging
-
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser(description="start an ilastik workflow")
 
-# Common options
-parser.add_argument('--headless', help="Don't start the ilastik gui.",
-                    action='store_true', default=False)
-parser.add_argument(
-    '--project', help='A project file to open on startup.', required=False)
-parser.add_argument(
-    '--readonly', help="Open all projects in read-only mode, to ensure you "
-    "don't accidentally make changes.", default=False)
+def _argparser() -> argparse.ArgumentParser:
+    """Create ArgumentParser for the main entry point."""
+    ap = argparse.ArgumentParser(description='start an ilastik workflow')
+    ap.add_argument(
+        '--headless',
+        help="Don't start the ilastik gui.",
+        action='store_true',
+    )
+    ap.add_argument(
+        '--project',
+        help='A project file to open on startup.',
+    )
+    ap.add_argument(
+        '--readonly',
+        help="Open all projects in read-only mode, to ensure you don't "
+             "accidentally make changes.",
+        action='store_true',
+    )
+    ap.add_argument(
+        '--new_project',
+        help='Create a new project with the specified name. Must also specify '
+             '--workflow.',
+    )
+    ap.add_argument(
+        '--workflow',
+        help='When used with --new_project, specifies the workflow to use.',
+    )
+    ap.add_argument(
+        '--clean_paths',
+        help='Remove ilastik-unrelated directories from PATH and PYTHONPATH.',
+        action='store_true',
+    )
+    ap.add_argument(
+        '--redirect_output',
+        help='A filepath to redirect stdout to',
+    )
+    ap.add_argument(
+        '--debug',
+        help='Start ilastik in debug mode.',
+        action='store_true',
+    )
+    ap.add_argument(
+        '--logfile',
+        help='A filepath to dump all log messages to.',
+    )
+    ap.add_argument(
+        '--process_name',
+        help='A process name (used for logging purposes).',
+    )
+    ap.add_argument(
+        '--configfile',
+        help='A custom path to a user config file for expert ilastik settings.',
+    )
+    ap.add_argument(
+        '--fullscreen',
+        help='Show Window in fullscreen mode.',
+        action='store_true',
+    )
+    ap.add_argument(
+        '--exit_on_failure',
+        help='Immediately call exit(1) if an unhandled exception occurs.',
+        action='store_true',
+    )
+    ap.add_argument(
+        '--hbp',
+        help='Enable HBP-specific functionality.',
+        action='store_true',
+    )
+    return ap
 
-parser.add_argument(
-    '--new_project', help='Create a new project with the specified name. '
-    'Must also specify --workflow.', required=False)
-parser.add_argument(
-    '--workflow', help='When used with --new_project, specifies the workflow '
-    'to use.', required=False)
 
-parser.add_argument(
-    '--clean_paths', help='Remove ilastik-unrelated directories from PATH and '
-    'PYTHONPATH.', action='store_true', default=False)
-parser.add_argument('--redirect_output',
-                    help='A filepath to redirect stdout to', required=False)
+def _ensure_compatible_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """If args are invalid, print an error message to stderr and exit."""
 
-parser.add_argument('--debug', help='Start ilastik in debug mode.',
-                    action='store_true', default=False)
-parser.add_argument(
-    '--logfile', help='A filepath to dump all log messages to.',
-    required=False)
-parser.add_argument(
-    '--process_name', help='A process name (used for logging purposes).',
-    required=False)
-parser.add_argument(
-    '--configfile', help='A custom path to a user config file for expert '
-    'ilastik settings.', required=False)
-parser.add_argument('--fullscreen', help='Show Window in fullscreen mode.',
-                    action='store_true', default=False)
-parser.add_argument(
-    '--exit_on_failure',
-    help='Immediately call exit(1) if an unhandled exception occurs.',
-    action='store_true', default=False)
-parser.add_argument(
-    '--hbp', help='Enable HBP-specific functionality.',
-    action='store_true', default=False)
+    if args.workflow is not None and args.new_project is None:
+        parser.error('The --workflow argument may only be used with the '
+                     '--new_project argument.')
+
+    if args.workflow is None and args.new_project is not None:
+        parser.error('No workflow specified. The --new_project argument must '
+                     'be used in conjunction with the --workflow argument.')
+
+    if args.project is not None and args.new_project is not None:
+        parser.error('The --project and --new_project settings cannot be used '
+                     'together. Choose one (or neither).')
+
+    if args.headless and (args.fullscreen or args.exit_on_failure):
+        parser.error('Some of the command-line options you provided are not '
+                     'supported in headless mode.')
+
+    if (args.headless and not args.project and
+            not (args.new_project and args.workflow)):
+        parser.error('You have to supply at least --project, or --new_project '
+                     'and workflow when invoking ilastik in headless mode.')
+
+
+def parse_args(args: Optional[Sequence[str]] = None,
+               namespace: Optional[argparse.Namespace] = None) -> argparse.Namespace:
+    """Parse and validate command-line arguments for :func:`main`.
+
+    See Also:
+        :meth:`argparse.ArgumentParser.parse_args`.
+    """
+    parser = _argparser()
+    known = parser.parse_args(args, namespace)
+    _ensure_compatible_args(parser, known)
+    return known
+
+
+def parse_known_args(args: Optional[Sequence[str]] = None,
+                     namespace: Optional[argparse.Namespace] = None) -> Tuple[argparse.Namespace, List[str]]:
+    """Parse and validate command-line arguments for :func:`main`.
+
+    See Also:
+        :meth:`argparse.ArgumentParser.parse_known_args`.
+    """
+    parser = _argparser()
+    known, unknown = parser.parse_known_args(args, namespace)
+    _ensure_compatible_args(parser, known)
+    return known, unknown
 
 
 def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
@@ -88,7 +169,6 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
 
     _init_sklearn_monkeypatch()
     _init_threading_logging_monkeypatch()
-    _validate_arg_compatibility(parsed_args)
 
     # Extra initialization functions.
     # These are called during app startup, but before the shell is created.
@@ -250,43 +330,6 @@ def _init_sklearn_monkeypatch():
 
     import sklearn
     sklearn.base.BaseEstimator.get_params = get_params
-
-
-def _validate_arg_compatibility(parsed_args):
-    # Check for bad input options
-    if parsed_args.workflow is not None and parsed_args.new_project is None:
-        sys.stderr.write(
-            "The --workflow argument may only be used with the --new_project "
-            "argument. "
-            "Please invoke ilastik with --help for more information. Exiting.\n")
-        sys.exit(1)
-    if parsed_args.workflow is None and parsed_args.new_project is not None:
-        sys.stderr.write(
-            "No workflow specified.  The --new_project argument must be used "
-            "in conjunction with the --workflow argument. "
-            "Please invoke ilastik with --help for more information. Exiting.\n")
-        sys.exit(1)
-    if parsed_args.project is not None and parsed_args.new_project is not None:
-        sys.stderr.write(
-            "The --project and --new_project settings cannot be used together."
-            " Choose one (or neither). Please invoke ilastik with --help for more information. Exiting.\n")
-        sys.exit(1)
-
-    if parsed_args.headless and \
-           (parsed_args.fullscreen or
-            parsed_args.exit_on_failure):
-        sys.stderr.write(
-            "Some of the command-line options you provided are not supported "
-            "in headless mode. Please invoke ilastik with --help for more information. Exiting.\n")
-        sys.exit(1)
-
-    if parsed_args.headless and not parsed_args.project:
-        if not (parsed_args.new_project and parsed_args.workflow):
-            sys.stderr.write(
-                "You have to supply at least --project, or --new_project and workflow when invoking "
-                "ilastik in headless mode. "
-                "Please invoke ilastik with --help for more information. Exiting.\n")
-            sys.exit(1)
 
 
 def _import_opengm():

--- a/internal-startup-options.cfg
+++ b/internal-startup-options.cfg
@@ -1,0 +1,52 @@
+###############################################################################
+# WARNING: THIS FILE SHOULD BE USED ONLY BY DEVELOPERS AND EXPERIENCED USERS! #
+# WARNING: SUPPORT FOR THIS FILE CAN BE DROPPED AT ANY MOMENT WITHOUT NOTICE! #
+###############################################################################
+
+## If you want to modify this file, ignore it in your local repository:
+##     echo internal-startup-options.cfg >> .git/info/exclude
+
+
+## Override lazyflow environment settings.
+#LAZYFLOW_THREADS=42
+#LAZYFLOW_TOTAL_RAM_MB=8192
+
+
+## Semicolons separate environment variables from command-line options.
+;;
+
+
+## Auto-open an existing project.
+#--project '/Users/bergs/MyProject.ilp'
+#--project '/magnetic/data/multicut-testdata/2d/MyMulticut2D.ilp'
+#--project '/Users/bergs/MyMulticutProject.ilp'
+#--project '/magnetic/data/multicut-testdata/chris-256/MyMulticutProject-chris256.ilp'
+#--project '/magnetic/data/flyem/fib25-neuroproof-validation/fib25-multicut/mc-training/mc-training-with-corrected-gt.ilp'
+
+## Headless-mode options.
+#--headless
+#--debug
+
+## Provide workflow-specific args
+#--retrain
+
+## Provide batch inputs (for headless mode).
+#/magnetic/data/cells/001cell.png
+#/magnetic/data/cells/002cell.png
+#/magnetic/data/cells/003cell.png
+
+## Create a new project from scratch (instead of opening existing project).
+#--new_project '/Users/bergs/MyProject.ilp'
+#--workflow 'Pixel Classification'
+#--workflow 'Object Classification (from pixel classification)'
+#--workflow 'Carving'
+
+## More examples.
+#--headless --project=MyProject.ilp --output_format=hdf5 raw_input.h5/volumes/data
+
+## Multicut headless test.
+#--headless
+#--project /magnetic/data/multicut-testdata/chris-256/MyMulticutProject-chris256.ilp
+#--raw_data /magnetic/data/multicut-testdata/chris-256/grayscale-256.h5/grayscale
+#--probabilities /magnetic/data/multicut-testdata/chris-256/final-membranes-256.h5/membranes
+#--superpixels /magnetic/data/multicut-testdata/chris-256/watershed-256.h5/watershed

--- a/tests/test_workflows/test_all/testAllHeadless.py
+++ b/tests/test_workflows/test_all/testAllHeadless.py
@@ -76,7 +76,7 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         sys.argv.extend(args)
 
         # Start up the ilastik.py entry script as if we had launched it from the command line
-        parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+        parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
 
         shell = ilastik_main.main(
             parsed_args=parsed_args, workflow_cmdline_args=workflow_cmdline_args, init_logging=False)
@@ -117,7 +117,7 @@ class TestHeadlessWorkflowStartupProjectCreation(object):
         sys.argv.extend(args)
 
         # Start up the ilastik.py entry script as if we had launched it from the command line
-        parsed_args, workflow_cmdline_args = ilastik_main.parser.parse_known_args()
+        parsed_args, workflow_cmdline_args = ilastik_main.parse_known_args()
         shell = ilastik_main.main(
             parsed_args=parsed_args, workflow_cmdline_args=workflow_cmdline_args, init_logging=False)
 


### PR DESCRIPTION
* Refactor `--clean_paths` option implementation
* Modify GUI launch command-line handling
* Remove direct access to argument parser instance
* Remove comments about modifying command-line args
