### PR TITLE
Enabling pixel class mask

### DIFF
--- a/ilastik/utility/__init__.py
+++ b/ilastik/utility/__init__.py
@@ -25,3 +25,4 @@ from .operatorSubView import OperatorSubView
 from .opMultiLaneWrapper import OpMultiLaneWrapper
 from .log_exception import log_exception
 from .autocleaned_tempdir import autocleaned_tempdir
+from .slot_name_enum import SlotNameEnum

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,7 +1,50 @@
 import enum
+from typing import List, Tuple
+from itertools import chain
 
 class SlotNameEnum(enum.IntEnum):
+    """A map from slot names to their indices within a multislot
+
+    Do note that the ENUM_NAMEs that you pick matter, as they determine
+    the human readable version that you get from instances of this enum:
+
+    e.g a value defined like so:
+        MY_DATA_SLOT = 123
+    will have its slotName rendered as
+        'My Data Slot'
+    """
+
+    @property
+    def slotName(self) -> str:
+        """A 'Human Readable Slot Name' str based on its ENUM_SLOT_NAME"""
+        return self.name.replace('_', ' ').title()
+
     @classmethod
-    def asNameList(cls):
-        return [item.name.replace('_', ' ').title() for item in cls]
+    def asNameList(cls) -> List[str]:
+        return [item.slotName for item in cls]
+
+    @classmethod
+    def getFirst(cls) -> int:
+        return list(cls)[0]
+
+    @classmethod
+    def getLast(cls) -> int:
+        return list(cls)[-1]
+
+    @classmethod
+    def getNext(cls) -> int:
+        return cls.getLast() + 1
+
+    @classmethod
+    def getPairs(cls) -> List[Tuple[str, int]]:
+        return [(item.name, item.value) for item in cls]
+
+    @classmethod
+    def extendedWithEnum(cls, extra_enum: 'SlotNameEnum', unique: bool=False) -> 'SlotNameEnum':
+        """Crates a new SlotNameEnum combining the keys from cls and extra_enum"""
+
+        wrapper = enum.unique if unique else lambda x: x
+        return wrapper(SlotNameEnum(extra_enum.__name__,
+                                    chain(cls.getPairs(),
+                                          extra_enum.getPairs())))
 

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -33,7 +33,7 @@ class SlotNameEnum(enum.IntEnum):
 
     @classmethod
     def getNext(cls) -> int:
-        return cls.getLast() + 1
+        return cls._generate_next_value_('', cls.getFirst(), len(cls), list(cls))
 
     @classmethod
     def getPairs(cls) -> List[Tuple[str, int]]:
@@ -48,3 +48,6 @@ class SlotNameEnum(enum.IntEnum):
                                     chain(cls.getPairs(),
                                           extra_enum.getPairs())))
 
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return 0 if count == 0 else last_values[-1] + 1

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,0 +1,7 @@
+import enum
+
+class SlotNameEnum(enum.IntEnum):
+    @classmethod
+    def asNameList(cls):
+        return [item.name.replace('_', ' ').title() for item in cls]
+

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -108,9 +108,6 @@ class PixelClassificationWorkflow(Workflow):
         self.dataSelectionApplet = self.createDataSelectionApplet()
         opDataSelection = self.dataSelectionApplet.topLevelOperator
 
-        # see role constants, above
-        opDataSelection.DatasetRoles.setValue(self.Roles.asNameList())
-
         self.featureSelectionApplet = self.createFeatureSelectionApplet()
 
         self.pcApplet = self.createPixelClassificationApplet()
@@ -161,12 +158,14 @@ class PixelClassificationWorkflow(Workflow):
         for perm in itertools.permutations('tzyx', 4):
             c_at_end.append(''.join(perm) + 'c')
 
