### PR TITLE
Fixes "Object Classification Workflow" Data Selection readiness when using multiple lanes

### DIFF
--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -430,7 +430,7 @@ class ObjectClassificationWorkflow(Workflow):
                     continue
                 if not input_lane_slot[role].ready():
                     return False
-        return True and len(image_group_slot)
+        return True and len(image_group_slot) > 0
 
     def postprocessClusterSubResult(self, roi, result, blockwise_fileset):
         """

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -430,7 +430,7 @@ class ObjectClassificationWorkflow(Workflow):
                     continue
                 if not input_lane_slot[role].ready():
                     return False
-        return True and len(image_group_slot) > 0
+        return bool(len(image_group_slot))
 
     def postprocessClusterSubResult(self, roi, result, blockwise_fileset):
         """


### PR DESCRIPTION
The `Object Classification Workflow`s were not correctly enabling applets when running with multiple lanes.

This PR ensures that the `_inputReady` function correctly reports its state as a boolean, which can then be correctly interpreted in operations such as `&=`.

## Reproducing the bugs this PR fixes:
- Create any "Object Classification Workflow";
- Create two lanes;
- Verify that the applet  after `Data Selection` is not enabled.