### PR TITLE
Replace PreferencesManager with module functions

### DIFF
--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -39,7 +39,6 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from volumina.utility import PreferencesManager
 
 from ilastik.utility import log_exception
 from ilastik.utility.gui import ThreadRouter, threadRouted

--- a/ilastik/applets/cropping/croppingGui.py
+++ b/ilastik/applets/cropping/croppingGui.py
@@ -35,7 +35,7 @@ from PyQt5.QtGui import QIcon, QColor, QKeySequence
 
 # HCI
 from volumina.api import LazyflowSinkSource, ColortableLayer
-from volumina.utility import ShortcutManager, PreferencesManager
+from volumina.utility import ShortcutManager
 from volumina import colortables
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.widgets.cropListView import Crop

--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import os
 import re
 from pathlib import Path
-from typing import List, Set
+from typing import Dict, List, Set
 import threading
 import h5py
 from functools import partial
@@ -40,7 +40,7 @@ from PyQt5.QtWidgets import QDialog, QMessageBox, QStackedWidget, QWidget
 from lazyflow.request import Request
 
 # volumina
-from volumina.utility import PreferencesManager
+from volumina.utility import preferences
 
 # ilastik
 from ilastik.utility import bind, log_exception
@@ -168,7 +168,6 @@ class DataSelectionGui(QWidget):
         self._cleaning_up = False
         self.parentApplet = parentApplet
         self._max_lanes = max_lanes
-        self.preferences = PreferencesManager()
         self.show_axis_details = show_axis_details
 
         self._viewerControls = QWidget()
@@ -657,16 +656,17 @@ class DataSelectionGui(QWidget):
         self.addFileNames([precomputed_url], roleIndex, laneIndex)
 
     def addDvidVolume(self, roleIndex, laneIndex):
-        recent_hosts_pref = PreferencesManager.Setting("DataSelection", "Recent DVID Hosts")
-        recent_hosts = recent_hosts_pref.get()
+        group = "DataSelection"
+        recent_hosts_key = "Recent DVID Hosts"
+        recent_hosts = preferences.get(group, recent_hosts_key)
         if not recent_hosts:
             recent_hosts = ["localhost:8000"]
         recent_hosts = [
             h for h in recent_hosts if h
         ]  # There used to be a bug where empty strings could be saved. Filter those out.
 
-        recent_nodes_pref = PreferencesManager.Setting("DataSelection", "Recent DVID Nodes")
-        recent_nodes = recent_nodes_pref.get() or {}
+        recent_nodes_key = "Recent DVID Nodes"
+        recent_nodes = preferences.get(group, recent_nodes_key) or {}
 
         from .dvidDataSelectionBrowser import DvidDataSelectionBrowser
 
@@ -694,9 +694,9 @@ class DataSelectionGui(QWidget):
             recent_hosts = recent_hosts[:10]
 
         # Save pref
-        recent_hosts_pref.set(recent_hosts)
+        preferences.set(group, recent_hosts_key, recent_hosts)
 
         recent_nodes[hostname] = node_uuid
-        recent_nodes_pref.set(recent_nodes)
+        preferences.set(group, recent_nodes_key, recent_nodes)
 
         self.addLanes([UrlDatasetInfo(url=dvid_url, subvolume_roi=subvolume_roi)], roleIndex)

--- a/ilastik/applets/featureSelection/featureSelectionGui.py
+++ b/ilastik/applets/featureSelection/featureSelectionGui.py
@@ -35,7 +35,7 @@ import lazyflow.operators.filterOperators as filterOps
 from lazyflow.operators.generic import OpSubRegion
 
 # volumina
-from volumina.utility import PreferencesManager
+from volumina.utility import preferences
 from volumina.widgets.layercontextmenu import layercontextmenu
 
 # ilastik
@@ -249,7 +249,7 @@ class FeatureSelectionGui(LayerViewerGui):
         self.featureDlg = FeatureDlg(parent=self)
         self.featureDlg.setWindowTitle("Features")
         try:
