### PR TITLE
Add StrictABC and use it for ShellABC

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -174,7 +174,7 @@ class ProgressDisplayManager(QObject):
         self.requestTimer.start()
 
         self.statusBar.addPermanentWidget(self.requestStatus)
-        
+
         self.memoryWidget = MemoryWidget()
         self.memoryWidget.showDialogButton.clicked.connect(self.parent().showMemUsageDialog)
         self.statusBar.addPermanentWidget(self.memoryWidget)
@@ -186,11 +186,11 @@ class ProgressDisplayManager(QObject):
 
         mgr.totalCacheMemory.subscribe(printIt)
 
-        # Route all signals we get through a queued connection, 
+        # Route all signals we get through a queued connection,
         #  to ensure that they are handled in the GUI thread
-        # Important: AutoConnection (the default type) is not okay here: that would cause 
-        #            progress signals coming from the main thread to "cut in line"  
-        #            in front of progress notifications that were previously sent, 
+        # Important: AutoConnection (the default type) is not okay here: that would cause
+        #            progress signals coming from the main thread to "cut in line"
+        #            in front of progress notifications that were previously sent,
         #            but from other threads.
         self.dispatchSignal.connect(self.handleAppletProgressImpl, Qt.QueuedConnection)
 
@@ -272,6 +272,7 @@ def styleStartScreenButton(button, icon):
     button.setIcon(QIcon(icon))
 
 
+@ShellABC.register
 class IlastikShell(QMainWindow):
     """
     The GUI's main window.  Simply a standard 'container' GUI for one or more applets.
@@ -393,7 +394,7 @@ class IlastikShell(QMainWindow):
         # No applet can be enabled unless his disableCount == 0
 
         self._refreshDrawerRecursionGuard = False
-        
+
         self._applet_enabled_states = {}
 
         self.setupOpenFileButtons()
@@ -413,8 +414,8 @@ class IlastikShell(QMainWindow):
             # Hence, show it now before doing our calculations.
             self.show()
 
-            # Qt offers no function for setting the size of the entire frame, 
-            # so instead we have to calculate the target size of the internal geometry.            
+            # Qt offers no function for setting the size of the entire frame,
+            # so instead we have to calculate the target size of the internal geometry.
             frame_padding_width = self.frameGeometry().width() - self.geometry().size().width()
             frame_padding_height = self.frameGeometry().height() - self.geometry().size().height()
             self.resize(w - frame_padding_width, h - frame_padding_height)
@@ -519,7 +520,7 @@ class IlastikShell(QMainWindow):
         if _has_dvid_support:
             shellActions.downloadProjectFromDvidAction = menu.addAction("&Download Project from DVID...")
             shellActions.downloadProjectFromDvidAction.setIcon(QIcon(ilastikIcons.Open))
-            shellActions.downloadProjectFromDvidAction.triggered.connect(self.onDownloadProjectFromDvidActionTriggered)    
+            shellActions.downloadProjectFromDvidAction.triggered.connect(self.onDownloadProjectFromDvidActionTriggered)
 
         shellActions.closeAction = menu.addAction("&Close")
         shellActions.closeAction.setIcon(QIcon(ilastikIcons.ProcessStop))
@@ -554,7 +555,7 @@ class IlastikShell(QMainWindow):
 
                 b.clicked.connect(partial(self.openFileAndCloseStartscreen, path))
 
-                # Insert the new button after all the other controls, 
+                # Insert the new button after all the other controls,
                 #  but before the vertical spacer at the end of the list.
                 insertion_index = self.startscreen.VL1.count() - 1
                 self.startscreen.VL1.insertWidget(insertion_index, b)
@@ -574,7 +575,7 @@ class IlastikShell(QMainWindow):
 
             import zipfile
             import tempfile
-            
+
             with tempfile.TemporaryDirectory() as tmp_dir:
                 with zipfile.ZipFile(os.path.join(localDir, 'ilastik-logo-alternative.zip'), 'r') as z:
                     z.setpassword(clearkey)
@@ -706,7 +707,7 @@ class IlastikShell(QMainWindow):
                 pstats_path = os.path.splitext(stats_path)[0] + '.pstats'
                 PreferencesManager().set('shell', 'recent sorted profile stats', stats_path)
 
-                # Export the yappi stats to builtin pstats format, 
+                # Export the yappi stats to builtin pstats format,
                 #  since pstats provides nicer printing IMHO
                 stats = yappi.get_func_stats()
                 stats.save(pstats_path, type='pstat')
@@ -737,7 +738,7 @@ class IlastikShell(QMainWindow):
             if stats_path:
                 PreferencesManager().set('shell', 'recent sorted profile stats', stats_path)
 
-                # Export the yappi stats to builtin pstats format, 
+                # Export the yappi stats to builtin pstats format,
                 #  since pstats provides nicer printing IMHO
                 stats = yappi.get_thread_stats()
                 stats.sort(sortby)
@@ -782,7 +783,7 @@ class IlastikShell(QMainWindow):
         self._allocation_threshold = PreferencesManager().get('shell', 'allocation tracking threshold')
         if self._allocation_threshold is None:
             self._allocation_threshold = 1000000 # 1 MB by default
-        
+
         self._traceback_depth = PreferencesManager().get('shell', 'allocation tracking traceback depth')
         if self._traceback_depth is None:
             self._traceback_depth = 3 # default
@@ -850,7 +851,7 @@ class IlastikShell(QMainWindow):
                 defaultPath = os.path.join(os.path.expanduser('~'), filename)
             else:
                 defaultPath = os.path.join(os.path.split(recentPath)[0], filename)
-            
+
             html_path, _filter = QFileDialog.getSaveFileName(
                 self, "Export allocation tracking table", defaultPath, "HTML files (*.html)",
                 options=QFileDialog.Options(QFileDialog.DontUseNativeDialog))
@@ -861,7 +862,7 @@ class IlastikShell(QMainWindow):
 
                 # As a convenience, go ahead and open it.
                 QDesktopServices.openUrl(QUrl.fromLocalFile(html_path))
-        
+
         startAction = allocationTrackingSubmenu.addAction("Start")
         startAction.triggered.connect(_startAllocationTracking)
         startAction.setIcon(QIcon(ilastikIcons.Record))
@@ -873,7 +874,7 @@ class IlastikShell(QMainWindow):
 
         configureAction = allocationTrackingSubmenu.addAction("Configure...")
         configureAction.triggered.connect(_configureSettings)
-        
+
         return allocationTrackingSubmenu
 
     def showMemUsageDialog(self):
@@ -1053,7 +1054,7 @@ class IlastikShell(QMainWindow):
     @property
     def currentImageIndex(self):
         return self._currentImageIndex
-    
+
     def handleAppletBarItemExpanded(self, modelIndex):
         """
         The user wants to view a different applet bar item.
