### PR TITLE
Move tracking export lugins to trackingExportApplet. 

### DIFF
--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -52,7 +52,7 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
         title,
         is_batch: bool = False,
         default_export_filename: str = '',
-        doPluginExport: Optional[PluginExportCallable] = None
+        pluginExportFunc: Optional[PluginExportCallable] = None
     ):
         self.export_op = None
         self._default_export_filename = default_export_filename
@@ -66,7 +66,7 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
             SerialDictSlot(self.topLevelOperator.AdditionalPluginArguments)
         ]
         self._serializers = [DataExportSerializer(self.topLevelOperator, title, extra_serial_slots)]
-        self._doPluginExport = doPluginExport
+        self._pluginExportFunc = pluginExportFunc
 
         super(TrackingBaseDataExportApplet, self).__init__(workflow, title, isBatch=is_batch)
 
@@ -79,7 +79,7 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
 
     @property
     def supports_plugins(self):
-        return self._doPluginExport is not None
+        return self._pluginExportFunc is not None
 
     def getMultiLaneGui(self):
         if self._gui is None:
@@ -243,9 +243,10 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
 
         self.progressSignal(-1)
 
-        status = self._doPluginExport(lane_index, filename, plugin, checkOverwriteFiles, argsSlot)
-
-        self.progressSignal(100)
+        try:
+            status = self._pluginExportFunc(lane_index, filename, plugin, checkOverwriteFiles, argsSlot)
+        finally:
+            self.progressSignal(100)
 
         if not status:
             return False

--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -228,14 +228,10 @@ class TrackingBaseDataExportApplet( DataExportApplet ):
         logger.info("Exporting tracking result using %s", pluginName)
 
         name_format = self.topLevelOperator.getLane(lane_index).OutputFilenameFormat.value
-        partially_formatted_name = self.getPartiallyFormattedName(lane_index, name_format)
+        filename = self.getPartiallyFormattedName(lane_index, name_format)
 
-        if plugin.exportsToFile:
-            filename = partially_formatted_name
-            if os.path.basename(filename) == '':
-                filename = os.path.join(filename, 'pluginExport.txt')
-        else:
-            filename = partially_formatted_name
+        if plugin.exportsToFile and not os.path.basename(filename):
+            filename = os.path.join(filename, 'pluginExport.txt')
 
         if not filename:
             logger.error("Cannot export from plugin with empty output filename")

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -47,11 +47,13 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
     def gui_applet(self):
         return self.parentApplet
 
-    def __init__(self, *args, **kwargs):
-        super(TrackingBaseDataExportGui, self).__init__(*args, **kwargs)
+    def __init__(self, applet, op, enable_plugins, *args, **kwargs):
+        self._enable_plugins = enable_plugins
         self.pluginWasSelected = False
         self._exporting_operator = None
         self._default_export_filename = None
+
+        super(TrackingBaseDataExportGui, self).__init__(applet, op, *args, **kwargs)
 
     def get_feature_names(self):
         op = self.get_exporting_operator()
@@ -156,7 +158,7 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
     def _initAppletDrawerUic(self):
         # first check whether "Plugins" should be made available
         availableExportPlugins = self._getAvailablePlugins()
-        if len(availableExportPlugins) > 0:
+        if self._enable_plugins and len(availableExportPlugins) > 0:
             self._includePluginOnlyOption()
 
         super()._initAppletDrawerUic()

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -162,6 +162,7 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
             self._includePluginOnlyOption()
 
         super()._initAppletDrawerUic()
+        self.topLevelOperator.SelectedExportSource.setValue(self.drawer.inputSelectionCombo.currentText())
 
         def _handleDirty(slot, roi):
             sourceName = slot.value

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -158,7 +158,7 @@ class TrackingBaseDataExportGui( DataExportGui, ExportingGui ):
     def _initAppletDrawerUic(self):
         # first check whether "Plugins" should be made available
         availableExportPlugins = self._getAvailablePlugins()
-        if self._enable_plugins and len(availableExportPlugins) > 0:
+        if self._enable_plugins and availableExportPlugins:
             self._includePluginOnlyOption()
 
         super()._initAppletDrawerUic()

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 
-from ilastik.plugins import PluginExportContext
+from ilastik.plugins import PluginExportContext, TrackingExportFormatPlugin
 from lazyflow.rtype import List
 from lazyflow.stype import Opaque
 
