### PR TITLE
Restores ability to use PreloadedDatasetInfo when batch processing

### DIFF
--- a/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
+++ b/tests/test_applets/pixelClassification/testPixelClassificationHeadless.py
@@ -116,8 +116,6 @@ class TestPixelClassificationHeadless(object):
         from ilastik.applets.dataSelection.opDataSelection import FilesystemDatasetInfo
 
         info = FilesystemDatasetInfo(filePath=dataset_path)
-        print(f"\n\n\n~~~~~~~~~~~~~~~~~~~~~>>>>info:{info.axiskeys}\n\n\n")
-        # import pydevd; pydevd.settrace()
         opDataSelection = workflow.dataSelectionApplet.topLevelOperator
         opDataSelection.DatasetGroup.resize(1)
         opDataSelection.DatasetGroup[0][0].setValue(info)


### PR DESCRIPTION
The ability to use a `PreloadedDatasaetInfo` in batch processing (which is useful when using ilastik inside a python script) was lost during the big `DatasetInfo` overhaul. This patches restores that capability and adds a test which is very much based on `examples/example_python_client.py`

Fixes #2137