### PR TITLE
PixelClassificationGui: Fixes recursive FreezePredictions dirty event and cleans up code

### DIFF
--- a/ilastik/applets/pixelClassification/FeatureSelectionDialog.py
+++ b/ilastik/applets/pixelClassification/FeatureSelectionDialog.py
@@ -89,7 +89,7 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
     def __init__(
             self,
             current_opFeatureSelection,
-            current_opPixelClassification,
+            current_opPixelClassificationApplet,
             labels_list_data
         ):
         '''
@@ -99,7 +99,8 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
         '''
         super(FeatureSelectionDialog, self).__init__()
 
-        self.opPixelClassification = current_opPixelClassification
+        self.pixelClassificationApplet = current_opPixelClassificationApplet
+        self.opPixelClassification = current_opPixelClassificationApplet.topLevelOperatorView
         self.opFeatureSelection = current_opFeatureSelection
 
         self._init_feature_matrix = False
@@ -589,8 +590,8 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
 
         start_time = times()[4]
 
-        old_freeze_prediction_value = self.opPixelClassification.FreezePredictions.value
-        self.opPixelClassification.FreezePredictions.setValue(False)
+        old_live_update_value = self.pixelClassificationApplet.getLiveUpdateFlag()
+        self.pixelClassificationApplet.setLiveUpdateFlag(True)
 
         # retrieve segmentation layer(s)
         slice_shape = self.raw_xy_slice.shape[:2]
@@ -626,7 +627,7 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
             self.opFeatureSelection.SelectionMatrix.setDirty() # this does not do anything!?!?
             self.opFeatureSelection.setupOutputs()
 
-        self.opPixelClassification.FreezePredictions.setValue(old_freeze_prediction_value)
+        self.pixelClassificationApplet.setLiveUpdateFlag(old_live_update_value)
 
         return segmentation, oob_err, end_time-start_time
 

--- a/ilastik/applets/pixelClassification/FeatureSelectionDialog.py
+++ b/ilastik/applets/pixelClassification/FeatureSelectionDialog.py
@@ -89,7 +89,7 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
     def __init__(
             self,
             current_opFeatureSelection,
-            current_opPixelClassificationApplet,
+            current_pixelClassificationApplet,
             labels_list_data
         ):
         '''
@@ -99,8 +99,8 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
         '''
         super(FeatureSelectionDialog, self).__init__()
 
-        self.pixelClassificationApplet = current_opPixelClassificationApplet
-        self.opPixelClassification = current_opPixelClassificationApplet.topLevelOperatorView
+        self.pixelClassificationApplet = current_pixelClassificationApplet
+        self.opPixelClassification = current_pixelClassificationApplet.topLevelOperatorView
         self.opFeatureSelection = current_opFeatureSelection
 
         self._init_feature_matrix = False
@@ -590,8 +590,8 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
 
         start_time = times()[4]
 
-        old_live_update_value = self.pixelClassificationApplet.getLiveUpdateFlag()
-        self.pixelClassificationApplet.setLiveUpdateFlag(True)
+        old_live_update_value = self.pixelClassificationApplet.isLiveUpdateEnabled()
+        self.pixelClassificationApplet.setLiveUpdateEnabled(True)
 
         # retrieve segmentation layer(s)
         slice_shape = self.raw_xy_slice.shape[:2]
@@ -627,7 +627,7 @@ class FeatureSelectionDialog(QtWidgets.QDialog):
             self.opFeatureSelection.SelectionMatrix.setDirty() # this does not do anything!?!?
             self.opFeatureSelection.setupOutputs()
 
-        self.pixelClassificationApplet.setLiveUpdateFlag(old_live_update_value)
+        self.pixelClassificationApplet.setLiveUpdateEnabled(old_live_update_value)
 
         return segmentation, oob_err, end_time-start_time
 

--- a/ilastik/applets/pixelClassification/labelingDrawer.ui
+++ b/ilastik/applets/pixelClassification/labelingDrawer.ui
@@ -183,8 +183,17 @@
        <property name="checkable">
         <bool>true</bool>
        </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
        <property name="toolButtonStyle">
         <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+       <property name="icon">