@@ -1067,11 +1068,11 @@ class IlastikShell(QMainWindow):
         if self._refreshDrawerRecursionGuard is False:
             assert threading.current_thread().name == "MainThread"
             self._refreshDrawerRecursionGuard = True
-            
+
             prev_applet_index = self.currentAppletIndex
             self.currentAppletIndex = applet_index
             self.currentAppletChanged.emit(prev_applet_index, self.currentAppletIndex)
-            
+
             # Collapse all drawers in the applet bar...
             # ...except for the newly selected item.
             self._appletBarMgr.focusApplet(applet_index)
@@ -1235,8 +1236,8 @@ class IlastikShell(QMainWindow):
         newProjectFile = ProjectManager.createBlankProjectFile(newProjectFilePath, workflow_class,
                                                                self._workflow_cmdline_args, h5_file_kwargs)
         self._loadProject(newProjectFile, newProjectFilePath, workflow_class, readOnly=False)
-        
-        # If load failed, projectManager is None 
+
+        # If load failed, projectManager is None
         if self.projectManager:
             self.projectManager.saveProject()
 
@@ -1312,7 +1313,7 @@ class IlastikShell(QMainWindow):
 
     def onDownloadProjectFromDvidActionTriggered(self):
         logger.debug("Download Project From DVID")
-        
+
         recent_hosts_pref = PreferencesManager.Setting("DataSelection", "Recent DVID Hosts")
         recent_hosts = recent_hosts_pref.get()
         if not recent_hosts:
@@ -1342,7 +1343,7 @@ class IlastikShell(QMainWindow):
         except ValueError:
             pass
         finally:
