### PR TITLE
disable 3d widget on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   ENV_NAME: test-env
   # set miniconda version explicitly
   MINICONDA: C:\Miniconda37-x64
+  VOLUMINA_SHOW_3D_WIDGET: 0
 
 
 install:


### PR DESCRIPTION
with the merge of https://github.com/ilastik/volumina/pull/239 the 3d widget can be disabled via an environment variable. Tests should pass on appveyor again.