-            size = PreferencesManager().get("featureSelection", "dialog size")
+            size = preferences.get("featureSelection", "dialog size")
             self.featureDlg.resize(*size)
         except TypeError:
             pass
@@ -257,7 +257,7 @@ class FeatureSelectionGui(LayerViewerGui):
         def saveSize():
             size = self.featureDlg.size()
             s = (size.width(), size.height())
-            PreferencesManager().set("featureSelection", "dialog size", s)
+            preferences.set("featureSelection", "dialog size", s)
 
         self.featureDlg.accepted.connect(saveSize)
         self.featureDlg.setImageToPreView(None)

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -36,7 +36,7 @@ from PyQt5.QtWidgets import QApplication, QMessageBox, QAction
 
 # HCI
 from volumina.api import LazyflowSinkSource, ColortableLayer, GrayscaleLayer
-from volumina.utility import ShortcutManager, PreferencesManager
+from volumina.utility import ShortcutManager, preferences
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.widgets.labelListView import Label
 from ilastik.widgets.labelListModel import LabelListModel
@@ -322,8 +322,8 @@ class LabelingGui(LayerViewerGui):
 
         _labelControlUi.brushSizeComboBox.currentIndexChanged.connect(self._onBrushSizeChange)
 
-        self.paintBrushSizeIndex = PreferencesManager().get("labeling", "paint brush size", default=0)
-        self.eraserSizeIndex = PreferencesManager().get("labeling", "eraser brush size", default=4)
+        self.paintBrushSizeIndex = preferences.get("labeling", "paint brush size", default=0)
+        self.eraserSizeIndex = preferences.get("labeling", "eraser brush size", default=4)
 
     def onLabelListDataChanged(self, topLeft, bottomRight):
         """Handle changes to the label list selections."""