-            recent_hosts.insert(0, hostname)        
+            recent_hosts.insert(0, hostname)
             recent_hosts = recent_hosts[:10]
 
         # Save pref
@@ -1433,8 +1434,8 @@ class IlastikShell(QMainWindow):
             return
 
         # If there are any "creation-time" command-line args saved to the project file,
-        #  load them so that the workflow can be instantiated with the same settings 
-        #  that were used when the project was first created. 
+        #  load them so that the workflow can be instantiated with the same settings
+        #  that were used when the project was first created.
         project_creation_args = []
         if "workflow_cmdline_args" in list(hdf5File.keys()):
             if len(hdf5File["workflow_cmdline_args"]) > 0:
@@ -1474,7 +1475,7 @@ class IlastikShell(QMainWindow):
                 self.closeCurrentProject()
 
                 # _loadProject failed, so we cannot expect it to clean up
-                # the hdf5 file (but it might have cleaned it up, so we catch 
+                # the hdf5 file (but it might have cleaned it up, so we catch
                 # the error)
                 try:
                     hdf5File.close()
@@ -1735,8 +1736,8 @@ class IlastikShell(QMainWindow):
             self.setAppletEnabled(applet, enabled)
 
     def setAppletEnabled(self, applet, enabled):
-        # We immediately track the enabled status in a member dict instead 
-        #  of checking with the applet gui itself, in case isAppletEnabled() 
+        # We immediately track the enabled status in a member dict instead
+        #  of checking with the applet gui itself, in case isAppletEnabled()
         #  gets called before _setAppletEnabled gets a chance to execute.
         self._applet_enabled_states[applet] = enabled
 
@@ -1796,6 +1797,3 @@ class IlastikShell(QMainWindow):
         else:
             applet.getMultiLaneGui().setEnabled(enabled)
             self._appletBarMgr.setEnabled(applet_index, enabled)
-
-
-assert issubclass(IlastikShell, ShellABC), "IlastikShell does not satisfy the generic shell interface!"

--- a/ilastik/shell/headless/headlessShell.py
+++ b/ilastik/shell/headless/headlessShell.py
@@ -27,6 +27,8 @@ from lazyflow.utility import isUrl
 from ilastik.shell.shellAbc import ShellABC
 from ilastik.shell.projectManager import ProjectManager
 
