### PR TITLE
Fix automatic inner dataset path selection

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -181,6 +181,7 @@ class DataSelectionGui(QWidget):
         self._initAppletDrawerUic(instructionText)
 
         self._viewerControlWidgetStack = QStackedWidget(self)
+        self._default_h5n5_volumes: Dict[int, Set[str]] = {}
 
         def handleImageRemove(multislot, index, finalLength):
             # Remove the viewer for this dataset
@@ -531,12 +532,12 @@ class DataSelectionGui(QWidget):
         return infos
 
     def _add_default_inner_path(self, roleIndex: int, inner_path: str):
-        paths = self._get_previously_used_inner_paths(roleIndex)
+        paths = self._default_h5n5_volumes.get(roleIndex, set())
         paths.add(inner_path)
-        self.preferences.set("Data Selection", "inner_paths__role{roleIndex}", paths)
+        self._default_h5n5_volumes[roleIndex] = paths
 
     def _get_previously_used_inner_paths(self, roleIndex: int) -> Set[str]:
-        previous_paths = self.preferences.get("Data Selection", "inner_paths__role{roleIndex}", set())
+        previous_paths = self._default_h5n5_volumes.get(roleIndex, set())
         return previous_paths.copy()
 
     def _createDatasetInfo(self, roleIndex: int, filePath: Path, roi=None) -> FilesystemDatasetInfo:

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -141,6 +141,7 @@ class DatasetInfoEditorWidget(QDialog):
         if not hierarchical_infos:
             self.internalDatasetNameLabel.setVisible(False)
             self.internalDatasetNameComboBox.setVisible(False)
+            self.internalDatasetNameComboBoxMessage.setVisible(False)
         else:
             common_internal_paths = set(hierarchical_infos[0].getPossibleInternalPaths())
             current_internal_paths = set(hierarchical_infos[0].internal_paths)
@@ -156,6 +157,7 @@ class DatasetInfoEditorWidget(QDialog):
                 self.internalDatasetNameComboBox.setCurrentText(current_internal_paths.pop())
             else:
                 self.internalDatasetNameComboBox.setCurrentIndex(-1)
+        self.internalDatasetNameComboBox.currentTextChanged.connect(self._handle_inner_path_change)
 
         self.displayModeComboBox.addItem("Default", userData="default")
         self.displayModeComboBox.addItem("Grayscale", userData="grayscale")
@@ -182,6 +184,14 @@ class DatasetInfoEditorWidget(QDialog):
         else:
             comboIndex = -1
         self.storageComboBox.setCurrentIndex(comboIndex)
+
+    def _handle_inner_path_change(self, new_internal_path: str):
+        msg = ""
+        for info in self.current_infos:
+            if new_internal_path and {new_internal_path} != set(info.internal_paths):
+                msg = "Note: Changing internal dataset path will reset the other fields to defaults"
+                break
+        self.internalDatasetNameComboBoxMessage.setText(msg)
 
     def get_new_axes_tags(self):
         if self.axesEdit.isEnabled() and self.axesEdit.text():

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -152,8 +152,8 @@ class DatasetInfoEditorWidget(QDialog):
                 self.internalDatasetNameComboBox.addItem(path)
                 self.internalDatasetNameComboBox.setEnabled(True)
 
-            if len(common_internal_paths) == 1:
-                self.internalDatasetNameComboBox.setCurrentText(common_internal_paths.pop())
+            if len(current_internal_paths) == 1:
+                self.internalDatasetNameComboBox.setCurrentText(current_internal_paths.pop())
             else:
                 self.internalDatasetNameComboBox.setCurrentIndex(-1)
 

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.ui
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.ui
@@ -275,7 +275,20 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="9" column="1" colspan="5">
+      <widget class="QLabel" name="internalDatasetNameComboBoxMessage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: gray; font-style: italic</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
       <widget class="QLabel" name="label_8">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -288,7 +301,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1" colspan="5">
+     <item row="10" column="1" colspan="5">
       <widget class="QComboBox" name="storageComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -298,7 +311,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -311,7 +324,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QComboBox" name="displayModeComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -260,7 +260,7 @@ class DatasetInfo(ABC):
 
         def accumulateInternalPaths(name, val):
             if isinstance(val, (h5py.Dataset, z5py.dataset.Dataset)) and min_ndim <= len(val.shape) <= max_ndim:
-                datasetNames.append(name)
+                datasetNames.append("/" + name)
 
         if cls.pathIsHdf5(file_path):
             with h5py.File(file_path, "r") as f:

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -341,7 +341,7 @@ class ProjectInternalDatasetInfo(DatasetInfo):
 
     @property
     def internal_paths(self) -> List[str]:
-        return [self.inner_path]
+        return []
 
 
 class PreloadedArrayDatasetInfo(DatasetInfo):

--- a/tests/test_applets/pixelClassification/testPixelClassificationGui.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationGui.py
@@ -164,7 +164,7 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
 
         if os.name != "nt":  # FIXME: enable these on windows without hangs or segfaults
             # opens multi dataset file and expects second dialog to choose inner path
-            self.add_file(self.tmp_h5_multiple_dataset, "test_group_3d/test_data_3d")
+            self.add_file(self.tmp_h5_multiple_dataset, "/test_group_3d/test_data_3d")
             self.remove_first_dataset()
 
             # opens multi dataset file and expects inner path to be picked automatically


### PR DESCRIPTION
Reverts automatic inner dataset selection (for, e.g. .h5 or .n5 files with multiple internal datasets) to classic logic, where remembered paths will persist only in a session, but will not leak over other projects.

Fixes pre-selected value in dataset combobox in `DatasetInfoEditorWidget`.

Adds a notice to the UI, informing the user that by changing the inner dataset path all his changes to the other DatasetInfo editor fields will be discarded in favor of the default values; Since we can't know in advance what kind of data will be found in the newly selected dataset, we can't apply the configurations (e.g. axis tags, normalization values) to that dataset, and therefore it's nice to notify the user.

Fixes #2129