### PR TITLE
don't wrap drange in tuple

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -143,7 +143,7 @@ class DatasetInfo(ABC):
         if "normalizeDisplay" in data:
             params["normalizeDisplay"] = (data["normalizeDisplay"][()],)
         if "drange" in data:
-            params["drange"] = (tuple(data["drange"]),)
+            params["drange"] = tuple(data["drange"])
         if "display_mode" in data:
             params["display_mode"] = data["display_mode"][()].decode("utf-8")
         return cls(**params)

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -141,7 +141,7 @@ class DatasetInfo(ABC):
         if "subvolume_roi" in data:
             params["subvolume_roi"] = tuple(data["subvolume_roi"][()])
         if "normalizeDisplay" in data:
-            params["normalizeDisplay"] = (data["normalizeDisplay"][()],)
+            params["normalizeDisplay"] = bool(data["normalizeDisplay"][()])
         if "drange" in data:
             params["drange"] = tuple(data["drange"])
         if "display_mode" in data:


### PR DESCRIPTION
another one-liner that was somewhat hard to spot.

this removes one dimension of tupleing from the drange. Comparison here with numpy.dtype object to tuple fails when loading the project file. This failure is overshadowed by an exception occurring in cleanup...

fixes  #2102