+
+@ShellABC.register
 class HeadlessShell(object):
     """
     For now, this class is just a stand-in for the GUI shell (used when running from the command line).
@@ -58,8 +60,8 @@ class HeadlessShell(object):
     @classmethod
     def downloadProjectFromDvid(cls, dvid_key_url):
         dvid_key_url = str(dvid_key_url)
-        
-        # By convention, command-line users specify the location of the project 
+
+        # By convention, command-line users specify the location of the project
         # keyvalue data using the same format that the DVID API itself uses.
         url_format = "^protocol://hostname/api/node/uuid/kv_instance_name(/key/keyname)?"
         for field in ['protocol', 'hostname', 'uuid', 'kv_instance_name', 'keyname']:
@@ -71,13 +73,13 @@ class HeadlessShell(object):
             # So if it looks like the user gave a URL that isn't a valid DVID node, then error.
             raise RuntimeError("Invalid URL format for DVID key-value data: {}".format(projectFilePath))
 
-        fields = match.groupdict()            
+        fields = match.groupdict()
         projectFilePath = ProjectManager.downloadProjectFromDvid( fields['hostname'],
                                                                   fields['uuid'],
                                                                   fields['kv_instance_name'],
                                                                   fields['keyname'] )
         return projectFilePath
-        
+
     def openProjectFile(self, projectFilePath, force_readonly=False):
         # If the user gave a URL to a DVID key, then download the project file from dvid first.
         # (So far, DVID is the only type of URL access we support for project files.)
@@ -92,8 +94,8 @@ class HeadlessShell(object):
             hdf5File, workflow_class, readOnly = ProjectManager.openProjectFile(projectFilePath, force_readonly)
 
             # If there are any "creation-time" command-line args saved to the project file,
-            #  load them so that the workflow can be instantiated with the same settings 
-            #  that were used when the project was first created. 
+            #  load them so that the workflow can be instantiated with the same settings
+            #  that were used when the project was first created.
             project_creation_args = []
             if "workflow_cmdline_args" in list(hdf5File.keys()):
                 if len(hdf5File["workflow_cmdline_args"]) > 0:
@@ -105,8 +107,8 @@ class HeadlessShell(object):
                 workflow_class = ilastik.workflows.pixelClassification.PixelClassificationWorkflow
                 import warnings
                 warnings.warn( "Your project file ({}) does not specify a workflow type.  "
-                               "Assuming Pixel Classification".format( projectFilePath ) )            
-            
+                               "Assuming Pixel Classification".format( projectFilePath ) )
+
             # Create our project manager
             # This instantiates the workflow and applies all settings from the project.
             self.projectManager = ProjectManager( self,
@@ -118,12 +120,12 @@ class HeadlessShell(object):
 
         except ProjectManager.FileMissingError:
             logger.error("Couldn't find project file: {}".format( projectFilePath ))
-            raise            
+            raise
         except ProjectManager.ProjectVersionError:
             # Couldn't open project.  Try importing it.
             oldProjectFilePath = projectFilePath
             name, ext = os.path.splitext(oldProjectFilePath)
-    
+
             # Create a brand new project file.
             projectFilePath = name + "_imported" + ext
             logger.info("Importing project as '" + projectFilePath + "'")
@@ -164,6 +166,3 @@ class HeadlessShell(object):
             self.projectManager._closeCurrentProject()
             self.projectManager.cleanUp()
             self.projectManager = None
-
-
-assert issubclass(HeadlessShell, ShellABC), "HeadlessShell does not satisfy the generic shell interface!"

--- a/ilastik/shell/shellAbc.py
+++ b/ilastik/shell/shellAbc.py
@@ -16,54 +16,48 @@
 #
 # See the LICENSE file for details. License information is also available
 # on the ilastik web site at:
-#		   http://ilastik.org/license.html
+# 		   http://ilastik.org/license.html
 ###############################################################################
-from abc import ABCMeta, abstractmethod, abstractproperty
-from future.utils import with_metaclass
 
-def _has_attribute( cls, attr ):
-    return True if any(attr in B.__dict__ for B in cls.__mro__) else False
+from __future__ import annotations
 
-def _has_attributes( cls, attrs ):
-    return True if all(_has_attribute(cls, a) for a in attrs) else False
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Type
 
-class ShellABC(with_metaclass(ABCMeta, object)):
-    """
-    This ABC defines the minimum interface that both the IlastikShell and HeadlessShell must implement.
-    """
+from ilastik.utility.abc import StrictABC
 
-    @abstractproperty
+if TYPE_CHECKING:
+    from ilastik.applets.base.applet import Applet
+    from ilastik.workflow import Workflow
+
+
+class ShellABC(StrictABC):
+    @property
+    @abstractmethod
     def workflow(self):
-        raise NotImplementedError
-
-    @abstractproperty
-    def currentImageIndex(self):
-        raise NotImplementedError
-
-    @abstractmethod
-    def createAndLoadNewProject(self, newProjectFilePath, workflow_class):
-        """
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def openProjectFile(self, projectFilePath):
-        """
-        """
-        raise NotImplementedError
-
-    def setAppletEnabled(self, applet, enabled):
         pass
 
-    def isAppletEnabled(self, applet):
-        return False
-
-    def enableProjectChanges(self, enabled):
+    @property
+    @abstractmethod
+    def currentImageIndex(self) -> int:
         pass
 
+    @abstractmethod
+    def createAndLoadNewProject(self, newProjectFilePath: str, workflow_class: Type[Workflow]) -> None:
+        pass
 
-    @classmethod
-    def __subclasshook__(cls, C):
-        if cls is ShellABC:
-            return _has_attributes(C, ['workflow', 'createAndLoadNewProject', 'openProjectFile', 'setAppletEnabled', 'currentImageIndex'])
-        return NotImplemented
+    @abstractmethod
+    def openProjectFile(self, projectFilePath: str) -> None:
+        pass
+
+    @abstractmethod
+    def setAppletEnabled(self, applet: Applet, enabled: bool) -> None:
+        pass
+
+    @abstractmethod
+    def isAppletEnabled(self, applet: Applet) -> bool:
+        pass
+
+    @abstractmethod
+    def enableProjectChanges(self, enabled: bool) -> None:
+        pass

