### PR TITLE
structured learning tracking: use correct slots for export

### DIFF
--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -321,9 +321,9 @@ class StructuredTrackingWorkflowBase(Workflow):
         opStructuredTracking.MaxNumObj.connect(opCellClassification.MaxNumObj)
 
         opDataTrackingExport.Inputs.resize(3)
-        opDataTrackingExport.Inputs[0].connect(opStructuredTracking.RelabeledImage)
+        opDataTrackingExport.Inputs[0].connect(opStructuredTracking.Output)
         opDataTrackingExport.Inputs[1].connect(opStructuredTracking.MergerOutput)
-        opDataTrackingExport.Inputs[2].connect(opStructuredTracking.LabelImage)
+        opDataTrackingExport.Inputs[2].connect(opStructuredTracking.RelabeledImage)
         opDataTrackingExport.RawData.connect(op5Raw.Output)
         opDataTrackingExport.RawDatasetInfo.connect(opData.DatasetGroup[0])
 


### PR DESCRIPTION
This is a "hotfix" for structured tracking. Apparently, the wrong slot was connected.

Looking at this code, the sheer amount of it, although structured tracking and conservation tracking should be fairly similar, made me open up #2059

fixes #1943