### PR TITLE
Dependency upgrade, test with newly build dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ jobs:
     - restore_cache:
         keys:
         # This branch if available
-        - v1.32rc2-dep-{{ .Branch }}-
+        - v1.33b1-dep-{{ .Branch }}-
         # Default branch if not
-        - v1.32rc2-dep-master-
+        - v1.33b1-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.32rc2-dep-
+        - v1.33b1-dep-
     - run: |
         if [[ ! -d ${CONDA_ROOT} ]]; then
             echo "Installing Miniconda...";
@@ -40,9 +40,9 @@ jobs:
         fi
     - run: |
         if [ ! -d ${TEST_ENV_PREFIX} ]; then
-            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
+            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers;
         else
-            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
+            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers;
         fi
     - run: rm -rf ${TEST_ENV_PREFIX}/ilastik-meta
     - run: git clone http://github.com/ilastik/ilastik-meta ${TEST_ENV_PREFIX}/ilastik-meta
@@ -53,7 +53,7 @@ jobs:
     - run: ln -s `pwd` ${TEST_ENV_PREFIX}/ilastik-meta/ilastik
     # Save dependency cache
     - save_cache:
-        key: v1.32rc2-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.33b1-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /home/ubuntu/miniconda
     # Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ jobs:
     - restore_cache:
         keys:
         # This branch if available
-        - v1.33b1-dep-{{ .Branch }}-
+        - v1.33b3-dep-{{ .Branch }}-
         # Default branch if not
-        - v1.33b1-dep-master-
+        - v1.33b3-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.33b1-dep-
+        - v1.33b3-dep-
     - run: |
         if [[ ! -d ${CONDA_ROOT} ]]; then
             echo "Installing Miniconda...";
@@ -40,9 +40,9 @@ jobs:
         fi
     - run: |
         if [ ! -d ${TEST_ENV_PREFIX} ]; then
-            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers;
+            conda create -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
         else
-            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers;
+            conda install -y -n ${TEST_ENV_NAME} -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers;
         fi
     - run: rm -rf ${TEST_ENV_PREFIX}/ilastik-meta
     - run: git clone http://github.com/ilastik/ilastik-meta ${TEST_ENV_PREFIX}/ilastik-meta
@@ -53,7 +53,7 @@ jobs:
     - run: ln -s `pwd` ${TEST_ENV_PREFIX}/ilastik-meta/ilastik
     # Save dependency cache
     - save_cache:
-        key: v1.33b1-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.33b3-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /home/ubuntu/miniconda
     # Test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 
 install:
-  - cmd: CALL %MINICONDA%/Scripts/activate.bat
+  - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
   - cmd: where conda
   - cmd: conda config --set always_yes yes --set changeps1 no
   - cmd: conda update -q conda
@@ -33,7 +33,7 @@ install:
 build: off
 
 test_script:
-  - cmd: CALL %MINICONDA%/Scripts/activate.bat
+  - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
   - cmd: CALL activate %ENV_NAME%
   - cmd: cd \
   - cmd: cd ilastik\ilastik-meta\ilastik\tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,12 @@ environment:
 
 
 install:
-  - set DEV_PREFIX=%MINICONDA%/envs/%ENV_NAME%
-  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - CALL %MINICONDA%/Scripts/activate.bat
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda create -q --yes -n %ENV_NAME% -c ilastik-forge -c conda-forge python=3.6 numpy=1.12 ilastik-dependencies-no-solvers
+  - conda create -q --yes -n %ENV_NAME% -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers
+  # Remove the conda ilastik-meta
+  - conda remove ilastik-meta
   - activate %ENV_NAME%
   - cd \
   # Get the current master of all submodules
@@ -19,8 +20,6 @@ install:
   - cd ilastik\ilastik-meta
   - git submodule update --init --recursive
   - git submodule foreach "git checkout master"
-  # Remove the conda ilastik-meta
-  - conda remove ilastik-meta
   - ps: rm -Force -Recurse c:\ilastik\ilastik-meta\ilastik\
   # replace with whatever version of ilastik triggered the appveyor
   - ps: cp -recurse C:\projects\ilastik c:\ilastik\ilastik-meta\ilastik
@@ -33,12 +32,10 @@ install:
 build: off
 
 test_script:
-  - set DEV_PREFIX=%MINICONDA%/envs/%ENV_NAME%
+  - CALL %MINICONDA%/Scripts/activate.bat
   - activate %ENV_NAME%
   - cd \
   - cd ilastik\ilastik-meta\ilastik\tests
