### PR TITLE
Fixes deserialization issue with sample projects: more lenient with 'axistags'

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -150,6 +150,7 @@ class DatasetInfo(ABC):
         elif "axisorder" in data:  # legacy support
             axisorder = data["axisorder"][()].decode("utf-8")
             params["axistags"] = vigra.defaultAxistags(axisorder)
+
         if "subvolume_roi" in data:
             params["subvolume_roi"] = tuple(data["subvolume_roi"][()])
         if "normalizeDisplay" in data:

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -140,12 +140,16 @@ class DatasetInfo(ABC):
         params = params or {}
         params.update(
             {
-                "axistags": AxisTags.fromJSON(data["axistags"][()].decode("utf-8")),
                 "allowLabels": data["allowLabels"][()],
                 "nickname": data["nickname"][()].decode("utf-8"),
                 "project_file": data.file,
             }
         )
+        if "axistags" in data:
+            params["axistags"] = AxisTags.fromJSON(data["axistags"][()].decode("utf-8"))
+        elif "axisorder" in data:  # legacy support
+            axisorder = data["axisorder"][()].decode("utf-8")
+            params["axistags"] = vigra.defaultAxistags(axisorder)
         if "subvolume_roi" in data:
             params["subvolume_roi"] = tuple(data["subvolume_roi"][()])
         if "normalizeDisplay" in data:


### PR DESCRIPTION
Old projects might have input data without axistags. The new deserializer was always expecting for that key to be present.

This PR changes this behavior to allow for data without axistags, using the legacy 'axisorder' if present or defaulting to the vigra default axis order if hat is not present either.