### PR TITLE
Restores .ilp forward compatibility

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -48,7 +48,13 @@ from ilastik.utility.gui import ThreadRouter, threadRouted
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 from ilastik.applets.base.applet import DatasetConstraintError
 
-from .opDataSelection import DatasetInfo, FilesystemDatasetInfo, ProjectInternalDatasetInfo, UrlDatasetInfo
+from .opDataSelection import (
+    DatasetInfo,
+    RelativeFilesystemDatasetInfo,
+    FilesystemDatasetInfo,
+    ProjectInternalDatasetInfo,
+    UrlDatasetInfo,
+)
 from .dataLaneSummaryTableModel import DataLaneSummaryTableModel
 from .datasetInfoEditorWidget import DatasetInfoEditorWidget
 from ilastik.widgets.stackFileSelectionWidget import StackFileSelectionWidget, SubvolumeSelectionDlg
@@ -565,7 +571,7 @@ class DataSelectionGui(QWidget):
             self._add_default_inner_path(roleIndex=roleIndex, inner_path=selected_dataset)
             data_path = data_path / re.sub("^/", "", selected_dataset)
 
-        return FilesystemDatasetInfo(
+        return RelativeFilesystemDatasetInfo.create_or_fallback_to_absolute(
             filePath=data_path.as_posix(),
             project_file=self.project_file,
             allowLabels=(self.guiMode == GuiMode.Normal),

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -98,6 +98,7 @@ class DataSelectionSerializer(AppletSerializer):
 
     @timeLogged(logger, logging.DEBUG)
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
+        getOrCreateGroup(topGroup, 'local_data')
         deleteIfPresent(topGroup, "Role Names")
         role_names = [name.encode("utf-8") for name in self.topLevelOperator.DatasetRoles.value]
         topGroup.create_dataset("Role Names", data=role_names)

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -259,10 +259,14 @@ class DataSelectionSerializer(AppletSerializer):
         if len(infoGroup) == 0:
             return None, False
 
-        if "location" in infoGroup:
-            info_class = self.LocationStrings[infoGroup["location"][()].decode("utf-8")]
-        else:
+        if "__class__" in infoGroup:
             info_class = self.InfoClassNames[infoGroup["__class__"][()].decode("utf-8")]
+        else: #legacy support
+            location = infoGroup["location"][()].decode("utf-8")
+            if location == "FileSystem" and isRelative(infoGroup['filePath'][()].decode("utf-8")):
+                info_class = RelativeFilesystemDatasetInfo
+            else:
+                info_class = self.LocationStrings[location]
 
         dirty = False
         try:

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -129,9 +129,9 @@ class DatasetInfo(ABC):
             "nickname": self.nickname.encode("utf-8"),
             "normalizeDisplay": self.normalizeDisplay,
             "drange": self.drange,
-            "location": self.legacy_location.encode("utf-8"), #legacy support
-            "filePath": self.effective_path.encode("utf-8"), #legacy support
-            "datasetId": self.legacy_datasetId.encode("utf-8"), #legacy support
+            "location": self.legacy_location.encode("utf-8"),  # legacy support
+            "filePath": self.effective_path.encode("utf-8"),  # legacy support
+            "datasetId": self.legacy_datasetId.encode("utf-8"),  # legacy support
             "__class__": self.__class__.__name__.encode("utf-8"),
         }
 
@@ -311,7 +311,7 @@ class ProjectInternalDatasetInfo(DatasetInfo):
     def to_json_data(self) -> Dict:
         out = super().to_json_data()
         out["inner_path"] = self.inner_path.encode("utf-8")
-        out["fromstack"] = True # legacy support
+        out["fromstack"] = True  # legacy support
         return out
 
     @classmethod
@@ -533,6 +533,13 @@ class RelativeFilesystemDatasetInfo(FilesystemDatasetInfo):
         super().__init__(**fs_info_kwargs)
         if not self.is_under_project_file():
             raise CantSaveAsRelativePathsException(self.filePath, self.base_dir)
+
+    @classmethod
+    def create_or_fallback_to_absolute(cls, *args, **kwargs):
+        try:
+            return cls(*args, **kwargs)
+        except CantSaveAsRelativePathsException:
+            return FilesystemDatasetInfo(*args, **kwargs)
 
     @property
     def display_string(self):


### PR DESCRIPTION
This patch adds back some properties that were expected by the classic project deserialization system, so that `.ilp` files created with the new versions can be opened with previous versions of ilastik.

We should eventually have multiple deserialization methods and just pick the one that matches the `.ilp` version rather than having new and old properties mixed together as they are today.

fixes #2121