+        <iconset>
+          <normalon>../../shell/gui/icons/16x16/actions/media-playback-pause.png</normalon>
+          <normaloff>../../shell/gui/icons/16x16/actions/media-playback-start.png</normaloff>
+        </iconset>
        </property>
       </widget>
      </item>

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -421,18 +421,11 @@ class PixelClassificationGui(LabelingGui):
 
         self.topLevelOperatorView = topLevelOperatorView
 
-        self.interactiveModeActive = False
-        # Immediately update our interactive state
-        self.toggleInteractive( not self.topLevelOperatorView.FreezePredictions.value )
-
         self._currentlySavingPredictions = False
 
         self.labelingDrawerUi.labelListView.support_merges = True
 
-        self.labelingDrawerUi.liveUpdateButton.setEnabled(False)
-        self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Play))
-        self.labelingDrawerUi.liveUpdateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
-        self.labelingDrawerUi.liveUpdateButton.toggled.connect( self.toggleInteractive )
+        self.labelingDrawerUi.liveUpdateButton.toggled.connect(self.setLiveUpdateFlag)
 
         self.initFeatSelDlg()
         self.labelingDrawerUi.suggestFeaturesButton.clicked.connect(self.show_feature_selection_dialog)
@@ -442,9 +435,6 @@ class PixelClassificationGui(LabelingGui):
         # Always force at least two labels because it makes no sense to have less here
         self.forceAtLeastTwoLabels(True)
 
-        self.topLevelOperatorView.LabelNames.notifyDirty( bind(self.handleLabelSelectionChange) )
-        self.__cleanup_fns.append( partial( self.topLevelOperatorView.LabelNames.unregisterDirty, bind(self.handleLabelSelectionChange) ) )
-        
         self._initShortcuts()
 
         self._bookmarks_window = BookmarksWindow(self, self.topLevelOperatorView)
@@ -467,13 +457,7 @@ class PixelClassificationGui(LabelingGui):
             except:
                 self.render = False
 
-        # toggle interactive mode according to freezePredictions.value
-        self.toggleInteractive(not self.topLevelOperatorView.FreezePredictions.value)
-        def FreezePredDirty():
-            self.toggleInteractive(not self.topLevelOperatorView.FreezePredictions.value)
-        # listen to freezePrediction changes
-        self.topLevelOperatorView.FreezePredictions.notifyDirty( bind(FreezePredDirty) )
-        self.__cleanup_fns.append( partial( self.topLevelOperatorView.FreezePredictions.unregisterDirty, bind(FreezePredDirty) ) )
+        self.setLiveUpdateFlag(False)
 
     def initFeatSelDlg(self):
         if self.topLevelOperatorView.name=="OpPixelClassification":
@@ -491,7 +475,7 @@ class PixelClassificationGui(LabelingGui):
 
         self.featSelDlg = FeatureSelectionDialog(
             thisOpFeatureSelection,
-            self.topLevelOperatorView,
+            self,
             self.labelListData
             )
 
@@ -718,46 +702,42 @@ class PixelClassificationGui(LabelingGui):
                 ref_label.pmapColorChanged.connect(setLayerColor)
                 ref_label.nameChanged.connect(setPredLayerName)
                 layers.append(predictLayer)
-        
-        self.handleLabelSelectionChange()
         return layers
 
-    def toggleInteractive(self, checked):
-        logger.debug("toggling interactive mode to '%r'" % checked)
+    def hasFeatures(self) -> bool:
+        feature_images_slot = self.topLevelOperatorView.FeatureImages
+        return feature_images_slot.ready() and feature_images_slot.meta.shape != None
 
-        if checked==True:
-            if not self.topLevelOperatorView.FeatureImages.ready() \
-            or self.topLevelOperatorView.FeatureImages.meta.shape==None:
-                self.labelingDrawerUi.liveUpdateButton.setChecked(False)
-                self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Play))
-                self.labelingDrawerUi.suggestFeaturesButton.setEnabled(False)
+    def getLiveUpdateFlag(self):
+        return self.labelingDrawerUi.liveUpdateButton.isChecked()
+
+    def setLiveUpdateFlag(self, checked:bool):
+        liveUpdateButton = self.labelingDrawerUi.liveUpdateButton
+        liveUpdateButton.blockSignals(True)
+        liveUpdateButton.setChecked(checked)
+        liveUpdateButton.blockSignals(False)
+
+        self.topLevelOperatorView.FreezePredictions.setValue(not checked)
+
+        if checked and self.hasFeatures():
+            self.labelingDrawerUi.labelListView.allowDelete = False
+            self.labelingDrawerUi.AddLabelButton.setEnabled( False )
+
+            self._viewerControlUi.checkShowPredictions.setChecked( True )
+            self.handleShowPredictionsClicked()
+        else:
+            self.labelingDrawerUi.suggestFeaturesButton.setEnabled(False)
+            if not self.hasFeatures():
                 mexBox=QMessageBox()
                 mexBox.setText("There are no features selected ")
                 mexBox.exec_()
                 return
 
