### PR TITLE
Use uint 32 in carvingTools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
     - restore_cache:
         keys:
         # This branch if available
-        - v1.33b5-dep-{{ .Branch }}-
+        - v1.33b6-dep-{{ .Branch }}-
         # Default branch if not
-        - v1.33b5-dep-master-
+        - v1.33b6-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.33b5-dep-
+        - v1.33b6-dep-
     - run: >
         if [[ ! -d ${CONDA_ROOT} ]]; then
             echo "Installing Miniconda...";
@@ -55,11 +55,11 @@ jobs:
         conda activate base &&
         cd ${ILASTIK_ROOT}/ilastik-meta &&
         python ilastik/scripts/devenv.py create -n ${TEST_ENV_NAME}
-        -p pytest-qt ilastik-dependencies-no-solvers
+        -p pytest-qt ilastik-dependencies-no-solvers black
         -c ilastik-forge conda-forge defaults
     # Save dependency cache
     - save_cache:
-        key: v1.33b5-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.33b6-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /home/ubuntu/miniconda
     # Test
@@ -67,6 +67,13 @@ jobs:
         conda activate ${TEST_ENV_NAME} &&
         cd ${ILASTIK_ROOT}/ilastik-meta/ilastik/tests &&
         xvfb-run --server-args="-screen 0 1024x768x24" pytest --run-legacy-gui
+    - run: >
+        conda activate ${TEST_ENV_NAME} &&
+        cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
+        git diff --name-only --diff-filter=AM master.. |
+            grep ".*\.py" |
+            xargs black --check --line-length=120
+
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results


### PR DESCRIPTION
Use uint32 throughout the watershed function in `carvingTools.py`. This will use less memory and was not possible earlier, because nifty did not expose the correct dtypes (should be fixed now).
Also, use `projectScalarNodeDataToPixels` to go from superpixel labels to volumetric segmentation by default.