-  - set Path="C:\Program Files\Git\usr\bin";%Path%
-  - set CONTINUE_ON_FAILURE=1
   - pytest --run-legacy-gui
 
 # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,40 +3,41 @@ clone_folder: c:\projects\ilastik
 environment:
   ENV_NAME: test-env
   # set miniconda version explicitly
-  MINICONDA: C:\Miniconda36-x64
+  MINICONDA: C:\Miniconda37-x64
 
 
 install:
-  - CALL %MINICONDA%/Scripts/activate.bat
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda create -q --yes -n %ENV_NAME% -c ilastik-forge/label/staging -c conda-forge ilastik-dependencies-no-solvers
+  - cmd: CALL %MINICONDA%/Scripts/activate.bat
+  - cmd: where conda
+  - cmd: conda config --set always_yes yes --set changeps1 no
+  - cmd: conda update -q conda
+  - cmd: conda create -q --yes -n %ENV_NAME% -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers
   # Remove the conda ilastik-meta
-  - conda remove ilastik-meta
-  - activate %ENV_NAME%
-  - cd \
+  - cmd: conda remove -n %ENV_NAME% ilastik-meta
+  - cmd: CALL activate %ENV_NAME%
+  - cmd: cd \
   # Get the current master of all submodules
-  - git clone https://github.com/ilastik/ilastik-meta c:\ilastik\ilastik-meta
-  - cd ilastik\ilastik-meta
-  - git submodule update --init --recursive
-  - git submodule foreach "git checkout master"
+  - cmd: git clone https://github.com/ilastik/ilastik-meta c:\ilastik\ilastik-meta
+  - cmd: cd ilastik\ilastik-meta
+  - cmd: git submodule update --init --recursive
+  - cmd: git submodule foreach "git checkout master"
   - ps: rm -Force -Recurse c:\ilastik\ilastik-meta\ilastik\
   # replace with whatever version of ilastik triggered the appveyor
   - ps: cp -recurse C:\projects\ilastik c:\ilastik\ilastik-meta\ilastik
   # Point to the current ilastik-meta
-  - set ILASTIK_PTH=%MINICONDA%/envs/%ENV_NAME%/Lib/site-packages/ilastik-meta.pth
-  - echo C:/ilastik/ilastik-meta/lazyflow > %ILASTIK_PTH%
-  - echo C:/ilastik/ilastik-meta/volumina >> %ILASTIK_PTH%
-  - echo C:/ilastik/ilastik-meta/ilastik >> %ILASTIK_PTH%
+  - cmd: set ILASTIK_PTH=%MINICONDA%/envs/%ENV_NAME%/Lib/site-packages/ilastik-meta.pth
+  - cmd: echo C:/ilastik/ilastik-meta/lazyflow > %ILASTIK_PTH%
+  - cmd: echo C:/ilastik/ilastik-meta/volumina >> %ILASTIK_PTH%
+  - cmd: echo C:/ilastik/ilastik-meta/ilastik >> %ILASTIK_PTH%
 
 build: off
 
 test_script:
-  - CALL %MINICONDA%/Scripts/activate.bat
-  - activate %ENV_NAME%
-  - cd \
-  - cd ilastik\ilastik-meta\ilastik\tests
-  - pytest --run-legacy-gui
+  - cmd: CALL %MINICONDA%/Scripts/activate.bat
+  - cmd: CALL activate %ENV_NAME%
+  - cmd: cd \
+  - cmd: cd ilastik\ilastik-meta\ilastik\tests
+  - cmd: pytest --run-legacy-gui
 
 # on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ install:
   - cmd: conda update -q conda
   - cmd: conda create -q --yes -n %ENV_NAME% -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers
   # Remove the conda ilastik-meta
-  - cmd: conda remove -n %ENV_NAME% ilastik-meta
+  # --force in order not to remove/update anything else
+  - cmd: conda remove -n %ENV_NAME% --force ilastik-meta
   - cmd: CALL activate %ENV_NAME%
   - cmd: cd \
   # Get the current master of all submodules
@@ -37,7 +38,6 @@ test_script:
   - cmd: CALL activate %ENV_NAME%
   - cmd: cd \
   - cmd: cd ilastik\ilastik-meta\ilastik\tests
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - cmd: pytest --run-legacy-gui
 
 # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ test_script:
   - cmd: CALL activate %ENV_NAME%
   - cmd: cd \
   - cmd: cd ilastik\ilastik-meta\ilastik\tests
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - cmd: pytest --run-legacy-gui
 
 # on_finish:

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import numpy as np
 import pandas as pd
-import networkx as nx
 import vigra
 
 import ilastikrag

