### PR TITLE
Don't call cleanupOnDiskView in DataExportGui

### DIFF
--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -206,7 +206,7 @@ class TrackingBaseDataExportGui(DataExportGui, ExportingGui):
         # TODO: remove once tracking is hytra-only
         self._default_export_filename = filename
 
-    def exportResultsForSlot(self, opLane):
+    def exportAsync(self, laneViewList) -> None:
         if (
             self.topLevelOperator.SelectedExportSource.value == OpTrackingBaseDataExport.PluginOnlyName
             and not self.pluginWasSelected
@@ -217,22 +217,8 @@ class TrackingBaseDataExportGui(DataExportGui, ExportingGui):
                 "You did not select any export plugin. \nPlease do so by clicking 'Choose Export Image Settings'",
             )
             return
-        else:
-            super(TrackingBaseDataExportGui, self).exportResultsForSlot(opLane)
 
-    def exportAllResults(self):
-        if (
-            self.topLevelOperator.SelectedExportSource.value == OpTrackingBaseDataExport.PluginOnlyName
-            and not self.pluginWasSelected
-        ):
-            QMessageBox.critical(
-                self,
-                "Choose Export Plugin",
-                "You did not select any export plugin. \nPlease do so by clicking 'Choose Export Image Settings'",
-            )
-            return
-        else:
-            super(TrackingBaseDataExportGui, self).exportAllResults()
+        super().exportAsync(laneViewList)
 
 
 class TrackingBaseResultsViewer(DataExportLayerViewerGui):

--- a/tests/test_workflows/testObjectClassificationGui.py
+++ b/tests/test_workflows/testObjectClassificationGui.py
@@ -454,7 +454,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
             with Timer() as timer:
                 # this will not properly wait for the export to finish.
                 # gui.drawer.exportAllButton.click()
-                gui.exportSlots(op_object_export_tlo)
+                gui.exportSync(op_object_export_tlo)
 
             assert object_export_applet.busy is False
             assert os.path.exists(csv_out), f"Could not find {csv_out}"
@@ -476,7 +476,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
             with Timer() as timer:
                 # this will not properly wait for the export to finish.
                 # gui.drawer.exportAllButton.click()
-                gui.exportSlots(op_object_export_tlo)
+                gui.exportSync(op_object_export_tlo)
 
             assert object_export_applet.busy is False
             assert os.path.exists(h5_out), f"Could not find {h5_out}"


### PR DESCRIPTION
Don't call `opLaneView.cleanupOnDiskView()` for all operators before
running export in a different thread because `OpDataExport.run_export()`
already calls `cleanupOnDiskView()` when needed.

Also, merge methods for exporting a single lane and all lanes because
they are almost identical.

Closes https://github.com/ilastik/ilastik/issues/2097.