### PR TITLE
use conda develop instead of symlinks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,11 @@ jobs:
     - restore_cache:
         keys:
         # This branch if available
-        - v1.33b4-dep-{{ .Branch }}-
+        - v1.33b5-dep-{{ .Branch }}-
         # Default branch if not
-        - v1.33b4-dep-master-
+        - v1.33b5-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.33b4-dep-
+        - v1.33b5-dep-
     - run: >
         if [[ ! -d ${CONDA_ROOT} ]]; then
             echo "Installing Miniconda...";
@@ -38,6 +38,10 @@ jobs:
             echo "Using cached Miniconda install";
         fi
     - run: conda init bash
+    - run: >
+        conda config --set always_yes yes --set changeps1 no &&
+        conda update -q conda &&
+        conda install -n base -c conda-forge conda-build
     - run: git clone http://github.com/ilastik/ilastik-meta ${ILASTIK_ROOT}/ilastik-meta
     - run: >
         cd ${ILASTIK_ROOT}/ilastik-meta &&
@@ -55,7 +59,7 @@ jobs:
         -c ilastik-forge conda-forge defaults
     # Save dependency cache
     - save_cache:
-        key: v1.33b4-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.33b5-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /home/ubuntu/miniconda
     # Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,14 @@ git clone https://github.com/ilastik/ilastik-meta
 Examining the created folder, e.g. `~/sources/ilastik-meta`, you can find the `.gitmodules` file.
 Check out a new branch in ilastik-meta, e.g. `git checkout -b my-forks` and edit the `.gitmodules`
 file such that it points to your own forks: replace all occurrences of `https://github.com/ilastik`
-with `https://github.com/<your_githug_username>`.
+with `https://github.com/<your_github_username>`.
 
 Now it is time to initialize the repository:
 
 ```bash
 # in ~/sources/ilastik-meta (or wherever you have cloned ilastik-meta to)
 git submodule update --init --recursive
-git submodule foreach "git checkout master"
+git submodule foreach 'git checkout master'
 ```
 
 Your forks are now set as the _origin_ remote for the respective repository.
@@ -147,44 +147,32 @@ bash Miniconda3-latest-MacOSX-x86_64.sh
 # Either re-open the terminal, or
 source ~/.bashrc  # Linux
 source ~/.bash_profile  # MAC
+
+# Install conda-build which is needed to correctly setup a development environment:
+conda install -n base -c conda-forge conda-build
 ```
 
 **Note:** the following steps guide you through the manual process of creating a development environment.
 For convenience, there is a `ilastik-meta/ilastik/scripts/devenv.py` script that automates this process.
 Ensure that your current working directory is `ilastik-meta` and run `python ilastik/scripts/devenv.py create -n idev`.
 
+#### Manual Creation of development environment
 Create the ilastik development environment (we assume that the dev-environment will have the name _idev_, but you can, of course choose a name to your liking):
 ```bash
 conda create --name idev -c ilastik-forge -c conda-forge ilastik-dependencies-no-solvers
 ```
 
-In order to run your own code, you need to link against your sources
+In order to run your own code, you need to install the local ilastik packages with `conda develop`.
 
 ```bash
-# Define some variables that make the following lines more portable
-CONDA_ROOT=`conda info --root`
-DEV_PREFIX=${CONDA_ROOT}/envs/idev
-
-# first remote ilastik-meta from the conda environment
-# make sure to "force" remove with --force so that other dependencies are not affected.
-conda remove --force --name idev ilastik-meta
-
-# now link against your own ilastik-meta repository
-# navigate to the idev environment root in your conda-folder
-cd ${DEV_PREFIX}
-ln -s <your_ilastik-meta_source_folder>  # e.g. ~/sources/ilastik-meta
-
-cat > ${DEV_PREFIX}/lib/python3.6/site-packages/ilastik-meta.pth << EOF
-../../../ilastik-meta/lazyflow
-../../../ilastik-meta/volumina
-../../../ilastik-meta/ilastik
-EOF
+# from you local ilastik-meta folder
+git submodule foreach 'conda develop .'
 ```
 
 Now it might be the time to test whether the installation was successful:
 ```bash
 # activate your conda environment
-source activate idev
+conda activate idev
 
 # check whether importing ilastik repos works
 python -c "import ilastik; import lazyflow; import volumina"
@@ -229,21 +217,21 @@ After making changes, please confirm that nothing else got broken by running the
  * Changes made in the ilastik repository _ilastik_:
    ```bash
    # in ~/source/ilastik-meta/ilastik/tests
-   source activate idev
+   conda activate idev
    pytest --run-legacy-gui
    ```
  * Changes made in lazyflow:
    ```bash
    # in ~/source/ilastik-meta/lazyflow
-   source activate idev
-   nosetests --where=./tests
+   conda activate idev
+   pytest
    ```
    * please also run the ilastik tests (see above)
  * Changes made in volumina:
    ```bash
    # in ~/source/ilastik-meta/volumina/tests
-   source activate idev
-   ./run-each-until-fail.sh
+   conda activate idev
+   pytest
    ```
    * please also run the ilastik tests (see above)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ install:
   - cmd: where conda
   - cmd: conda config --set always_yes yes --set changeps1 no
   - cmd: conda update -q conda
+  - cmd: conda install -c conda-forge conda-build
   # Get the current master of all submodules
   - cmd: git clone https://github.com/ilastik/ilastik-meta %IlASTIK_ROOT%\ilastik-meta
   - cmd: cd %IlASTIK_ROOT%\ilastik-meta

--- a/scripts/devenv.py
+++ b/scripts/devenv.py
@@ -89,7 +89,8 @@ class CondaEnv:
         """Remove a package in this environment."""
         run("conda", "remove", "--yes", "--force" if force else None, "--name", self.name, package)
 
-    def develop(self, path: pathlib.Path):
+    def install_pacakge_dev(self, path: pathlib.Path) -> None:
+        """Install a local package with conda develop"""
         run("conda", "develop", "--name", self.name, str(path))
 
     @property
@@ -238,10 +239,10 @@ def command_create(args: argparse.Namespace, env: CondaEnv) -> None:
         return
 
     packages = "lazyflow", "volumina", "ilastik"
-    package_locations = [location / pkg for pkg in packages]
 
-    for package_location in package_locations:
-        env.develop(package_location)
+    logging.info(f"Installing local ilastik packages in development mode.")
+    for pkg in packages:
+        env.install_pacakge_dev(location / pkg)
 
 
 def command_remove(_args: argparse.Namespace, env: CondaEnv) -> None:


### PR DESCRIPTION
**Rationale:**
 with _recent_ changes to conda, it will try to repair your env when installing new packages. This means with our current approach of force-removing `ilastik-meta` and symlinking you practically cannot install new packages into your current environment... Creating a new environment every time you want to install something drove me nuts!

In preparation for this I changed `ilastik-dependencies` package not to include `ilastik-meta` in the first place. (https://github.com/ilastik/ilastik-conda-recipes/pull/66)

**Summary:**
 * Instead of force-remove - symlink, use `conda develop` to add local
 `ilastik-meta` to packages discoverable by current python environment.


You can try it out right now with the update `ilastik-dependencies-no-solvers-package` with

```bash
# from your ilastik-meta folder
python ilastik/scripts/devenv.py creaste -n idev -c kdominik ilastik-forge conda-forge defaults
```

_edit_: it's expected that the tests fail right now - the updated `ilastik-dependencies-no-solvers` package is not yet in `ilastik-forge`