### PR TITLE
Add drag-n-drop support in  batch processing applet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
       VOLUMINA_SHOW_3D_WIDGET: 0
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
     steps:
     # add interpolated environment variables (CircleCI 2.0 does not support direct interpolation)
     - run: echo 'export PATH=${CONDA_ROOT}/bin:${PATH}' >> $BASH_ENV
@@ -63,7 +62,7 @@ jobs:
     - run: >
         conda activate ${TEST_ENV_NAME} &&
         cd ${ILASTIK_ROOT}/ilastik-meta/ilastik/tests &&
-        pytest --run-legacy-gui
+        xvfb-run --server-args="-screen 0 1024x768x24" pytest --run-legacy-gui
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results

--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -1,17 +1,19 @@
-import copy
+import logging
 import weakref
 from collections import OrderedDict
-import logging
-import typing
-logger = logging.getLogger(__name__)  # noqa
+from typing import Dict, Hashable, List, Optional, Union, Mapping, Iterable
 
 import numpy
 import vigra
 from lazyflow.request import Request
-from ilastik.utility import log_exception
+
 from ilastik.applets.base.applet import Applet
 from ilastik.applets.dataSelection import DataSelectionApplet
-from ilastik.applets.dataSelection.opDataSelection import DatasetInfo, OpMultiLaneDataSelectionGroup
+from ilastik.applets.dataSelection.opDataSelection import (
+    DatasetInfo, OpMultiLaneDataSelectionGroup)
+from ilastik.utility import log_exception
+
+logger = logging.getLogger(__name__)  # noqa
 
 
 class BatchProcessingApplet(Applet):