@@ -610,7 +610,13 @@ class OpConservationTracking(Operator):
 
         return opRelabeledRegionFeatures
 
-    def exportPlugin(self, filename, plugin, checkOverwriteFiles=False, additionalPluginArgumentsSlot=None):
+    def exportPlugin(
+        self,
+        filename: str,
+        plugin: TrackingExportFormatPlugin,
+        checkOverwriteFiles: bool = False,
+        additionalPluginArgumentsSlot = None
+    ):
         if checkOverwriteFiles and plugin.checkFilesExist(filename):
             logger.info("Tracking export files already exist. Tracking export skipped")
             # do not export if we would otherwise overwrite files

--- a/ilastik/applets/tracking/manual/opManualTracking.py
+++ b/ilastik/applets/tracking/manual/opManualTracking.py
@@ -59,6 +59,7 @@ class OpManualTracking(Operator, ExportingOperator):
     # Override functions ExportingOperator mixin
     def configure_table_export_settings(self, settings, selected_features):
         self.ExportSettings.setValue( (settings, selected_features) )
+
     def get_table_export_settings(self):
         if self.ExportSettings.ready():
             (settings, selected_features) = self.ExportSettings.value
@@ -228,7 +229,7 @@ class OpManualTracking(Operator, ExportingOperator):
         :param filename_suffix: If provided, appended to the filename (before the extension).
         :return:
         """
-        
+
         obj_count = list(objects_per_frame(self.LabelImage))  # slow
         divisions = self.divisions
         t_range = (0, self.LabelImage.meta.shape[self.LabelImage.meta.axistags.index("t")])

--- a/ilastik/plugins.py
+++ b/ilastik/plugins.py
@@ -157,7 +157,7 @@ class TrackingExportFormatPlugin(IPlugin):
     def __init__(self, *args, **kwargs):
         super(TrackingExportFormatPlugin, self).__init__(*args, **kwargs)
 
-    def checkFilesExist(self, filename):
+    def checkFilesExist(self, filename: str) -> bool:
         ''' Check whether the files we want to export (when appending the base filename) are already present '''
         return False
 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -111,7 +111,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
             self,
             "Tracking Result Export",
             default_export_filename=self.default_export_filename,
-            doPluginExport=self._doPluginExport,
+            pluginExportFunc=self._pluginExportFunc,
         )
 
         opDataExport = self.dataExportApplet.topLevelOperator
@@ -359,7 +359,7 @@ class ConservationTrackingWorkflowBase( Workflow ):
             withBatchProcessing = True
         )
 
-    def _doPluginExport(self, lane_index, filename, exportPlugin, checkOverwriteFiles, plugArgsSlot) -> int:
+    def _pluginExportFunc(self, lane_index, filename, exportPlugin, checkOverwriteFiles, plugArgsSlot) -> int:
         return (
             self.trackingApplet
             .topLevelOperator

--- a/ilastik/workflows/tracking/manual/manualTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/manual/manualTrackingWorkflow.py
@@ -155,9 +155,6 @@ class ManualTrackingWorkflow( Workflow ):
 
         return input_ready
 
-    def _doPluginExport(self, lane_index: int, *args, **kwargs):
-        return self.trackingApplet.topLevelOperator.getLane(lane_index).exportPlugin(*args, **kwargs)
-
     def handleAppletStateUpdateRequested(self):
         """
         Overridden from Workflow base class

--- a/ilastik/workflows/tracking/manual/manualTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/manual/manualTrackingWorkflow.py
@@ -68,9 +68,11 @@ class ManualTrackingWorkflow( Workflow ):
         
         self.trackingApplet = ManualTrackingApplet( workflow=self )
         self.default_export_filename = '{dataset_dir}/{nickname}-exported_data.csv'
-        self.dataExportApplet = TrackingBaseDataExportApplet(self, 
-                                                             "Tracking Result Export", 
-                                                             default_export_filename=self.default_export_filename)
+        self.dataExportApplet = TrackingBaseDataExportApplet(
+            self,
+            "Tracking Result Export",
+            default_export_filename=self.default_export_filename,
+        )
         
         opDataExport = self.dataExportApplet.topLevelOperator
         opDataExport.SelectionNames.setValue( ['Manual Tracking', 'Object Identities'] )
