### PR TITLE
Implementing mask atlas

### DIFF
--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -876,22 +876,10 @@ class LabelingGui(LayerViewerGui):
 
         # Raw Input Layer
         if self._rawInputSlot is not None and self._rawInputSlot.ready():
-            layer = self.createStandardLayerFromSlot(self._rawInputSlot)
-            layer.name = "Raw Input"
-            layer.visible = True
-            layer.opacity = 1.0
-
-            # the flag window_leveling is used to determine if the contrast
-            # of the layer is adjustable
-            if isinstance(layer, GrayscaleLayer):
-                layer.window_leveling = True
-            else:
-                layer.window_leveling = False
-
+            layer = self.createStandardLayerFromSlot(self._rawInputSlot, name="Raw Input")
             layers.append(layer)
 
-            # The thresholding button can only be used if the data is displayed as grayscale.
-            if layer.window_leveling:
+            if isinstance(layer, GrayscaleLayer):
                 self.labelingDrawerUi.thresToolButton.show()
             else:
                 self.labelingDrawerUi.thresToolButton.hide()

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -568,6 +568,7 @@ class ObjectClassificationGui(LabelingGui):
         layers = super(ObjectClassificationGui, self).setupLayers()
 
         binarySlot = self.op.BinaryImages
+        atlas_slot = self.op.Atlas
         segmentedSlot = self.op.SegmentationImages
         #This is just for colors
         labels = self.labelListData
@@ -691,6 +692,9 @@ class ObjectClassificationGui(LabelingGui):
             binLayer.opacity = 1.0
             binLayer.setToolTip("Segmentation results as a binary mask")
             layers.append(binLayer)
+
+        if atlas_slot.ready():
+            layers.append(self.createStandardLayerFromSlot(atlas_slot, name="Atlas", opacity=0.5))
 
         # since we start with existing labels, it makes sense to start
         # with the first one selected. This would make more sense in

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -70,6 +70,7 @@ class OpObjectClassification(Operator, ExportingOperator, MultiLaneOperatorABC):
     ###############
     BinaryImages = InputSlot(level=1) # for visualization
     RawImages = InputSlot(level=1) # for visualization
+    Atlas = InputSlot(level=1, optional=True) # for visualization
     SegmentationImages = InputSlot(level=1) #connected components
 
     # the actual feature arrays

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -595,13 +595,14 @@ class OpRegionFeatures(Operator):
         atlas_mapping = numpy.zeros(num_center_points * num_channels_in_atlas)
         atlas_mapping = atlas_mapping.reshape(num_center_points, num_channels_in_atlas)
         for objIdx, center_coords in enumerate(region_centers):
+            rounded_coords = center_coords.round().astype(numpy.uint64)
             slicing = [0] * len(axes)
             slicing[axes['c']] = slice(None)
 
-            slicing[axes['x']] = round(center_coords[0])
-            slicing[axes['y']] = round(center_coords[1])
+            slicing[axes['x']] = rounded_coords[0]
+            slicing[axes['y']] = rounded_coords[1]
             if len(center_coords) == 3:
-                slicing[axes['z']] = round(center_coords[2])
+                slicing[axes['z']] = rounded_coords[2]
 
             atlas_value = atlasImage[slicing]
             atlas_mapping[objIdx] = atlas_value

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -595,14 +595,15 @@ class OpRegionFeatures(Operator):
         atlas_mapping = numpy.zeros(num_center_points * num_channels_in_atlas)
         atlas_mapping = atlas_mapping.reshape(num_center_points, num_channels_in_atlas)
         for objIdx, center_coords in enumerate(region_centers):
-            slicing = numpy.zeros(len(axes)).astype(numpy.uint32)
+            slicing = [0] * len(axes)
+            slicing[axes['c']] = slice(None)
 
-            slicing[axes['x']] = center_coords[0]
-            slicing[axes['y']] = center_coords[1]
+            slicing[axes['x']] = round(center_coords[0])
+            slicing[axes['y']] = round(center_coords[1])
             if len(center_coords) == 3:
-                slicing[axes['z']] = center_coords[2]
+                slicing[axes['z']] = round(center_coords[2])
 
