### PR TITLE
quickfix: import after volumina/pulls/254

### DIFF
--- a/ilastik/excepthooks.py
+++ b/ilastik/excepthooks.py
@@ -59,7 +59,7 @@ def init_user_mode_excepthook():
 
     def display_and_log(*exc_info):
         # Slot-not-ready errors in the render thread are logged, but not shown to the user.
-        from volumina.pixelpipeline.asyncabcs import IndeterminateRequestError
+        from volumina.pixelpipeline.interface import IndeterminateRequestError
 
         if isinstance(exc_info[1], IndeterminateRequestError):
             logger.warning("Caught unhandled IndeterminateRequestError from volumina.")


### PR DESCRIPTION
`volumina.pixelpipeline.asyncabcs` was superseeded by `volumina.pixelpipeline.interface`

relates to https://github.com/ilastik/volumina/pull/254