@@ -65,13 +67,13 @@ class BatchProcessingApplet(Applet):
 
     def run_export(
         self,
-        role_data_dict: typing.Dict[
-            typing.Hashable, typing.List[typing.Union[str, DatasetInfo]]
+        role_data_dict: Mapping[
+            Hashable, Iterable[Union[str, DatasetInfo]]
         ],
-        input_axes: typing.Optional[str] = None,
+        input_axes: Optional[str] = None,
         export_to_array: bool = False,
-        sequence_axis: typing.Optional[str] = None,
-    ) -> typing.List[typing.Union[str, numpy.array]]:
+        sequence_axis: Optional[str] = None,
+    ) -> Union[List[str], List[numpy.array]]:
         """Run the export for each dataset listed in role_data_dict
 
         For each dataset:
@@ -92,7 +94,7 @@ class BatchProcessingApplet(Applet):
             role_data_dict: dict with role_name: list(paths) of data that should be processed.
               You may pass either filepaths OR preconfigured DatasetInfo objects.
               The latter is useful if you are batch processing data that already exists in memory as a numpy array.
-              (See DatasetInfo.preloaded_array for how to provide a numpy array instead of a filepath.)
+              (See :meth: `DatasetInfo.preloaded_array` for how to provide a numpy array instead of a filepath.)
             input_axes: axis description to override from the default role
             export_to_array: If True do NOT export to disk as usual.
               Instead, export the results to a list of arrays, which is returned.

--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -214,6 +214,9 @@ class BatchProcessingGui( QTabWidget ):
         dominant_role_name = role_names[0]
         num_paths = len(role_path_dict[dominant_role_name])
 
+        if num_paths == 0:
+            return
+
         for role_name in role_names[1:]:
             paths = role_path_dict[role_name]
             if len(paths) == 0:

--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -18,22 +18,117 @@
 # on the ilastik web site at:
 #           http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
 import os
 import logging
+import typing
 from collections import OrderedDict
 from functools import partial
-logger = logging.getLogger(__name__)
 
-from PyQt5.QtCore import QTimer, Qt
-from PyQt5.QtWidgets import QApplication, QWidget, QTabWidget, QVBoxLayout, QPushButton, QHBoxLayout, \
-                        QLabel, QSpacerItem, QSizePolicy, QListWidget, QMessageBox
+from PyQt5.QtCore import QTimer, Qt, QUrl
+from PyQt5.QtWidgets import (
+    QApplication, QHBoxLayout, QLabel, QListWidget, QMessageBox, QPushButton,
+    QSizePolicy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget,
+)
 
 from lazyflow.request import Request
 from volumina.utility import PreferencesManager
 from ilastik.utility import log_exception
 from ilastik.utility.gui import ThreadRouter, threadRouted
-from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui # We borrow the file selection window function.
+from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui  # We borrow the file selection window function.
+
+
+logger = logging.getLogger(__name__)
+
+
+class BatchProcessingDataConstraintException(Exception):
+    pass
+
+
+class FileListWidget(QListWidget):
+    """QListWidget with custom drag-n-drop for file paths
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    # Drag-and-drop
+    def dropEvent(self, dropEvent):
+        urls = dropEvent.mimeData().urls()
+        filepaths = list(map(QUrl.toLocalFile, urls))
+        filepaths = list(map(str, filepaths))
+        self.clear()
+        self.addItems(qurl.path() for qurl in urls)
+
+    def dragEnterEvent(self, event):
+        # Only accept drag-and-drop events that consist of urls to local files.
+        if not event.mimeData().hasUrls():
+            return
+        urls = event.mimeData().urls()
+        if all(map(QUrl.isLocalFile, urls)):
+            event.acceptProposedAction()
+
+    def dragMoveEvent(self, event):
+        # Must override this or else the QTableView base class steals dropEvents from us.
+        pass
+
+
+class BatchRoleWidget(QWidget):
+    """Container Widget for Batch File list and buttons
+    """
+    def __init__(self, role_name: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._role_name = role_name
+        self._init_ui()
+
+    def _init_ui(self):
+        self.select_button = QPushButton(f"Select {self._role_name} Files...")
+        self.clear_button = QPushButton(f"Clear {self._role_name} Files")
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self.select_button)
+        button_layout.addSpacerItem(QSpacerItem(0, 0, hPolicy=QSizePolicy.Expanding))
+        button_layout.addWidget(self.clear_button)
+        button_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.list_widget = FileListWidget(parent=self)
+        self.list_widget.setSizePolicy(QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding))
+        self.list_widget.setAcceptDrops(True)
+
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addLayout(button_layout)
+        main_layout.addWidget(self.list_widget)
+
+        self.clear_button.clicked.connect(self.clear)
+        self.select_button.clicked.connect(self.select_files)
+
+        self.setLayout(main_layout)
+
+    def get_all_item_strings(self) -> typing.List[str]:
+        """
+        Utility function.
+        Return all items in the given QListWidget as a list of strings.
+        """
+        all_item_strings = []
+        for row in range(self.list_widget.count()):
+            all_item_strings.append(self.list_widget.item(row).text())
+        return all_item_strings
+
+    def select_files(self):
+        preference_name = 'recent-dir-role-{}'.format(self._role_name)
+        recent_processing_directory = PreferencesManager().get(
+            'BatchProcessing', preference_name, default=os.path.normpath('~'))
+        file_paths = DataSelectionGui.getImageFileNamesToOpen(self, recent_processing_directory)
+        if file_paths:
+            recent_processing_directory = os.path.dirname(file_paths[0])
+            PreferencesManager().set('BatchProcessing', preference_name, recent_processing_directory)
+
+            self.clear()
+            self.list_widget.addItems(file_paths)
+
+    def clear(self):
+        """Remove all items from the list"""
+        self.list_widget.clear()
+
 
 class BatchProcessingGui( QTabWidget ):
     """
@@ -70,46 +165,24 @@ class BatchProcessingGui( QTabWidget ):
     ###########################################
     
     def __init__(self, parentApplet):
-        super(BatchProcessingGui, self).__init__()
+        super().__init__()
         self.parentApplet = parentApplet
-        self.threadRouter = ThreadRouter(self) # For using @threadRouted
+        self.threadRouter = ThreadRouter(self)  # For using @threadRouted
         self._drawer = None
+        self._data_role_widgets = {}
         self.initMainUi()
         self.initAppletDrawerUi()
         self.export_req = None
 
     def initMainUi(self):
+
         role_names = self.parentApplet.dataSelectionApplet.topLevelOperator.DatasetRoles.value
-        self.list_widgets = []
-        
         # Create a tab for each role
-        for role_index, role_name in enumerate(role_names):
-            select_button = QPushButton("Select " + role_name + " Files...", 
-                                        clicked=partial(self.select_files, role_index) )
-            clear_button = QPushButton("Clear " + role_name + " Files",
-                                       clicked=partial(self.clear_files, role_index) )
-            button_layout = QHBoxLayout()
-            button_layout.addWidget(select_button)
-            button_layout.addSpacerItem( QSpacerItem(0,0,hPolicy=QSizePolicy.Expanding) )
-            button_layout.addWidget(clear_button)
-            button_layout.setContentsMargins(0, 0, 0, 0)
-            
-            button_layout_widget = QWidget()
-            button_layout_widget.setLayout(button_layout)
-            button_layout_widget.setSizePolicy( QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum) )
-
-            list_widget = QListWidget(parent=self)
-            list_widget.setSizePolicy( QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding) )
-            self.list_widgets.append( list_widget )
-
-            tab_layout = QVBoxLayout()
-            tab_layout.setContentsMargins(0, 0, 0, 0)
-            tab_layout.addWidget( button_layout_widget )
-            tab_layout.addWidget( list_widget )
-            
-            layout_widget = QWidget(parent=self)
-            layout_widget.setLayout(tab_layout)
-            self.addTab(layout_widget, role_name)
+        for role_name in role_names:
+            assert role_name not in self._data_role_widgets
+            data_role_widget = BatchRoleWidget(role_name=role_name, parent=self)
+            self.addTab(data_role_widget, role_name)
+            self._data_role_widgets[role_name] = data_role_widget
 
     def initAppletDrawerUi(self):
         instructions_label = QLabel(
@@ -133,37 +206,26 @@ class BatchProcessingGui( QTabWidget ):
 
         self._drawer = QWidget(parent=self)
         self._drawer.setLayout(layout)
-        
-    def select_files(self, role_index):
-        preference_name = 'recent-dir-role-{}'.format(role_index)
-        recent_processing_directory = PreferencesManager().get( 'BatchProcessing', 
-                                                                preference_name, 
-                                                                default=os.path.normpath('~') )
-        file_paths = DataSelectionGui.getImageFileNamesToOpen(self, recent_processing_directory)
-        if file_paths:
-            recent_processing_directory = os.path.dirname(file_paths[0])
-            PreferencesManager().set( 'BatchProcessing', preference_name, recent_processing_directory )
-        
-            self.list_widgets[role_index].clear()
-            self.list_widgets[role_index].addItems(file_paths)
 
-    def clear_files(self, role_index):
-        self.list_widgets[role_index].clear()
-    
     def run_export(self):
         role_names = self.parentApplet.dataSelectionApplet.topLevelOperator.DatasetRoles.value
 
         # Prepare file lists in an OrderedDict
-        role_path_dict = OrderedDict()
-        role_path_dict[0] = BatchProcessingGui.get_all_item_strings(self.list_widgets[0])
-        num_datasets = len(role_path_dict[0])
+        role_path_dict = OrderedDict(
+            (role_name, self._data_role_widgets[role_name].get_all_item_strings())
+            for role_name
+            in role_names
+        )
+        dominant_role_name = role_names[0]
+        num_datasets = len(role_path_dict[dominant_role_name])
 
-        for role_index, list_widget in enumerate(self.list_widgets[1:], start=1):
-            role_path_dict[role_index] = BatchProcessingGui.get_all_item_strings(self.list_widgets[role_index])
-            assert len(role_path_dict[role_index]) <= num_datasets, \
-                "Too many files given for role: '{}'".format( role_names[role_index] )
-            if len(role_path_dict[role_index]) < num_datasets:
-                role_path_dict[role_index] += [None] * (num_datasets-len(role_path_dict[role_index]))
+        for role_name in role_names[1:]:
+            datasets = role_path_dict[role_name]
+            if len(datasets) == 0:
+                role_path_dict[role_name] = [None] * num_datasets
+
+            if len(role_path_dict[role_name]) != num_datasets:
+                raise BatchProcessingDataConstraintException(f"Number of files for '{role_name}' does not match ")
 
         # Run the export in a separate thread
         export_req = Request(partial(self.parentApplet.run_export, role_path_dict))
@@ -213,15 +275,4 @@ class BatchProcessingGui( QTabWidget ):
         self.handle_batch_processing_finished()
         self.handle_batch_processing_complete()
         QMessageBox.information(self, "Batch Processing Cancelled.", "Batch Processing Cancelled.")
-
-    @staticmethod
-    def get_all_item_strings(list_widget):
-        """
-        Utility function.
-        Return all items in the given QListWidget as a list of strings.
-        """
-        all_item_strings = []
-        for row in range(list_widget.count()):
-            all_item_strings.append( str(list_widget.item(row).text()) )
-        return all_item_strings
             

--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -57,7 +57,7 @@ class FileListWidget(QListWidget):
         if not event.mimeData().hasUrls():
             return
         urls = event.mimeData().urls()
-        if all(map(QUrl.isLocalFile, urls)):
+        if all(url.isLocalFile() for url in urls):
             event.acceptProposedAction()
 
     def dragMoveEvent(self, event):

--- a/tests/test_applets/batchProcessing/test_batchProcessingGui.py
+++ b/tests/test_applets/batchProcessing/test_batchProcessingGui.py
@@ -1,9 +1,12 @@
 from unittest import mock
 
 import pytest
-from ilastik.applets.batchProcessing.batchProcessingGui import (BatchProcessingGui,
-                                                                BatchRoleWidget,
-                                                                FileListWidget)
+from ilastik.applets.batchProcessing.batchProcessingGui import (
+    BatchProcessingDataConstraintException,
+    BatchProcessingGui,
+    BatchRoleWidget,
+    FileListWidget,
+)
 from PyQt5.QtCore import Qt, QUrl
 
 
@@ -23,6 +26,25 @@ def file_list_widget(qtbot):
 @pytest.fixture
 def batch_role_widget(qtbot):
     return construct_widget(qtbot, BatchRoleWidget, "TestRoleName")
+
+
+@pytest.fixture()
+def role_names():
+    return ["testRoleName1", "testRoleName2", "testRoleName3"]
+
+
+@pytest.fixture()
+def parent_applet(role_names):
+    parent_applet = mock.Mock()
+    parent_applet.dataSelectionApplet.topLevelOperator.DatasetRoles.value = role_names
+    parent_applet.run_export = mock.Mock()
+
+    return parent_applet
+
+
+@pytest.fixture()
+def batch_processing_gui(qtbot, parent_applet):
+    return construct_widget(qtbot, BatchProcessingGui, parent_applet)
 
 
 @pytest.fixture
@@ -66,3 +88,116 @@ def test_BatchRoleWidget(qtbot, batch_role_widget, filenames):
 
     qtbot.mouseClick(batch_role_widget.clear_button, Qt.LeftButton, delay=1)
     assert len(batch_role_widget.filepaths) == 0
+
+
+class RequestMock:
+    _instances = []
+
+    def __new__(cls, *args, **kwargs):
+        instance = mock.Mock()
+        cls._instances.append(instance)
+        return instance
+
+
+def assert_buttons_in_init_state(batch_processing_gui):
+    assert batch_processing_gui.run_button.isEnabled() is True
+    assert batch_processing_gui.cancel_button.isVisible() is False
+
+
+def assert_buttons_in_running_state(batch_processing_gui):
+    assert batch_processing_gui.run_button.isEnabled() is False
+    assert batch_processing_gui.cancel_button.isVisible() is True
+    assert batch_processing_gui.cancel_button.isEnabled() is True
+
+
+def test_BatchProcessingGui_execution(qtbot, batch_processing_gui, role_names, filenames):
+    assert batch_processing_gui.count() == len(role_names)
+    assert_buttons_in_init_state(batch_processing_gui)
+
+    with mock.patch("ilastik.applets.batchProcessing.batchProcessingGui.Request", new=RequestMock):
+        qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)
+        assert len(RequestMock._instances) == 0
+
+        # add some data
+        batch_processing_gui._data_role_widgets[role_names[0]].list_widget.addItems(filenames)
+
+        qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)
+        assert len(RequestMock._instances) == 1
+        assert_buttons_in_running_state(batch_processing_gui)
+
+        # pretend we were successful:
+        req = RequestMock._instances[0]
+        success_args, success_kwargs = req.notify_finished.call_args
+        assert len(success_args) == 1
+        success_args[0]()
+
+        assert_buttons_in_init_state(batch_processing_gui)
+
+        qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)
+        assert len(RequestMock._instances) == 2
+        assert_buttons_in_running_state(batch_processing_gui)
+
+        # cancel:
+        qtbot.mouseClick(batch_processing_gui.cancel_button, Qt.LeftButton, delay=1)
+        req = RequestMock._instances[1]
+        req.cancel.assert_called_once()
+        cancel_args, cancel_kwargs = req.notify_cancelled.call_args
+        assert len(cancel_args) == 1
+
+        info_messagebox = mock.Mock()
+        with mock.patch(
+            "ilastik.applets.batchProcessing.batchProcessingGui.QMessageBox.information", new=info_messagebox
+        ):
+            cancel_args[0]()
+            info_messagebox.assert_called_once()
+
+        assert_buttons_in_init_state(batch_processing_gui)
+
+        # failure:
+        qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)
+        assert len(RequestMock._instances) == 3
+        assert_buttons_in_running_state(batch_processing_gui)
+
+        req = RequestMock._instances[2]
+        failed_args, failed_kwargs = req.notify_failed.call_args
+        assert len(failed_args) == 1
+
+        critical_messagebox = mock.Mock()
+        with mock.patch(
+            "ilastik.applets.batchProcessing.batchProcessingGui.QMessageBox.critical", new=critical_messagebox
+        ):
+            failed_args[0](mock.MagicMock(Exception), None)
+            critical_messagebox.assert_called_once()
+
+        assert_buttons_in_init_state(batch_processing_gui)
+
+
+def test_BatchProcessingGui_clear(qtbot, batch_processing_gui, role_names, filenames):
+    for role_name in role_names:
+        current_data_role_widget = batch_processing_gui._data_role_widgets[role_name]
+        current_data_role_widget.list_widget.addItems(filenames)
+        assert current_data_role_widget.list_widget.count() == len(filenames)
+
+    for role_name in role_names:
+        current_data_role_widget = batch_processing_gui._data_role_widgets[role_name]
+        qtbot.mouseClick(current_data_role_widget.clear_button, Qt.LeftButton, delay=1)
+        assert current_data_role_widget.list_widget.count() == 0
+
+
+@pytest.mark.parametrize(
+    "secondary_files",
+    [tuple(), ("sec1",), ("sec1", "sec2"), ("sec1", "sec2", "sec3"), ("sec1", "sec2", "sec3", "sec4")],
+)
+def test_BatchProcessingGui_nonmatching_raises(qtbot, batch_processing_gui, role_names, filenames, secondary_files):
+    batch_processing_gui._data_role_widgets[role_names[0]].list_widget.addItems(filenames)
+    secondary_data_role = batch_processing_gui._data_role_widgets[role_names[1]]
+    with mock.patch("ilastik.applets.batchProcessing.batchProcessingGui.Request", new=RequestMock):
+        secondary_data_role.list_widget.addItems(secondary_files)
+        if len(secondary_files) > 0 and (len(secondary_files) != len(filenames)):
+            with qtbot.capture_exceptions() as exceptions:
+                qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)
+            assert len(exceptions) == 1
+            exc_class, exc_instance, exc_traceback = exceptions[0]
+            assert exc_class == BatchProcessingDataConstraintException
+        else:
+            qtbot.mouseClick(batch_processing_gui.run_button, Qt.LeftButton, delay=1)

--- a/tests/test_applets/batchProcessing/test_batchProcessingGui.py
+++ b/tests/test_applets/batchProcessing/test_batchProcessingGui.py
@@ -1,0 +1,68 @@
+from unittest import mock
+
+import pytest
+from ilastik.applets.batchProcessing.batchProcessingGui import (BatchProcessingGui,
+                                                                BatchRoleWidget,
+                                                                FileListWidget)
+from PyQt5.QtCore import Qt, QUrl
+
+
+def construct_widget(qtbot, widget_class, *args, **kwargs):
+    widget = widget_class(*args, **kwargs)
+    qtbot.addWidget(widget)
+    widget.show()
+    qtbot.waitForWindowShown(widget)
+    return widget
+
+
+@pytest.fixture
+def file_list_widget(qtbot):
+    return construct_widget(qtbot, FileListWidget)
+
+
+@pytest.fixture
+def batch_role_widget(qtbot):
+    return construct_widget(qtbot, BatchRoleWidget, "TestRoleName")
+
+
+@pytest.fixture
+def filenames():
+    return ["file1", "file2"]
+
+
+@pytest.fixture
+def drag_n_drop_event(filenames):
+    dndevent = mock.Mock()
+    urls = [QUrl(x) for x in filenames]
+    for url in urls:
+        url.isLocalFile = mock.Mock(return_value=True)
+    dndevent.mimeData.return_value.has_urls.return_value = True
+    dndevent.mimeData.return_value.urls.return_value = urls
+    return dndevent
+
+
+def test_FileListWidget_drag_n_drop(file_list_widget, drag_n_drop_event, filenames):
+    assert file_list_widget.count() == 0
+
+    file_list_widget.dragEnterEvent(drag_n_drop_event)
+    assert drag_n_drop_event.acceptProposedAction.called_once()
+    assert file_list_widget.count() == 0
+
+    file_list_widget.dropEvent(drag_n_drop_event)
+    assert file_list_widget.count() == len(filenames)
+    for url in filenames:
+        items = file_list_widget.findItems(url, Qt.MatchFixedString)
+        assert len(items) == 1
+
+
+def test_BatchRoleWidget(qtbot, batch_role_widget, filenames):
+    assert batch_role_widget.select_button.text() == f"Select TestRoleName Files..."
+    assert batch_role_widget.clear_button.text() == f"Clear TestRoleName Files"
+
+    assert batch_role_widget.list_widget.count() == 0
+
+    batch_role_widget.list_widget.addItems(filenames)
+    assert batch_role_widget.filepaths == filenames
+
+    qtbot.mouseClick(batch_role_widget.clear_button, Qt.LeftButton, delay=1)
+    assert len(batch_role_widget.filepaths) == 0


### PR DESCRIPTION
Summay:

* added drag and drop support
* factored out BatchRoleWidget to handle data
* added custom exception (as opposed to asserts)
* removed "feature" where one would supply less number of "secondary" images
  in batch processing
* improved docstring for `run_export`
* removed some legacy stuff

closes #2004