-            atlas_value = atlasImage[tuple(slicing)]
+            atlas_value = atlasImage[slicing]
             atlas_mapping[objIdx] = atlas_value
         return atlas_mapping
 

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -114,6 +114,7 @@ def make_bboxes(binary_bbox, margin):
 class OpCachedRegionFeatures(Operator):
     """Caches the region features computed by OpRegionFeatures."""
     RawImage = InputSlot()
+    Atlas = InputSlot(optional=True)
     LabelImage = InputSlot()
     CacheInput = InputSlot(optional=True)
     Features = InputSlot(rtype=List, stype=Opaque)
@@ -135,6 +136,7 @@ class OpCachedRegionFeatures(Operator):
         # Hook up the actual region features operator
         self._opRegionFeatures = OpRegionFeatures(parent=self)
         self._opRegionFeatures.RawVolume.connect(self.RawImage)
+        self._opRegionFeatures.Atlas.connect(self.Atlas)
         self._opRegionFeatures.LabelVolume.connect(self.LabelImage)
         self._opRegionFeatures.Features.connect(self.Features)
 
@@ -304,6 +306,7 @@ class OpObjectExtraction(Operator):
 
     RawImage = InputSlot()
     BinaryImage = InputSlot()
+    Atlas = InputSlot(optional=True)
     BackgroundLabels = InputSlot(optional=True)
 
     # Bypass cache (for headless mode)
@@ -363,6 +366,7 @@ class OpObjectExtraction(Operator):
         self._opRegFeats.RawImage.connect(self.RawImage)
         self._opRegFeats.LabelImage.connect(self._opLabelVolume.CachedOutput)
         self._opRegFeats.Features.connect(self.Features)
+        self._opRegFeats.Atlas.connect(self.Atlas) #move into constructor?
         self.RegionFeaturesCleanBlocks.connect(self._opRegFeats.CleanBlocks)
 
         self._opRegFeats.CacheInput.connect(self.RegionFeaturesCacheInput)