@@ -504,9 +504,10 @@ class LabelingGui(LayerViewerGui):
         The user has selected another applet or is closing the whole app.
         Save all preferences.
         """
-        with PreferencesManager() as prefsMgr:
-            prefsMgr.set("labeling", "paint brush size", self.paintBrushSizeIndex)
-            prefsMgr.set("labeling", "eraser brush size", self.eraserSizeIndex)
+        preferences.setmany(
+            ("labeling", "paint brush size", self.paintBrushSizeIndex),
+            ("labeling", "eraser brush size", self.eraserSizeIndex),
+        )
         super(LabelingGui, self).hideEvent(event)
 
     def _handleToolButtonClicked(self, checked, toolId):

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -45,9 +45,6 @@ from PyQt5.QtWidgets import (
     QApplication,
 )
 
-# volumina
-from volumina.utility import PreferencesManager
-
 # lazyflow
 import lazyflow
 from lazyflow.utility import chunked_bincount

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -41,7 +41,7 @@ from PyQt5.QtWidgets import (
 from ilastik.utility.gui import threadRouted
 from volumina.api import createDataSource
 from volumina.layer import SegmentationEdgesLayer
-from volumina.utility import ShortcutManager, PreferencesManager
+from volumina.utility import ShortcutManager
 
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui

--- a/ilastik/applets/networkClassification/nnClassGui.py
+++ b/ilastik/applets/networkClassification/nnClassGui.py
@@ -28,7 +28,7 @@ import numpy
 import torch
 
 from volumina.api import createDataSource, AlphaModulatedLayer
-from volumina.utility import PreferencesManager
+from volumina.utility import preferences
 
 from PyQt5 import uic
 from PyQt5.QtCore import Qt, pyqtSlot
@@ -441,7 +441,7 @@ class NNClassGui(LayerViewerGui):
         """
         When AddModels button is clicked.
         """
-        mostRecentImageFile = PreferencesManager().get("DataSelection", "recent models")
+        mostRecentImageFile = preferences.get("DataSelection", "recent models")
         mostRecentImageFile = str(mostRecentImageFile)
         if mostRecentImageFile is not None:
             defaultDirectory = os.path.split(mostRecentImageFile)[0]

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -57,7 +57,7 @@ from PyQt5.QtGui import QColor, QIcon, QCursor
 
 # HCI
 from volumina.api import createDataSource, AlphaModulatedLayer, GrayscaleLayer, ColortableLayer
-from volumina.utility import ShortcutManager, PreferencesManager
+from volumina.utility import ShortcutManager
 
 from lazyflow.utility import PathComponents
 from lazyflow.roi import slicing_to_string

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -66,7 +66,7 @@ from lazyflow.utility import timeLogged, isUrl
 from lazyflow.request import Request
 
 # volumina
-from volumina.utility import PreferencesManager, ShortcutManagerDlg, ShortcutManager
+from volumina.utility import preferences, ShortcutManagerDlg, ShortcutManager
 
 # ilastik
 from ilastik.workflow import getAvailableWorkflows, getWorkflowFromName
@@ -429,7 +429,7 @@ class IlastikShell(QMainWindow):
 
         self.errorMessageFilter = ErrorMessageFilter(self)
 
-        frame_geometry = PreferencesManager().get("shell", "startscreenGeometry")
+        frame_geometry = preferences.get("shell", "startscreenGeometry")
         if frame_geometry is not None:
             x, y, w, h = frame_geometry
             self.move(x, y)
@@ -570,7 +570,7 @@ class IlastikShell(QMainWindow):
             b.deleteLater()
         self.openFileButtons = []
 
-        projects = PreferencesManager().get("shell", "recently opened list")
+        projects = preferences.get("shell", "recently opened list")
 
         if projects is not None:
             # (projects is already sorted from most-recent to least-recent.)
@@ -726,7 +726,7 @@ class IlastikShell(QMainWindow):
             assert not yappi.is_running()
 
             filename = "ilastik_profile_sortedby_{}.txt".format(sortby)
-            recentPath = PreferencesManager().get("shell", "recent sorted profile stats")
+            recentPath = preferences.get("shell", "recent sorted profile stats")
             if recentPath is None:
                 defaultPath = os.path.join(os.path.expanduser("~"), filename)
             else:
@@ -741,7 +741,7 @@ class IlastikShell(QMainWindow):
 
             if stats_path:
                 pstats_path = os.path.splitext(stats_path)[0] + ".pstats"
-                PreferencesManager().set("shell", "recent sorted profile stats", stats_path)
+                preferences.set("shell", "recent sorted profile stats", stats_path)
 
                 # Export the yappi stats to builtin pstats format,
                 #  since pstats provides nicer printing IMHO
@@ -762,7 +762,7 @@ class IlastikShell(QMainWindow):
 
             filename = "ilastik_threadstats_sortedby_{}.txt".format(sortby)
 
-            recentPath = PreferencesManager().get("shell", "recent sorted profile stats")
+            recentPath = preferences.get("shell", "recent sorted profile stats")
             if recentPath is None:
                 defaultPath = os.path.join(os.path.expanduser("~"), filename)
             else:
@@ -776,7 +776,7 @@ class IlastikShell(QMainWindow):
             )
 
             if stats_path:
-                PreferencesManager().set("shell", "recent sorted profile stats", stats_path)
+                preferences.set("shell", "recent sorted profile stats", stats_path)
 
                 # Export the yappi stats to builtin pstats format,
                 #  since pstats provides nicer printing IMHO
@@ -820,11 +820,11 @@ class IlastikShell(QMainWindow):
         return profilingSubmenu
 
     def _createAllocationTrackingSubmenu(self):
-        self._allocation_threshold = PreferencesManager().get("shell", "allocation tracking threshold")
+        self._allocation_threshold = preferences.get("shell", "allocation tracking threshold")
         if self._allocation_threshold is None:
             self._allocation_threshold = 1000000  # 1 MB by default
 
-        self._traceback_depth = PreferencesManager().get("shell", "allocation tracking traceback depth")
+        self._traceback_depth = preferences.get("shell", "allocation tracking traceback depth")
         if self._traceback_depth is None:
             self._traceback_depth = 3  # default
 
@@ -870,10 +870,10 @@ class IlastikShell(QMainWindow):
             dlg.setLayout(layout)
             if dlg.exec_() == QDialog.Accepted:
                 self._allocation_threshold = threshold_box.value()
-                PreferencesManager().set("shell", "allocation tracking threshold", self._allocation_threshold)
+                preferences.set("shell", "allocation tracking threshold", self._allocation_threshold)
 
                 self._traceback_depth = traceback_depth_box.value()
-                PreferencesManager().set("shell", "allocation tracking traceback depth", self._traceback_depth)
+                preferences.set("shell", "allocation tracking traceback depth", self._traceback_depth)
 
         def _startAllocationTracking():
             self._allocation_tracker = PrettyAllocationTracker(self._allocation_threshold, self._traceback_depth)
@@ -887,7 +887,7 @@ class IlastikShell(QMainWindow):
             stopAction.setEnabled(False)
 
             filename = "ilastik-tracked-numpy-allocations.html"
-            recentPath = PreferencesManager().get("shell", "allocation tracking output html")
+            recentPath = preferences.get("shell", "allocation tracking output html")
             if recentPath is None:
                 defaultPath = os.path.join(os.path.expanduser("~"), filename)
             else:
@@ -902,7 +902,7 @@ class IlastikShell(QMainWindow):
             )
 
             if html_path:
-                PreferencesManager().set("shell", "allocation tracking output html", html_path)
+                preferences.set("shell", "allocation tracking output html", html_path)
                 self._allocation_tracker.write_html(html_path)
 
                 # As a convenience, go ahead and open it.
@@ -968,7 +968,7 @@ class IlastikShell(QMainWindow):
         self.exportOperatorDiagram(self.projectManager.workflow, detail)
 
     def exportOperatorDiagram(self, op, detail):
-        recentPath = PreferencesManager().get("shell", "recent debug diagram")
+        recentPath = preferences.get("shell", "recent debug diagram")
         if recentPath is None:
             defaultPath = os.path.join(os.path.expanduser("~"), op.name + ".svg")
         else:
@@ -983,7 +983,7 @@ class IlastikShell(QMainWindow):
         )
 
         if svgPath:
-            PreferencesManager().set("shell", "recent debug diagram", svgPath)
+            preferences.set("shell", "recent debug diagram", svgPath)
             lazyflow.tools.schematic.generateSvgFileForOperator(svgPath, op, detail)
             QDesktopServices.openUrl(QUrl.fromLocalFile(svgPath))
 
@@ -1348,7 +1348,7 @@ class IlastikShell(QMainWindow):
         logger.debug("Import Project Action")
 
         # Find the directory of the most recently *imported* project
-        mostRecentImportPath = PreferencesManager().get("shell", "recently imported")
+        mostRecentImportPath = preferences.get("shell", "recently imported")
         if mostRecentImportPath is not None:
             defaultDirectory = os.path.split(mostRecentImportPath)[0]
         else:
@@ -1357,7 +1357,7 @@ class IlastikShell(QMainWindow):
         # Select the paths to the ilp to import and the name of the new one we'll create
         importedFilePath = self.getProjectPathToOpen(defaultDirectory)
         if importedFilePath is not None:
-            PreferencesManager().set("shell", "recently imported", importedFilePath)
+            preferences.set("shell", "recently imported", importedFilePath)
             defaultFile, ext = os.path.splitext(importedFilePath)
             defaultFile += "_imported"
             defaultFile += ext
@@ -1375,16 +1375,17 @@ class IlastikShell(QMainWindow):
     def onDownloadProjectFromDvidActionTriggered(self):
         logger.debug("Download Project From DVID")
 
-        recent_hosts_pref = PreferencesManager.Setting("DataSelection", "Recent DVID Hosts")
-        recent_hosts = recent_hosts_pref.get()
+        group = "DataSelection"
+        recent_hosts_key = "Recent DVID Hosts"
+        recent_hosts = preferences.get(group, recent_hosts_key)
         if not recent_hosts:
             recent_hosts = ["localhost:8000"]
         recent_hosts = [
             h for h in recent_hosts if h
         ]  # There used to be a bug where empty strings could be saved. Filter those out.
 
-        recent_nodes_pref = PreferencesManager.Setting("DataSelection", "Recent DVID Nodes")
-        recent_nodes = recent_nodes_pref.get() or {}
+        recent_nodes_key = "Recent DVID Nodes"
+        recent_nodes = preferences.get(group, recent_nodes_key) or {}
 
         # Ask for a selection.
         from libdvid.gui import ContentsBrowser
@@ -1414,8 +1415,8 @@ class IlastikShell(QMainWindow):
 
         # Save pref
         recent_nodes[str(hostname)] = str(node_uuid)
-        recent_nodes_pref.set(recent_nodes)
-        recent_hosts_pref.set(recent_hosts)
+        preferences.set(group, recent_nodes_key, recent_nodes)
+        preferences.set(group, recent_hosts_key, recent_hosts)
 
         # Open
         self.openProjectFile(dvid_url)
@@ -1442,7 +1443,7 @@ class IlastikShell(QMainWindow):
         logger.debug("Open Project action triggered")
 
         # Find the directory of the most recently opened project
-        mostRecentProjectPath = PreferencesManager().get("shell", "recently opened")
+        mostRecentProjectPath = preferences.get("shell", "recently opened")
         if mostRecentProjectPath:
             defaultDirectory = os.path.split(mostRecentProjectPath)[0]
         else:
@@ -1560,7 +1561,7 @@ class IlastikShell(QMainWindow):
                 logger.debug("Loading the project took {:.2f} sec.".format(stop - start))
 
                 # add file and workflow to users preferences
-                mostRecentProjectPaths = PreferencesManager().get("shell", "recently opened list")
+                mostRecentProjectPaths = preferences.get("shell", "recently opened list")
                 if mostRecentProjectPaths is None:
                     mostRecentProjectPaths = []
 
@@ -1577,8 +1578,8 @@ class IlastikShell(QMainWindow):
                 if len(mostRecentProjectPaths) > 5:
                     mostRecentProjectPaths = mostRecentProjectPaths[:5]
 
-                PreferencesManager().set("shell", "recently opened list", mostRecentProjectPaths)
-                PreferencesManager().set("shell", "recently opened", projectFilePath)
+                preferences.set("shell", "recently opened list", mostRecentProjectPaths)
+                preferences.set("shell", "recently opened", projectFilePath)
 
                 # be friendly to user: if this file has not specified a default workflow, do it now
                 if not "workflowName" in list(hdf5File.keys()) and not readOnly:
@@ -1795,7 +1796,7 @@ class IlastikShell(QMainWindow):
     def closeAndQuit(self, quitApp=True):
         geom = self.frameGeometry()
         x, y, width, height = geom.x(), geom.y(), geom.width(), geom.height()
-        PreferencesManager().set("shell", "startscreenGeometry", (x, y, width, height))
+        preferences.set("shell", "startscreenGeometry", (x, y, width, height))
 
         if self.projectManager is not None:
             self.closeCurrentProject()

--- a/ilastik/widgets/ImageFileDialog.py
+++ b/ilastik/widgets/ImageFileDialog.py
@@ -17,12 +17,6 @@ class ImageFileDialog(QFileDialog):
     ):
         self.preferences_group = preferences_group
         self.preferences_setting = preferences_setting
-        # Find the directory of the most recently opened image file
-        mostRecentImageFile = preferences.get(preferences_group, preferences_setting)
-        if mostRecentImageFile is None:
-            defaultDirectory = os.path.expanduser("~")
-        else:
-            defaultDirectory = os.path.dirname(str(mostRecentImageFile))
 
         ext_str = " ".join(f"*.{ext}" for ext in OpDataSelection.SupportedExtensions)
         filters = f"Image files ({ext_str})"
@@ -30,7 +24,7 @@ class ImageFileDialog(QFileDialog):
         super().__init__(
             parent_window,
             caption="Select Images",
-            directory=defaultDirectory,
+            directory=str(Path(preferences.get(preferences_group, preferences_setting, Path.home()))),
             filter=filters,
             options=QFileDialog.Options(),
         )
@@ -39,7 +33,7 @@ class ImageFileDialog(QFileDialog):
     def getSelectedPaths(self) -> List[Path]:
         if not super().exec_():
             return []
-        preferences.set(self.preferences_group, self.preferences_setting, self.selectedFiles()[0])
+        preferences.set(self.preferences_group, self.preferences_setting, Path(self.selectedFiles()[0]).as_posix())
         filePaths = []
         for selected_file in self.selectedFiles():
             path = Path(selected_file)

--- a/ilastik/widgets/ImageFileDialog.py
+++ b/ilastik/widgets/ImageFileDialog.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from PyQt5.QtWidgets import QFileDialog
 
-from volumina.utility import PreferencesManager
+from volumina.utility import preferences
 from ilastik.applets.dataSelection.opDataSelection import OpDataSelection
 
 
@@ -14,13 +14,11 @@ class ImageFileDialog(QFileDialog):
         parent_window,
         preferences_group: str = "DataSelection",
         preferences_setting: str = "recent image",
-        preferences_manager: PreferencesManager = PreferencesManager(),
     ):
         self.preferences_group = preferences_group
         self.preferences_setting = preferences_setting
-        self.preferences_manager = preferences_manager
         # Find the directory of the most recently opened image file
-        mostRecentImageFile = preferences_manager.get(preferences_group, preferences_setting)
+        mostRecentImageFile = preferences.get(preferences_group, preferences_setting)
         if mostRecentImageFile is None:
             defaultDirectory = os.path.expanduser("~")
         else:
@@ -41,7 +39,7 @@ class ImageFileDialog(QFileDialog):
     def getSelectedPaths(self) -> List[Path]:
         if not super().exec_():
             return []
-        self.preferences_manager.set(self.preferences_group, self.preferences_setting, self.selectedFiles()[0])
+        preferences.set(self.preferences_group, self.preferences_setting, self.selectedFiles()[0])
         filePaths = []
         for selected_file in self.selectedFiles():
             path = Path(selected_file)

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QDialogButtonBox, QComboBox, QDialog, QFileDialog, Q
 
 import vigra
 
-from volumina.utility import PreferencesManager
+from volumina.utility import preferences
 
 import ilastik.config
 from ilastik.widgets.hdf5SubvolumeSelectionDialog import H5N5StackingDlg, SubvolumeSelectionDlg
@@ -117,7 +117,7 @@ class StackFileSelectionWidget(QDialog):
 
     def _chooseDirectory(self):
         # Find the directory of the most recently opened image file
-        mostRecentStackDirectory = PreferencesManager().get("DataSelection", "recent stack directory")
+        mostRecentStackDirectory = preferences.get("DataSelection", "recent stack directory")
         if mostRecentStackDirectory is not None:
             defaultDirectory = os.path.split(mostRecentStackDirectory)[0]
         else:
@@ -134,7 +134,7 @@ class StackFileSelectionWidget(QDialog):
             # User cancelled
             return
 
-        PreferencesManager().set("DataSelection", "recent stack directory", directory)
+        preferences.set("DataSelection", "recent stack directory", directory)
 
         self.directoryEdit.setText(directory)
         try:
@@ -253,7 +253,7 @@ class StackFileSelectionWidget(QDialog):
 
     def _selectFiles(self):
         # Find the directory of the most recently opened image file
-        mostRecentStackDirectory = PreferencesManager().get("DataSelection", "recent stack directory")
+        mostRecentStackDirectory = preferences.get("DataSelection", "recent stack directory")
         if mostRecentStackDirectory is not None:
             defaultDirectory = os.path.split(mostRecentStackDirectory)[0]
         else:
@@ -300,7 +300,7 @@ class StackFileSelectionWidget(QDialog):
             return None
 
         directory = pathComponents.externalPath
-        PreferencesManager().set("DataSelection", "recent stack directory", directory)
+        preferences.set("DataSelection", "recent stack directory", directory)
 
         if (
             pathComponents.extension in OpStreamingH5N5SequenceReaderM.H5EXTS

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -38,7 +38,7 @@ from lazyflow.request import Request
 # volumina
 from volumina.api import createDataSource, ArraySource
 from volumina.layer import ColortableLayer, GrayscaleLayer
-from volumina.utility import ShortcutManager, PreferencesManager
+from volumina.utility import ShortcutManager, preferences
 
 from ilastik.widgets.labelListModel import LabelListModel
 
@@ -475,7 +475,7 @@ class CarvingGui(LabelingGui):
         """
         Export a single object mesh to a user-specified filename.
         """
-        recent_dir = PreferencesManager().get("carving", "recent export mesh directory")
+        recent_dir = preferences.get("carving", "recent export mesh directory")
         if recent_dir is None:
             defaultPath = os.path.join(os.path.expanduser("~"), "{}obj".format(_name))
         else:
@@ -486,7 +486,7 @@ class CarvingGui(LabelingGui):
         if not filepath:
             return
         obj_filepath = str(filepath)
-        PreferencesManager().set("carving", "recent export mesh directory", os.path.split(obj_filepath)[0])
+        preferences.set("carving", "recent export mesh directory", os.path.split(obj_filepath)[0])
 
         self._exportMeshes([_name], [obj_filepath])
 
@@ -499,7 +499,7 @@ class CarvingGui(LabelingGui):
             QMessageBox.critical(self, "Can't Export", "You have no saved objets, so there are no meshes to export.")
             return
 
-        recent_dir = PreferencesManager().get("carving", "recent export mesh directory")
+        recent_dir = preferences.get("carving", "recent export mesh directory")
         if recent_dir is None:
             defaultPath = os.path.join(os.path.expanduser("~"))
         else:
@@ -508,7 +508,7 @@ class CarvingGui(LabelingGui):
         if not export_dir:
             return
         export_dir = str(export_dir)
-        PreferencesManager().set("carving", "recent export mesh directory", export_dir)
+        preferences.set("carving", "recent export mesh directory", export_dir)
 
         # Get the list of all object names
         object_names = []

--- a/tests/widgets/test_ImageFileDialog.py
+++ b/tests/widgets/test_ImageFileDialog.py
@@ -33,19 +33,18 @@ def image(tmp_path) -> Path:
 
 def test_default_image_directory_is_home_with_blank_preferences_file():
     dialog = ImageFileDialog(None)
-    assert dialog.directory().absolutePath() == Path("~").expanduser().absolute().as_posix()
+    assert dialog.directory().absolutePath() == Path.home().as_posix()
 
 
 def test_picking_file_updates_default_image_directory_to_previously_used(image: Path, tmp_preferences):
     dialog = ImageFileDialog(None)
-    assert dialog.directory().absolutePath() == Path("~").expanduser().absolute().as_posix()
     dialog.selectFile(image.as_posix())
 
     QTimer.singleShot(SINGLE_SHOT_DELAY, dialog.accept)
     assert dialog.getSelectedPaths() == [image]
 
     with open(tmp_preferences, "rb") as f:
-        assert pickle.load(f) == {dialog.preferences_group: {dialog.preferences_setting: str(image)}}
+        assert pickle.load(f) == {dialog.preferences_group: {dialog.preferences_setting: image.as_posix()}}
 
 
 def test_picking_n5_json_file_returns_directory_path(tmp_n5_file: Path):


### PR DESCRIPTION
PreferencesManager is a singleton that controls access to a preferences
file on disk. Since Python has module-level variables, singleton classes
can be replaced with private variables and public functions in a module.

Needs https://github.com/ilastik/volumina/pull/260.