### PR TITLE
Fix index error

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -878,14 +878,14 @@ class ObjectClassificationGui(LabelingGui):
             subslot_index = self.op.current_view_index()
             if subslot_index == -1:
                 return
-            temp = self.op.triggerTransferLabels(subslot_index)
-        else:
-            temp = None
-        if temp is not None:
-            new_labels, old_labels_lost, new_labels_lost = temp
-            labels_lost = dict(list(old_labels_lost.items()) + list(new_labels_lost.items()))
-            if sum(len(v) for v in labels_lost.values()) > 0:
-                self.warnLost(labels_lost)
+            # just clears all labels atm.
+            self.op.triggerTransferLabelsAll()
+            # FIXME: this needs to be revived once transferLabels is fixed
+            # if temp is not None:
+            #     new_labels, old_labels_lost, new_labels_lost = temp
+            #     labels_lost = dict(list(old_labels_lost.items()) + list(new_labels_lost.items()))
+            #     if sum(len(v) for v in labels_lost.values()) > 0:
+            #         self.warnLost(labels_lost)
 
     @threadRouted
     def warnLost(self, labels_lost):

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -330,6 +330,7 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
         self._resetLabelInputs(imageIndex)
 
     def _resetLabelInputs(self, imageIndex, roi=None):
+        logger.debug(f"Resetting label inputs for {imageIndex}")
         labels = dict()
         for t in range(self.SegmentationImages[imageIndex].meta.shape[0]):
             #initialize, because volumina needs to reshape to use it as a datasink
@@ -416,9 +417,34 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
 
     def propagateDirty(self, slot, subindex, roi):
         if slot==self.SegmentationImages and len(self.LabelInputs)>0:
-            
-            self._ambiguousLabels[subindex[0]] = self.LabelInputs[subindex[0]].value
-            self._needLabelTransfer = True
+            labels = self.LabelInputs[subindex].value
+            if self.containsLabels(labels):
+                self._ambiguousLabels[subindex[0]] = self.LabelInputs[subindex[0]].value
+                self._needLabelTransfer = True
+
+    @classmethod
+    def containsLabels(self, labels: dict) -> bool:
+        """Check whether a certain lane really contains user labels
+
+        Labels are initialized with [0., 0.], per timepoint, this function just
+        checks this condition.
+
+        Args:
+            labels (dict): dict of timepoints: labels; {0: [0., 0.], 1: ...}
+
+        Returns:
+            bool: True if user has placed any labels, False otherwise
+
+        Examples:
+        >>> OpObjectClassification.containsLabels({0: [0., 0.], 1: [0., 0.]})
+        False
+        >>> OpObjectClassification.containsLabels({0: [0., 0.], 1: [0., 0., 0.]})
+        True
+        >>> OpObjectClassification.containsLabels({0: [0., 1.], 1: [0., 0.]})
+        True
+        """
+        has_labels = any(True for (_, val) in labels.items() if not (len(val)==2 and numpy.allclose(val, 0)))
+        return has_labels
 
     def assignObjectLabel(self, imageIndex, coordinate, assignedLabel):
         """
@@ -471,16 +497,18 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
             return None
         if not self.SegmentationImages[imageIndex].ready():
             return None
-        if len(list(self._labelBBoxes[imageIndex].keys()))==0:
+        # FIXME:
+        # if len(list(self._labelBBoxes[imageIndex].keys()))==0:
             #we either don't have any labels or we just read the project from file
             #nothing to transfer
-            self._needLabelTransfer = False
-            return None
+        #    self._needLabelTransfer = False
+        #    return None
         if not self.EnableLabelTransfer:
             self._resetLabelInputs(imageIndex)
             self._needLabelTransfer = False
             return None
 
+        assert False, "Should not go on here, remove once transfer is re-enabled."
         labels = dict()
         for timeCoord in range(self.SegmentationImages[imageIndex].meta.shape[0]):
             #we have to get new object features to get bounding boxes

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -491,6 +491,20 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
 #             bboxes["Coord<Maximum>"] = maxs
 #             self._labelBBoxes[imageIndex][timeCoord]=bboxes
 
+    def triggerTransferLabelsAll(self):
+        """Triggers deletion of labels on all lanes
+
+        Should only be triggered, if segmentation changed for images with
+        annotations.
+        """
+        if self._needLabelTransfer is True:
+            logger.warning('cleaning up all labels!')
+            for i in range(len(self.LabelInputs)):
+                labels = self.LabelInputs[i].value
+                if self.containsLabels(labels):
+                    self.triggerTransferLabels(i)
+        self._needLabelTransfer = False
+
     def triggerTransferLabels(self, imageIndex):
         # FIXME: This function no longer works, partly thanks to the code commented out above.  See "FIXME: TRANSFER LABELS"
         if not self._needLabelTransfer:

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from builtins import range
 import collections
 import numpy as np
@@ -192,7 +191,8 @@ def prepare_list(list_, names, dtypes=None):
 
     """
     n_items = len(list_)
-
+    if n_items == 0:
+        return np.array(())
     # make sure inner items are iterables
     first_row = list_[0]
     if isinstance(first_row, str) or not isinstance(first_row, collections.Iterable):


### PR DESCRIPTION
Fixes #1776 

The underlying problem was that `LabelInputs` and the objects were out of sync. The fix is quite small, and kind of drastic: If the segmentation changes, then all labels are removed.
One problem (should be present in general in workflows that have more than one input image): changing the probability map image will not emit any _dirtyness_ and will, therefore, be unnoticed. Annotations will be meaningless then. @akreshuk @stuarteberg, out of your head, would you have an idea how to fix this properly?

This also fixes the unrelated index error in https://github.com/ilastik/ilastik/commit/41fad9acf247ce7a29b62f5c99ddacd3a0fcefae that occurred upon export when with no objects in the image

a "fix" for broken projects could be a script, that deletes the labels. Or one just changes the threshold back and forth, that should also work to revive those.

Of course what we should do in close future is fix this: https://github.com/ilastik/ilastik/issues/1944