-        return DataSelectionApplet(self,
+        appl = DataSelectionApplet(self,
                                    "Input Data",
                                    "Input Data",
                                    supportIlastik05Import=True,
                                    instructionText=data_instructions,
                                    forceAxisOrder=c_at_end)
+        appl.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
+        return appl
 
     def createFeatureSelectionApplet(self):
         """

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -221,8 +221,7 @@ class PixelClassificationWorkflow(Workflow):
         opTrainingFeatures.InputImage.connect( opData.Image )
         opClassify.InputImages.connect( opData.Image )
 
-        if ilastik_config.getboolean('ilastik', 'debug'):
-            opClassify.PredictionMasks.connect( opData.ImageGroup[self.Roles.PREDICTION_MASK] )
+        opClassify.PredictionMasks.connect( opData.ImageGroup[self.Roles.PREDICTION_MASK] )
 
         # Feature Images -> Classification Op (for training, prediction)
         opClassify.FeatureImages.connect( opTrainingFeatures.OutputImage )

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -48,12 +48,12 @@ class PixelClassificationWorkflow(Workflow):
 
     @enum.unique
     class Roles(SlotNameEnum):
-        RAW_DATA = 0
+        RAW_DATA = enum.auto()
         PREDICTION_MASK = enum.auto()
 
     @enum.unique
     class ExportNames(SlotNameEnum):
-        PROBABILITIES = 0
+        PROBABILITIES = enum.auto()
         SIMPLE_SEGMENTATION = enum.auto()
         UNCERTAINTY = enum.auto()
         FEATURES = enum.auto()
@@ -158,14 +158,14 @@ class PixelClassificationWorkflow(Workflow):
         for perm in itertools.permutations('tzyx', 4):
             c_at_end.append(''.join(perm) + 'c')
 
-        appl = DataSelectionApplet(self,
-                                   "Input Data",
-                                   "Input Data",
-                                   supportIlastik05Import=True,
-                                   instructionText=data_instructions,
-                                   forceAxisOrder=c_at_end)
-        appl.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
-        return appl
+        applet = DataSelectionApplet(self,
+                                     "Input Data",
+                                     "Input Data",
+                                     supportIlastik05Import=True,
+                                     instructionText=data_instructions,
+                                     forceAxisOrder=c_at_end)
+        applet.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
+        return applet
 
     def createFeatureSelectionApplet(self):
         """

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -117,6 +117,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
 
     if ilastik_config.getboolean("ilastik", "debug"):
         message = 'Starting ilastik in debug mode from "%s".' % ilastik_dir
+        logging.basicConfig(level=logging.DEBUG)
         logger.info(message)
         print(message)     # always print the startup message
     else:


### PR DESCRIPTION
# Cleaning up Pixel Classification Workflow code and enabling usage of masks

Depends on https://github.com/ilastik/lazyflow/pull/290

This PR cleans up some of the code in PixelClassificationWorkflow by introducing SlotNameEnum which removes some of the magical constants used throughout the code.

It also enables the use of masks when doing pixel classification, which avoids computations on ROIs completely covered by 0-valued pixels.

## Usage:

### Without mask:

```
time python3 ilastik/ilastik.py \
    --headless --project ~/testProjects/trainedProject.ilp \
    --export_source="Probabilities"  --output_filename_format /tmp/headlessTestNoMask.h5  \
    --raw_data ~/SampleData/fakeMaskData/fakeData.png
```

### With mask (i.e.: using the --prediciton_mask argument):

```
time python3 ilastik/ilastik.py \
    --headless --project ~/testProjects/trainedFakeProject.ilp \
    --export_source="Probabilities"  --output_filename_format /tmp/headlessTest.h5 \
    --prediction_mask ~/SampleData/fakeMaskData/fakeMask.png  \
    --raw_data ~/SampleData/fakeMaskData/fakeData.png
```



## ~~Issues:~~
~~When using big images (10000^2 px .png images in my tetsts), the GUI will run into some race conditions, which I think is due to the slots that provide the raw/mask data not being ready to fetch the needed pixels yet. You can reproduce it by:~~

- ~~Creating a new `Pixel Classification Workflow` project;~~
- ~~Loading some big `Raw Data` and `Mask`;~~
- ~~Immediately zooming out very quickly in the mask view;~~
- ~~Quickly switching to the `Feature Selection` applet;~~
- ~~Quickly clicking the `Select Features...` button.~~

The issue I had detected is unrelated to the masking stuff. I'll open a bug report for it, though.
I have run into no issues in headless mode, though.
