### PR TITLE
Inherit all interpreters from InterpreterABC

### DIFF
--- a/ilastik/applets/counting/countingGuiBoxesInterface.py
+++ b/ilastik/applets/counting/countingGuiBoxesInterface.py
@@ -622,7 +622,7 @@ class CoupledRectangleElement(object):
         del self
 
 
-class BoxInterpreter(QObject):
+class BoxInterpreter(QObject, InterpreterABC):
     boxDrawn = pyqtSignal(QRect)
 
     def __init__(self, base: InterpreterABC, posModel: PositionModel, newBoxParent: QWidget):


### PR DESCRIPTION
Previously, interpreters relied on a custom `__subclasshook__` for
`isinstance` checks. Now, each interpreter is a subclass of
`InterpreterABC`, which is a proper abstract base class.
This change should make it easier to trace class relationships.