-        # If we're changing modes, enable/disable our controls and other applets accordingly
-        if self.interactiveModeActive != checked:
-            self.interactiveModeActive = checked
-            if checked:
-                self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Pause))
-                self.labelingDrawerUi.labelListView.allowDelete = False
-                self.labelingDrawerUi.AddLabelButton.setEnabled( False )
-            else:
-                self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Play))
-                num_label_classes = self._labelControlUi.labelListModel.rowCount()
-                self.labelingDrawerUi.labelListView.allowDelete = ( num_label_classes > self.minLabelNumber )
-                self.labelingDrawerUi.AddLabelButton.setEnabled( ( num_label_classes < self.maxLabelNumber ) )
+            num_label_classes = self._labelControlUi.labelListModel.rowCount()
+            self.labelingDrawerUi.labelListView.allowDelete = ( num_label_classes > self.minLabelNumber )
+            self.labelingDrawerUi.AddLabelButton.setEnabled( ( num_label_classes < self.maxLabelNumber ) )
 
-            self.labelingDrawerUi.suggestFeaturesButton.setEnabled(not checked)
-            self.labelingDrawerUi.liveUpdateButton.setChecked(checked)
-
-        self.topLevelOperatorView.FreezePredictions.setValue( not checked )
-
-        # Auto-set the "show predictions" state according to what the user just clicked.
-        if checked:
-            self._viewerControlUi.checkShowPredictions.setChecked( True )
-            self.handleShowPredictionsClicked()
+        self.labelingDrawerUi.suggestFeaturesButton.setEnabled(not checked)
 
         # Notify the workflow that some applets may have changed state now.
         # (For example, the downstream pixel classification applet can 
@@ -811,29 +791,6 @@ class PixelClassificationGui(LabelingGui):
             self._viewerControlUi.checkShowSegmentation.setCheckState(Qt.Checked)
         else:
             self._viewerControlUi.checkShowSegmentation.setCheckState(Qt.PartiallyChecked)
-
-    @pyqtSlot()
-    @threadRouted
-    def handleLabelSelectionChange(self):
-        enabled = False
-        if self.topLevelOperatorView.LabelNames.ready():
-            enabled = True
-            enabled &= len(self.topLevelOperatorView.LabelNames.value) >= 2
-            enabled &= numpy.all(numpy.asarray(self.topLevelOperatorView.CachedFeatureImages.meta.shape) > 0)
-            # FIXME: also check that each label has scribbles?
-        
-        if not enabled:
-            self.labelingDrawerUi.liveUpdateButton.setChecked(False)
-            self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Play))
-            self._viewerControlUi.checkShowPredictions.setChecked(False)
-            self._viewerControlUi.checkShowSegmentation.setChecked(False)
-            self.handleShowPredictionsClicked()
-            self.handleShowSegmentationClicked()
-
-        self.labelingDrawerUi.liveUpdateButton.setEnabled(enabled)
-        self.labelingDrawerUi.suggestFeaturesButton.setEnabled(enabled)
-        self._viewerControlUi.checkShowPredictions.setEnabled(enabled)
-        self._viewerControlUi.checkShowSegmentation.setEnabled(enabled)
 
     def _getNext(self, slot, parentFun, transform=None):
         numLabels = self.labelListData.rowCount()


### PR DESCRIPTION
## Done in this PR:

- Removes recursive handling of FreezePredictions dirty event - the handler itself was also setting the value of the slot, firing another event;
- Moves code that deals with visual configuration of the "live update" button into the proper .ui file;
- Cleans up the code a bit.