--- a/ilastik/utility/abc.py
+++ b/ilastik/utility/abc.py
@@ -1,0 +1,67 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+# 		   http://ilastik.org/license.html
+###############################################################################
+
+import abc
+
+
+class StrictABCMeta(abc.ABCMeta):
+    """ABCMeta that validates methods during virtual subclass registration.
+
+    In most cases it's better to derive from :cls:`abc.ABC` to achieve the same effect.
+    However, this class could be useful if implementing classes have parents with
+    complex metaclass machinery that prevents you from doing that (e.g. PyQt).
+
+    See Also:
+        :cls:`StrictABC`
+    """
+
+    def register(cls, subclass: type) -> type:
+        """Register subclass as a "virtual subclass" of this ABC.
+
+        Virtual subclass validity is based only on attribute membership.
+        That is, registering an ABC subclass with abstract methods
+        behaves identical to registering a non-ABC subclass.
+
+        Can be used as a class decorator::
+
+            @MyABC.register
+            class MyCls:
+                ...
+
+        Returns:
+            The registered subclass.
+
+        Raises:
+            TypeError: The subclass does not have all the methods required by this ABC.
+        """
+        missing = ", ".join(sorted(name for name in cls.__abstractmethods__ if not hasattr(subclass, name)))
+        if missing:
+            raise TypeError(f"Can't register class {subclass.__name__} with missing methods {missing}")
+
+        return super().register(subclass)
+
+
+class StrictABC(metaclass=StrictABCMeta):
+    """ABC that validates methods during virtual subclass registration.
+
+    See Also:
+        :cls:`StrictABCMeta`
+    """

--- a/tests/test_utility/test_abc.py
+++ b/tests/test_utility/test_abc.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+from ilastik.utility.abc import StrictABC
+from pytest import raises
+
+
+class SpamABC(StrictABC):
+    @abstractmethod
+    def spam(self):
+        pass
+
+
+class SpamEggsABC(SpamABC):
+    @abstractmethod
+    def eggs(self):
+        pass
+
+
+def noop(_self):
+    pass
+
+
+@abstractmethod
+def abstract_noop(_self):
+    pass
+
+
+@pytest.mark.parametrize(
+    "abc_class,subclass,expectation",
+    [
+        (SpamABC, type("MyCls", (), {"spam": noop}), does_not_raise()),
+        (SpamEggsABC, type("MyCls", (), {"spam": noop}), raises(TypeError)),
+        (SpamEggsABC, type("MyCls", (), {"spam": noop, "eggs": noop}), does_not_raise()),
+        (SpamABC, type("MyCls", (ABC,), {"spam": abstract_noop}), does_not_raise()),
+        (SpamEggsABC, type("MyCls", (ABC,), {"spam": abstract_noop}), raises(TypeError)),
+        (SpamEggsABC, type("MyCls", (ABC,), {"spam": abstract_noop, "eggs": abstract_noop}), does_not_raise()),
+    ],
+)
+def test_StrictABC(abc_class, subclass, expectation):
+    with expectation:
+        abc_class.register(subclass)


### PR DESCRIPTION
`ShellABC` now uses `StrictABCMeta` metaclass and registers it's virtual
subclasses after their definitions.

PyQt5 uses a custom SIP metaclass for QObject and it's subclasses,
making it impossible to use plain `ABC` or `ABCMeta` for `ShellABC`
since `IlastikShell` inherits from `QMainWindow`.

It is possible to define a custom metaclass
`QObjectABCMeta(QObject.__class__, ABCMeta)`  and use it for `ShellABC`,
but in this case we always depend on `QObject`, even though some
subclasses should not use Qt at all (e.g. `HeadlessShell`).

We could use `ABC.register` to "virtually" subclass `ShellABC`. However,
because such subclass is not a real ABC subclass, it is possible to
create an instance even if some abstract methods are not implemented.

Therefore, we perform all necessary checks during the `register` call
in `StrictABCMeta`. This solution automatically provides proper
`__subclasshook__` and `__instancehook__`, together with more meaningful
error message.