@@ -451,6 +455,7 @@ class OpRegionFeatures(Operator):
 
     """
     RawVolume = InputSlot()
+    Atlas = InputSlot(optional=True)
     LabelVolume = InputSlot()
     Features = InputSlot(rtype=List, stype=Opaque)
 
@@ -483,17 +488,26 @@ class OpRegionFeatures(Operator):
         assert t_ind < len(self.RawVolume.meta.shape)
 
         def compute_features_for_time_slice(res_t_ind, t):
+            axes4d = [k for k in self.RawVolume.meta.getTaggedShape().keys() if k in 'xyzc']
+
             # Process entire spatial volume
-            s = [slice(None) for i in range(len(self.RawVolume.meta.shape))]
+            s = [slice(None)] * len(self.RawVolume.meta.shape)
             s[t_ind] = slice(t, t+1)
             s = tuple(s)
 
             # Request in parallel
             raw_req = self.RawVolume[s]
-            label_req = self.LabelVolume[s]
-
             raw_req.submit()
+
+            label_req = self.LabelVolume[s]
             label_req.submit()
+
+            if self.Atlas.ready():
+                atlasVolume = self.Atlas[s].wait()
+                atlasVolume = vigra.taggedView(atlasVolume, axistags=self.Atlas.meta.axistags)
+                atlasVolume = atlasVolume.withAxes(*axes4d)
+            else:
+                atlasVolume = None
 
             # Get results
             rawVolume = raw_req.wait()
@@ -501,16 +515,14 @@ class OpRegionFeatures(Operator):
 
             rawVolume = vigra.taggedView(rawVolume, axistags=self.RawVolume.meta.axistags)
             labelVolume = vigra.taggedView(labelVolume, axistags=self.LabelVolume.meta.axistags)
-    
+
             # Convert to 4D (preserve axis order)
-            axes4d = list(self.RawVolume.meta.getTaggedShape().keys())
-            axes4d = [k for k in axes4d if k in 'xyzc']
             rawVolume = rawVolume.withAxes(*axes4d)
             labelVolume = labelVolume.withAxes(*axes4d)
-            acc = self._extract(rawVolume, labelVolume)
-            
+            acc = self._extract(rawVolume, labelVolume, atlasVolume)
+
             # Copy into the result
-            result[res_t_ind] = acc            
+            result[res_t_ind] = acc
 
         # loop over requested time slices
         pool = RequestPool()
@@ -576,7 +588,25 @@ class OpRegionFeatures(Operator):
 
         return feature_names_with_default
 
-    def _extract(self, image, labels):
+    def _createAtlasMapping(self, region_centers:numpy.ndarray, atlasImage:numpy.ndarray):
+        axes = {tag.key:idx for idx, tag in  enumerate(atlasImage.axistags)}
+        num_center_points = len(region_centers)
+        num_channels_in_atlas = atlasImage.shape[axes['c']] if 'c' in axes else 1
+        atlas_mapping = numpy.zeros(num_center_points * num_channels_in_atlas)
+        atlas_mapping = atlas_mapping.reshape(num_center_points, num_channels_in_atlas)
+        for objIdx, center_coords in enumerate(region_centers):
+            slicing = numpy.zeros(len(axes)).astype(numpy.uint32)
+
+            slicing[axes['x']] = center_coords[0]
+            slicing[axes['y']] = center_coords[1]
+            if len(center_coords) == 3:
+                slicing[axes['z']] = center_coords[2]
+
+            atlas_value = atlasImage[tuple(slicing)]
+            atlas_mapping[objIdx] = atlas_value
+        return atlas_mapping
+
+    def _extract(self, image, labels, atlas=None):
         if not (image.ndim == labels.ndim == 4):
             raise Exception("both images must be 4D. raw image shape: {}"
                             " label image shape: {}".format(image.shape, labels.shape))
@@ -628,6 +658,9 @@ class OpRegionFeatures(Operator):
             else:
                 feature = global_features["Standard Object Features"][feat_key]
             extrafeats[feat_key] = feature
+
+        if atlas is not None:
+            extrafeats['AtlasMapping'] = self._createAtlasMapping(extrafeats['RegionCenter'], atlas)
 
         extrafeats = dict((k.replace(' ', ''), v)
                           for k, v in extrafeats.items())

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -594,7 +594,7 @@ class OpRegionFeatures(Operator):
         num_channels_in_atlas = atlasImage.shape[axes['c']] if 'c' in axes else 1
         atlas_mapping = numpy.zeros(num_center_points * num_channels_in_atlas)
         atlas_mapping = atlas_mapping.reshape(num_center_points, num_channels_in_atlas)
-        for objIdx, center_coords in enumerate(region_centers):
+        for obj_idx, center_coords in enumerate(region_centers):
             rounded_coords = center_coords.round().astype(numpy.uint64)
             slicing = [0] * len(axes)
             slicing[axes['c']] = slice(None)
@@ -605,7 +605,7 @@ class OpRegionFeatures(Operator):
                 slicing[axes['z']] = rounded_coords[2]
 
             atlas_value = atlasImage[slicing]
-            atlas_mapping[objIdx] = atlas_value
+            atlas_mapping[obj_idx] = atlas_value
         return atlas_mapping
 
     def _extract(self, image, labels, atlas=None):

--- a/ilastik/utility/__init__.py
+++ b/ilastik/utility/__init__.py
@@ -25,3 +25,4 @@ from .operatorSubView import OperatorSubView
 from .opMultiLaneWrapper import OpMultiLaneWrapper
 from .log_exception import log_exception
 from .autocleaned_tempdir import autocleaned_tempdir
+from .slot_name_enum import SlotNameEnum

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,7 +1,50 @@
 import enum
+from typing import List, Tuple
+from itertools import chain
 
 class SlotNameEnum(enum.IntEnum):
+    """A map from slot names to their indices within a multislot
+
+    Do note that the ENUM_NAMEs that you pick matter, as they determine
+    the human readable version that you get from instances of this enum:
+
+    e.g a value defined like so:
+        MY_DATA_SLOT = 123
+    will have its slotName rendered as
+        'My Data Slot'
+    """
+
+    @property
+    def slotName(self) -> str:
+        """A 'Human Readable Slot Name' str based on its ENUM_SLOT_NAME"""
+        return self.name.replace('_', ' ').title()
+
     @classmethod
-    def asNameList(cls):
-        return [item.name.replace('_', ' ').title() for item in cls]
+    def asNameList(cls) -> List[str]:
+        return [item.slotName for item in cls]
+
+    @classmethod
+    def getFirst(cls) -> int:
+        return list(cls)[0]
+
+    @classmethod
+    def getLast(cls) -> int:
+        return list(cls)[-1]
+
+    @classmethod
+    def getNext(cls) -> int:
+        return cls.getLast() + 1
+
+    @classmethod
+    def getPairs(cls) -> List[Tuple[str, int]]:
+        return [(item.name, item.value) for item in cls]
+
+    @classmethod
+    def extendedWithEnum(cls, extra_enum: 'SlotNameEnum', unique: bool=False) -> 'SlotNameEnum':
+        """Crates a new SlotNameEnum combining the keys from cls and extra_enum"""
+
+        wrapper = enum.unique if unique else lambda x: x
+        return wrapper(SlotNameEnum(extra_enum.__name__,
+                                    chain(cls.getPairs(),
+                                          extra_enum.getPairs())))
 

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -33,7 +33,7 @@ class SlotNameEnum(enum.IntEnum):
 
     @classmethod
     def getNext(cls) -> int:
-        return cls.getLast() + 1
+        return cls._generate_next_value_('', cls.getFirst(), len(cls), list(cls))
 
     @classmethod
     def getPairs(cls) -> List[Tuple[str, int]]:
@@ -48,3 +48,6 @@ class SlotNameEnum(enum.IntEnum):
                                     chain(cls.getPairs(),
                                           extra_enum.getPairs())))
 
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return 0 if count == 0 else last_values[-1] + 1

--- a/ilastik/utility/slot_name_enum.py
+++ b/ilastik/utility/slot_name_enum.py
@@ -1,0 +1,7 @@
+import enum
+
+class SlotNameEnum(enum.IntEnum):
+    @classmethod
+    def asNameList(cls):
+        return [item.name.replace('_', ' ').title() for item in cls]
+

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -640,10 +640,12 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         opThreshold = self.thresholdingApplet.topLevelOperator.getLane(laneIndex)
 
         rawslot = self.createRawDataSourceSlot(laneIndex, canonicalOrder=False)
+        atlas_slot = self.createAtlasSourceSlot(laneIndex)
 
         opTrainingFeatures.InputImage.connect(rawslot)
 
         opClassify.InputImages.connect(rawslot)
+        opClassify.PredictionMasks.connect(atlas_slot)
         opClassify.FeatureImages.connect(opTrainingFeatures.OutputImage)
         opClassify.CachedFeatureImages.connect(opTrainingFeatures.CachedOutputImage)
 

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -18,8 +18,7 @@
 # on the ilastik web site at:
 #		   http://ilastik.org/license.html
 ###############################################################################
-from __future__ import division
-from builtins import range
+from abc import abstractmethod
 import sys
 import os
 import enum
@@ -95,10 +94,8 @@ class ObjectClassificationWorkflow(Workflow):
                  workflow_cmdline_args,
                  project_creation_args,
                  *args, **kwargs):
-        graph = kwargs['graph'] if 'graph' in kwargs else Graph()
-        if 'graph' in kwargs:
-            del kwargs['graph']
-        super(ObjectClassificationWorkflow, self).__init__(shell, headless, workflow_cmdline_args, project_creation_args, graph=graph, *args, **kwargs)
+        graph = kwargs.pop('graph') if 'graph' in kwargs else Graph()
+        super().__init__(shell, headless, workflow_cmdline_args, project_creation_args, graph=graph, *args, **kwargs)
         self.stored_object_classifier = None
 
         # Parse workflow-specific command-line args
@@ -178,6 +175,7 @@ class ObjectClassificationWorkflow(Workflow):
         if unused_args:
             logger.warning("Unused command-line args: {}".format( unused_args ))
 
+    @abstractmethod
     def createInputApplets(self):
         self.dataSelectionApplet = DataSelectionApplet( self,
                                                         "Input Data",
@@ -250,6 +248,10 @@ class ObjectClassificationWorkflow(Workflow):
             return op5raw.Output
 
         return rawslot
+
+    @abstractmethod
+    def connectInputs(self, laneIndex):
+        pass
 
     def connectLane(self, laneIndex):
         rawslot, binaryslot = self.connectInputs(laneIndex)

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -627,13 +627,6 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
             self._shell.currentAppletChanged.connect( self.handle_applet_changed )
 
     def connectInputs(self, laneIndex):
-        op5raw = OpReorderAxes(parent=self)
-        op5raw.AxisOrder.setValue("txyzc")
-        op5pred = OpReorderAxes(parent=self)
-        op5pred.AxisOrder.setValue("txyzc")
-        op5threshold = OpReorderAxes(parent=self)
-        op5threshold.AxisOrder.setValue("txyzc")
-        
         ## Access applet operators
         opTrainingFeatures = self.featureSelectionApplet.topLevelOperator.getLane(laneIndex)
         opClassify = self.pcApplet.topLevelOperator.getLane(laneIndex)
@@ -647,14 +640,14 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         opClassify.FeatureImages.connect(opTrainingFeatures.OutputImage)
         opClassify.CachedFeatureImages.connect(opTrainingFeatures.CachedOutputImage)
 
-        op5raw.Input.connect(rawslot)
-        op5pred.Input.connect(opClassify.CachedPredictionProbabilities)
+        op5raw = OpReorderAxes(parent=self, AxisOrder="txyzc", Input=rawslot)
+        op5pred = OpReorderAxes(parent=self, AxisOrder="txyzc", Input=opClassify.CachedPredictionProbabilities)
 
         opThreshold.RawInput.connect(op5raw.Output)
         opThreshold.InputImage.connect(op5pred.Output)
         opThreshold.InputChannelColors.connect( opClassify.PmapColors )
 
-        op5threshold.Input.connect(opThreshold.CachedOutput)
+        op5threshold = OpReorderAxes(parent=self, AxisOrder="txyzc", Input=opThreshold.CachedOutput)
 
         return op5raw.Output, op5threshold.Output
 

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -108,9 +108,6 @@ class PixelClassificationWorkflow(Workflow):
         self.dataSelectionApplet = self.createDataSelectionApplet()
         opDataSelection = self.dataSelectionApplet.topLevelOperator
 
-        # see role constants, above
-        opDataSelection.DatasetRoles.setValue(self.Roles.asNameList())
-
         self.featureSelectionApplet = self.createFeatureSelectionApplet()
 
         self.pcApplet = self.createPixelClassificationApplet()
@@ -161,12 +158,14 @@ class PixelClassificationWorkflow(Workflow):
         for perm in itertools.permutations('tzyx', 4):
             c_at_end.append(''.join(perm) + 'c')
 
-        return DataSelectionApplet(self,
+        appl = DataSelectionApplet(self,
                                    "Input Data",
                                    "Input Data",
                                    supportIlastik05Import=True,
                                    instructionText=data_instructions,
                                    forceAxisOrder=c_at_end)
+        appl.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
+        return appl
 
     def createFeatureSelectionApplet(self):
         """

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -221,8 +221,7 @@ class PixelClassificationWorkflow(Workflow):
         opTrainingFeatures.InputImage.connect( opData.Image )
         opClassify.InputImages.connect( opData.Image )
 
