### PR TITLE
set log level in volumina.tiling explicitly

### DIFF
--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -66,6 +66,7 @@
         "workflows":                                                { "level":"INFO" },
         "volumina":                                                 { "level":"INFO" },
         "volumina.pixelpipeline":                                   { "level":"INFO" },
+        "volumina.tiling":                                          { "level":"WARN" },
         "volumina.imageScene2D":                                    { "level":"INFO" },
         "volumina.utility.shortcutManager":                         { "level":"INFO" },
 


### PR DESCRIPTION
Summary: this commit restores the original behavior of hiding the exceptions,
it doesn't solve any other problem.

previously there were some error messages in volumina that have never appeared
although they called `sys.excepthook` explicitly. See

https://github.com/ilastik/volumina/commit/2b09109b478a7f30787d9cecbad01ce82812a671

which introduced the change that made exceptions surface.

Together with this PR there is a PR in volumina:
https://github.com/ilastik/volumina/pull/253 that changes these
`logging.errors` to `logging.debug`. In order to hide these, this PR sets the
log level to warning.