### PR TITLE
Quickfix: changed default export path for project-internal data

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -348,6 +348,10 @@ class ProjectInternalDatasetInfo(DatasetInfo):
     def internal_paths(self) -> List[str]:
         return []
 
+    @property
+    def default_output_dir(self) -> Path:
+        return Path(self.project_file.filename).parent
+
 
 class PreloadedArrayDatasetInfo(DatasetInfo):
     def __init__(self, *, preloaded_array: numpy.ndarray, axistags: AxisTags = None, nickname: str = "", **info_kwargs):


### PR DESCRIPTION
default location changed from home-directory to project file location by overriding the base-class method.

`default_output_dir` will be accessed in `OpDataExport` to determine the output location for our magic value `{dataset_dir}`.