### PR TITLE
Removes exported file layer from export applet and export operator

### DIFF
--- a/ilastik/applets/counting/countingDataExportGui.py
+++ b/ilastik/applets/counting/countingDataExportGui.py
@@ -92,12 +92,6 @@ class CountingResultsViewer(DataExportLayerViewerGui):
         layers = []
         opLane = self.topLevelOperatorView
 
-        exportedLayers = self._initPredictionLayers(opLane.ImageOnDisk)
-        for layer in exportedLayers:
-            layer.visible = True
-            layer.name = layer.name + "- Exported"
-        layers += exportedLayers
-
         previewLayers = self._initPredictionLayers(opLane.ImageToExport)
         for layer in previewLayers:
             layer.visible = False

--- a/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
@@ -90,13 +90,6 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
         ]
 
         if selection in ("Object Predictions", "Blockwise Object Predictions"):
-            fromDiskSlot = self.topLevelOperatorView.ImageOnDisk
-            if fromDiskSlot.ready():
-                exportLayer = ColortableLayer(createDataSource(fromDiskSlot), colorTable=self._colorTable16)
-                exportLayer.name = "Prediction - Exported"
-                exportLayer.visible = True
-                layers.append(exportLayer)
-
             previewSlot = self.topLevelOperatorView.ImageToExport
             if previewSlot.ready():
                 previewLayer = ColortableLayer(createDataSource(previewSlot), colorTable=self._colorTable16)
@@ -105,12 +98,6 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
                 layers.append(previewLayer)
 
         elif selection in ("Object Probabilities", "Blockwise Object Probabilities"):
-            exportedLayers = self._initPredictionLayers(opLane.ImageOnDisk)
-            for layer in exportedLayers:
-                layer.visible = True
-                layer.name = layer.name + "- Exported"
-            layers += exportedLayers
-
             previewLayers = self._initPredictionLayers(opLane.ImageToExport)
             for layer in previewLayers:
                 layer.visible = False
@@ -118,12 +105,6 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
             layers += previewLayers
 
         elif selection == "Pixel Probabilities":
-            exportedLayers = self._initPredictionLayers(opLane.ImageOnDisk)
-            for layer in exportedLayers:
-                layer.visible = True
-                layer.name = layer.name + "- Exported"
-            layers += exportedLayers
-
             previewLayers = self._initPredictionLayers(opLane.ImageToExport)
             for layer in previewLayers:
                 layer.visible = False

--- a/ilastik/applets/pixelClassification/pixelClassificationDataExportGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationDataExportGui.py
@@ -66,24 +66,12 @@ class PixelClassificationResultsViewer(DataExportLayerViewerGui):
         selection = selection_names[opLane.InputSelection.value]
 
         if selection.startswith("Probabilities"):
-            exportedLayers = self._initPredictionLayers(opLane.ImageOnDisk)
-            for layer in exportedLayers:
-                layer.visible = True
-                layer.name = layer.name + "- Exported"
-            layers += exportedLayers
-
             previewLayers = self._initPredictionLayers(opLane.ImageToExport)
             for layer in previewLayers:
                 layer.visible = False
                 layer.name = layer.name + "- Preview"
             layers += previewLayers
         elif selection.startswith("Simple Segmentation") or selection.startswith("Labels"):
-            exportedLayer = self._initColortablelayer(opLane.ImageOnDisk)
-            if exportedLayer:
-                exportedLayer.visible = True
-                exportedLayer.name = selection + " - Exported"
-                layers.append(exportedLayer)
-
             previewLayer = self._initColortablelayer(opLane.ImageToExport)
             if previewLayer:
                 previewLayer.visible = False
@@ -102,18 +90,6 @@ class PixelClassificationResultsViewer(DataExportLayerViewerGui):
                 previewLayer.visible = False
                 previewLayer.name = "Uncertainty - Preview"
                 layers.append(previewLayer)
-            if opLane.ImageOnDisk.ready():
-                exportedUncertaintySource = createDataSource(opLane.ImageOnDisk)
-                exportedLayer = AlphaModulatedLayer(
-                    exportedUncertaintySource,
-                    tintColor=QColor(0, 255, 255),  # cyan
-                    range=(0.0, 1.0),
-                    normalize=(0.0, 1.0),
-                )
-                exportedLayer.opacity = 0.5
-                exportedLayer.visible = True
-                exportedLayer.name = "Uncertainty - Exported"
-                layers.append(exportedLayer)
 
         else:  # Features and all other layers.
             if selection.startswith("Features"):
@@ -127,12 +103,6 @@ class PixelClassificationResultsViewer(DataExportLayerViewerGui):
                 previewLayer.name = "{} - Preview".format(selection)
                 previewLayer.set_normalize(0, None)
                 layers.append(previewLayer)
-            if opLane.ImageOnDisk.ready():
-                exportedLayer = self.createStandardLayerFromSlot(opLane.ImageOnDisk)
-                exportedLayer.visible = True
-                exportedLayer.name = "{} - Exported".format(selection)
-                exportedLayer.set_normalize(0, None)
-                layers.append(exportedLayer)
 
         # If available, also show the raw data layer
         rawSlot = opLane.FormattedRawData

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -229,13 +229,6 @@ class TrackingBaseResultsViewer(DataExportLayerViewerGui):
     def setupLayers(self):
         layers = []
 
-        fromDiskSlot = self.topLevelOperatorView.ImageOnDisk
-        if fromDiskSlot.ready():
-            exportLayer = ColortableLayer(createDataSource(fromDiskSlot), colorTable=self.ct)
-            exportLayer.name = "Selected Output - Exported"
-            exportLayer.visible = True
-            layers.append(exportLayer)
-
         previewSlot = self.topLevelOperatorView.ImageToExport
         if previewSlot.ready():
             previewLayer = ColortableLayer(createDataSource(previewSlot), colorTable=self.ct)


### PR DESCRIPTION
Removes the exported, from-disk layers of the export applets. These layers were a bit problematic on windows, as they claimed a handle to the underlying file, making it impossible to overwrite such file in subsequent exports.

Furthermore, this layer would often show stale data, like a previous run of ilastik, or even some run from a different lane if the user was using a static export path like `/tmp/my_export.h5`

Fixes #1547