@@ -79,7 +81,7 @@ class ManualTrackingWorkflow( Workflow ):
         # Extra configuration for object export table (as CSV table or HDF5 table)
         opTracking = self.trackingApplet.topLevelOperator
         self.dataExportApplet.set_exporting_operator(opTracking)
-        self.dataExportApplet.post_process_lane_export = self.post_process_lane_export
+        #self.dataExportApplet.post_process_lane_export = self.post_process_lane_export
         
         self._applets = []        
         self._applets.append(self.dataSelectionApplet)        
@@ -152,6 +154,9 @@ class ManualTrackingWorkflow( Workflow ):
             input_ready = False
 
         return input_ready
+
+    def _doPluginExport(self, lane_index: int, *args, **kwargs):
+        return self.trackingApplet.topLevelOperator.getLane(lane_index).exportPlugin(*args, **kwargs)
 
     def handleAppletStateUpdateRequested(self):
         """

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -133,7 +133,12 @@ class StructuredTrackingWorkflowBase( Workflow ):
         opStructuredTracking._solver = self._solver
 
         self.default_tracking_export_filename = '{dataset_dir}/{nickname}-tracking_exported_data.csv'
-        self.dataExportTrackingApplet = TrackingBaseDataExportApplet(self, "Tracking Result Export",default_export_filename=self.default_tracking_export_filename)
+        self.dataExportTrackingApplet = TrackingBaseDataExportApplet(
+            self,
+            "Tracking Result Export",
+            default_export_filename=self.default_tracking_export_filename,
+            doPluginExport=self._doPluginExport
+        )
         opDataExportTracking = self.dataExportTrackingApplet.topLevelOperator
         opDataExportTracking.SelectionNames.setValue( ['Tracking-Result', 'Merger-Result', 'Object-Identities'] )
         opDataExportTracking.WorkingDirectory.connect( opDataSelection.WorkingDirectory )
@@ -192,6 +197,19 @@ class StructuredTrackingWorkflowBase( Workflow ):
 
         if unused_args:
             logger.warning("Unused command-line args: {}".format( unused_args ))
+
+    def _doPluginExport(self, lane_index, filename, exportPlugin, checkOverwriteFiles, plugArgsSlot) -> int:
+        return (
+            self.trackingApplet
+            .topLevelOperator
+            .getLane(lane_index)
+            .exportPlugin(
+                filename,
+                exportPlugin,
+                checkOverwriteFiles,
+                additionalPluginArgumentsSlot
+            )
+        )
 
     def connectLane(self, laneIndex):
         opData = self.dataSelectionApplet.topLevelOperator.getLane(laneIndex)
@@ -436,67 +454,6 @@ class StructuredTrackingWorkflowBase( Workflow ):
             assert linkingFlag, "Transition results are NOT correct. They differ from your annotated transitions."
             logger.info("Transition results are correct.")
         self.result = runLearningAndTracking(withMergerResolution=parameters['withMergerResolution'])
-
-    def post_process_lane_export(self, lane_index, checkOverwriteFiles=False):
-        # Plugin export if selected
-        logger.info("Export source is: " + self.dataExportTrackingApplet.topLevelOperator.SelectedExportSource.value)
-
-        print("in post_process_lane_export")
-        if self.dataExportTrackingApplet.topLevelOperator.SelectedExportSource.value == OpTrackingBaseDataExport.PluginOnlyName:
-            logger.info("Export source plugin selected!")
-            selectedPlugin = self.dataExportTrackingApplet.topLevelOperator.SelectedPlugin.value
-            additionalPluginArgumentsSlot = self.dataExportTrackingApplet.topLevelOperator.AdditionalPluginArguments
-
-            exportPluginInfo = pluginManager.getPluginByName(selectedPlugin, category="TrackingExportFormats")
-            if exportPluginInfo is None:
-                logger.error("Could not find selected plugin %s" % exportPluginInfo)
-            else:
-                exportPlugin = exportPluginInfo.plugin_object
-                logger.info("Exporting tracking result using %s" % selectedPlugin)
-                name_format = self.dataExportTrackingApplet.topLevelOperator.getLane(lane_index).OutputFilenameFormat.value
-                partially_formatted_name = self.getPartiallyFormattedName(lane_index, name_format)
-
-                if exportPlugin.exportsToFile:
-                    filename = partially_formatted_name
-                    if os.path.basename(filename) == '':
-                        filename = os.path.join(filename, 'pluginExport.txt')
-                else:
-                    filename = partially_formatted_name
-
-                if filename is None or len(str(filename)) == 0:
-                    logger.error("Cannot export from plugin with empty output filename")
-                    return True
-
-                self.dataExportTrackingApplet.progressSignal(-1)
-                exportStatus = self.trackingApplet.topLevelOperator.getLane(lane_index).exportPlugin(
-                    filename, exportPlugin, checkOverwriteFiles, additionalPluginArgumentsSlot)
-                self.dataExportTrackingApplet.progressSignal(100)
-
-                if not exportStatus:
-                    return False
-                logger.info("Export done")
-
-            return True
-
-        return True
-
-    def getPartiallyFormattedName(self, lane_index, path_format_string):
-        ''' Takes the format string for the output file, fills in the most important placeholders, and returns it '''
-        raw_dataset_info = self.dataSelectionApplet.topLevelOperator.DatasetGroup[lane_index][0].value
-        project_path = self.shell.projectManager.currentProjectPath
-        project_dir = os.path.dirname(project_path)
-        dataset_dir = PathComponents(raw_dataset_info.filePath).externalDirectory
-        abs_dataset_dir = make_absolute(dataset_dir, cwd=project_dir)
-        known_keys = {}
-        known_keys['dataset_dir'] = abs_dataset_dir
-        nickname = raw_dataset_info.nickname.replace('*', '')
-        if os.path.pathsep in nickname:
-            nickname = PathComponents(nickname.split(os.path.pathsep)[0]).fileNameBase
-        known_keys['nickname'] = nickname
-        known_keys['result_type'] = self.dataExportTrackingApplet.topLevelOperator.SelectedPlugin._value
-        # use partial formatting to fill in non-coordinate name fields
-        partially_formatted_name = format_known_keys(path_format_string, known_keys)
-        return partially_formatted_name
 
     def _inputReady(self, nRoles):
         slot = self.dataSelectionApplet.topLevelOperator.ImageGroup

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -137,7 +137,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
             self,
             "Tracking Result Export",
             default_export_filename=self.default_tracking_export_filename,
-            doPluginExport=self._doPluginExport
+            pluginExportFunc=self._pluginExportFunc
         )
         opDataExportTracking = self.dataExportTrackingApplet.topLevelOperator
         opDataExportTracking.SelectionNames.setValue( ['Tracking-Result', 'Merger-Result', 'Object-Identities'] )
@@ -197,7 +197,7 @@ class StructuredTrackingWorkflowBase( Workflow ):
         if unused_args:
             logger.warning("Unused command-line args: {}".format( unused_args ))
 
-    def _doPluginExport(self, lane_index, filename, exportPlugin, checkOverwriteFiles, plugArgsSlot) -> int:
+    def _pluginExportFunc(self, lane_index, filename, exportPlugin, checkOverwriteFiles, plugArgsSlot) -> int:
         return (
             self.trackingApplet
             .topLevelOperator

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -144,7 +144,6 @@ class StructuredTrackingWorkflowBase( Workflow ):
         opDataExportTracking.WorkingDirectory.connect( opDataSelection.WorkingDirectory )
         self.dataExportTrackingApplet.set_exporting_operator(opStructuredTracking)
         self.dataExportTrackingApplet.prepare_lane_for_export = self.prepare_lane_for_export
-        self.dataExportTrackingApplet.post_process_lane_export = self.post_process_lane_export
 
         # configure export settings
         settings = {'file path': self.default_tracking_export_filename, 'compression': {}, 'file type': 'h5'}


### PR DESCRIPTION
Plugins export shouldn't be available for manual tracking since all plugins assume the existence of hypothesisGraph which is absent in manual tracking.