--- a/ilastik/applets/tracking/structured/opStructuredTracking.py
+++ b/ilastik/applets/tracking/structured/opStructuredTracking.py
@@ -554,13 +554,13 @@ class OpStructuredTracking(OpConservationTracking):
         traxelToUuidMap, uuidToTraxelMap = traxelgraph.getMappingsBetweenUUIDsAndTraxels()
 
         # reset all values
-        for n in traxelgraph._graph.nodes_iter():
-            traxelgraph._graph.node[n]['value'] = 0
-            traxelgraph._graph.node[n]['divisionValue'] = False
+        for n in traxelgraph._graph.nodes():
+            traxelgraph._graph.nodes[n]['value'] = 0
+            traxelgraph._graph.nodes[n]['divisionValue'] = False
 
-        for e in traxelgraph._graph.edges_iter():
-            traxelgraph._graph.edge[e[0]][e[1]]['value'] = 0
-            traxelgraph._graph.edge[e[0]][e[1]]['gap'] = 1 # only single step transitions supported in annotations
+        for e in traxelgraph._graph.edges():
+            traxelgraph._graph.edges[e]['value'] = 0
+            traxelgraph._graph.edges[e]['gap'] = 1 # only single step transitions supported in annotations
 
         labels = annotations['labels']
         divisions = annotations['divisions']

--- a/ilastik/plugins_default/tracking_csv_export.py
+++ b/ilastik/plugins_default/tracking_csv_export.py
@@ -37,7 +37,10 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
                 formats.append('%f')
 
         # check which features are present and construct table of the appropriate size
-        frame, _ = next(graph.nodes_iter())
+        # need to awkwardly grab one node in the for loop since networkx 2.0
+        for node in graph.nodes():
+            frame = node[0]
+            break
 
         # the feature categories can contain 'Default features' and 'Standard Object Features',
         # which actually reference the same features. Hence we block all of the one group from the other to prevent duplicates.
@@ -70,7 +73,7 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
 
         table = np.zeros([graph.number_of_nodes(), len(headers)])
 
-        for rowIdx, node in enumerate(graph.nodes_iter()):
+        for rowIdx, node in enumerate(graph.nodes()):
             frame, label = node
             trackId = graph.node[node]['trackId']
             lineageId = graph.node[node]['lineageId']

--- a/ilastik/plugins_default/tracking_mamut_export.py
+++ b/ilastik/plugins_default/tracking_mamut_export.py
@@ -58,7 +58,7 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
 
         # first loop over all nodes to find present features
         presentTrackIds = set([])
-        for node in graph.nodes_iter():
+        for node in graph.nodes():
             frame, label = node
             # print(f"Node {node} has value={graph.node[node]['value']} and trackId={graph.node[node]['trackId']}")
             if graph.node[node]['value'] > 0:
@@ -85,8 +85,8 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
                 break
 
         # insert edges
-        for edge in graph.edges_iter():
-            if graph.edge[edge[0]][edge[1]]['value'] > 0:
+        for edge in graph.edges():
+            if graph.edges[edge]['value'] > 0:
                 builder.addLink(graph.node[edge[0]]['trackId'], graph.node[edge[0]]['id'], graph.node[edge[1]]['id'])
                 presentTrackIds.add(int(graph.node[edge[0]]['trackId']))
 
@@ -97,7 +97,7 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
             builder.setTrackFeatures(trackId, {'Track_color': randomColorPerTrack[trackId]})
 
         # second pass over the nodes passes features and tracks to the builder
-        for node in graph.nodes_iter():
+        for node in graph.nodes():
             frame, label = node
             if graph.node[node]['value'] > 0:
                 t = graph.node[node]['traxel']

--- a/scripts/create-dev-env.sh
+++ b/scripts/create-dev-env.sh
@@ -79,7 +79,7 @@ then
     DEV_PREFIX=${CONDA_ROOT}/envs/${ENV_NAME}
     eval "conda remove -y -n ${ENV_NAME} ilastik-meta"
     # Re-install ilastik-meta.pth
-    cat > "${DEV_PREFIX}"/lib/python3.6/site-packages/ilastik-meta.pth << EOF
+    cat > "${DEV_PREFIX}"/lib/python3.7/site-packages/ilastik-meta.pth << EOF
 ../../../ilastik-meta/lazyflow
 ../../../ilastik-meta/volumina
 ../../../ilastik-meta/ilastik


### PR DESCRIPTION
Upgraded all dependencies to build with conda compilers, so let's see...

Also, the following dependencies have had considerable upgrades:
* python: `3.6` -> `3.7`
* numpy: `1.12` -> `1.14`
* networkx: `1.x` -> `2.x`
* boost: `1.63` -> `1.68`
* h5py: `2.7.1` -> `2.9.0`
* hdf5: `1.10.1` -> `1.10.4`