-        if ilastik_config.getboolean('ilastik', 'debug'):
-            opClassify.PredictionMasks.connect( opData.ImageGroup[self.Roles.PREDICTION_MASK] )
+        opClassify.PredictionMasks.connect( opData.ImageGroup[self.Roles.PREDICTION_MASK] )
 
         # Feature Images -> Classification Op (for training, prediction)
         opClassify.FeatureImages.connect( opTrainingFeatures.OutputImage )

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -48,12 +48,12 @@ class PixelClassificationWorkflow(Workflow):
 
     @enum.unique
     class Roles(SlotNameEnum):
-        RAW_DATA = 0
+        RAW_DATA = enum.auto()
         PREDICTION_MASK = enum.auto()
 
     @enum.unique
     class ExportNames(SlotNameEnum):
-        PROBABILITIES = 0
+        PROBABILITIES = enum.auto()
         SIMPLE_SEGMENTATION = enum.auto()
         UNCERTAINTY = enum.auto()
         FEATURES = enum.auto()
@@ -158,14 +158,14 @@ class PixelClassificationWorkflow(Workflow):
         for perm in itertools.permutations('tzyx', 4):
             c_at_end.append(''.join(perm) + 'c')
 
-        appl = DataSelectionApplet(self,
-                                   "Input Data",
-                                   "Input Data",
-                                   supportIlastik05Import=True,
-                                   instructionText=data_instructions,
-                                   forceAxisOrder=c_at_end)
-        appl.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
-        return appl
+        applet = DataSelectionApplet(self,
+                                     "Input Data",
+                                     "Input Data",
+                                     supportIlastik05Import=True,
+                                     instructionText=data_instructions,
+                                     forceAxisOrder=c_at_end)
+        applet.topLevelOperator.DatasetRoles.setValue(self.Roles.asNameList())
+        return applet
 
     def createFeatureSelectionApplet(self):
         """

--- a/ilastik_main.py
+++ b/ilastik_main.py
@@ -117,6 +117,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
 
     if ilastik_config.getboolean("ilastik", "debug"):
         message = 'Starting ilastik in debug mode from "%s".' % ilastik_dir
+        logging.basicConfig(level=logging.DEBUG)
         logger.info(message)
         print(message)     # always print the startup message
     else:


### PR DESCRIPTION
Supersedes and fixes all observations from https://github.com/ilastik/ilastik/pull/1960
Depends on https://github.com/ilastik/lazyflow/pull/293 (new constructor for OpAxesReorder)
Depends on https://github.com/ilastik/lazyflow/pull/290 (cleanup and small fixes to pixel mask usage)

# Implements Masks for pixel classification and Atlases for Object Classification

## Refactoring along the way
Cleans up some of the code in PixelClassificationWorkflow and Object Classification Workflow by introducing SlotNameEnum, removing a lot of code replication and making better use of inheritance in the children of Object Classification Workflow. The SlotNameEnum removes some of the magical constants used throughout the code and ties the names of the slots to its indices. 

As noted in the comments from https://github.com/ilastik/ilastik/pull/1960, this is still not the best solution, and we should probably move over to something like `myOp.myOutput` and `myOp.myOtherOutput` rather than `myOp.Output[myenum.MY_OUTPUT]` and `myOp.Output[myenum.MY_OTHER_OUTPUT]`, but there is a lot of fixing required before we get to that. For the time being, it is still a bit more readable.

## New Features

### Pixel Classification
Enables the use of masks, which avoids computations on ROIs completely covered by 0-valued pixels and discards predictions in the masked pixels of the blocks that actually were picked for computations.

#### Gui Usage:
Just load a mask using the Prediction Mask tab and go through the normal workflow. 0-valued pixels will be masked out.

#### Headless Usage:
```
time python3 ilastik/ilastik.py \
    --headless --project ~/testProjects/trainedFakeProject.ilp \
    --export_source="Probabilities"  --output_filename_format /tmp/headlessTest.h5 \
    --prediction_mask ~/SampleData/fakeMaskData/fakeMask.png  \
    --raw_data ~/SampleData/fakeMaskData/fakeData.png
```


### Object Classification
Enables the use of Atlases when doing object classification. Selecting an image atlas will cause the workflow to map object centers to the color on the same coordinates as the selected Atlas. When using Pixel + Object Classification, the areas of the atlas with 0 value will also be masked out of the pixel classification, just like in the standalone masked Pixel Classification Workflow.

If the user has selected an Atlas image for the workflow, then the exported object table will contain columns labeled `AtlasMapping_<channel index>`, which contain the values of all the channels in the atlas image in the center point of the object being described in that table line. The AtlasMapping values are implemented as part of the `Standard Object Features` and are therefore automatically written to the object table whenever an Atlas is given as input.

#### Gui Usage:
Just load an atlas using the Atlas tab and go through the normal workflow. 0-valued pixels will be masked out in the Pixel  Object Classification Workflow and object centers will be mapped to the colors in the atlas.

#### Headless Usage:
```
./ilastik.py --headless --project ~/myProj.ilp \
                --prediction_map ~/myPredictions.h5 \
                --raw_data ~/myRawData.png \
                --atlas ~/myAtlas.png \
                --table_filename=/tmp/myobjtable.csv  
```
