### PR TITLE
Fix depreciated methods for NetworkX 2.4 and above

### DIFF
--- a/ilastik/applets/tracking/structured/opStructuredTracking.py
+++ b/ilastik/applets/tracking/structured/opStructuredTracking.py
@@ -391,8 +391,8 @@ class OpStructuredTracking(OpConservationTracking):
                                         and self.appearances[time][label][track]
                                     ):
                                         # print("---> appearance",time,label,track)
-                                        if (time, int(label)) in list(hypothesesGraph._graph.node.keys()):
-                                            hypothesesGraph._graph.node[(time, int(label))]["appearance"] = True
+                                        if (time, int(label)) in list(hypothesesGraph._graph.nodes.keys()):
+                                            hypothesesGraph._graph.nodes[(time, int(label))]["appearance"] = True
                                             logger.debug(
                                                 "[structuredTrackingGui] APPEARANCE: {} {}".format(time, int(label))
                                             )
@@ -405,8 +405,8 @@ class OpStructuredTracking(OpConservationTracking):
                                         and self.disappearances[time][label][track]
                                     ):
                                         # print("---> disappearance",time,label,track)
-                                        if (time, int(label)) in list(hypothesesGraph._graph.node.keys()):
-                                            hypothesesGraph._graph.node[(time, int(label))]["disappearance"] = True
+                                        if (time, int(label)) in list(hypothesesGraph._graph.nodes.keys()):
+                                            hypothesesGraph._graph.nodes[(time, int(label))]["disappearance"] = True
                                             logger.debug(
                                                 "[structuredTrackingGui] DISAPPEARANCE: {} {}".format(time, int(label))
                                             )
@@ -417,8 +417,8 @@ class OpStructuredTracking(OpConservationTracking):
                                     )
 
                                 elif type[0] in ["FIRST", "LAST", "INTERMEDIATE", "SINGLETON(FIRST_LAST)"]:
-                                    if (time, int(label)) in list(hypothesesGraph._graph.node.keys()):
-                                        hypothesesGraph._graph.node[(time, int(label))]["value"] = trackCount
+                                    if (time, int(label)) in list(hypothesesGraph._graph.nodes.keys()):
+                                        hypothesesGraph._graph.nodes[(time, int(label))]["value"] = trackCount
                                         logger.debug("[structuredTrackingGui] NODE: {} {}".format(time, int(label)))
                                         # print "[structuredTrackingGui] NODE: {} {} {}".format(time, int(label), int(trackCount))
                                     else:
@@ -446,7 +446,7 @@ class OpStructuredTracking(OpConservationTracking):
                         if parent >= 0:
                             children = [int(self.getLabelTT(time + 1, division[0][i])) for i in [0, 1]]
                             parentNode = (time, parent)
-                            hypothesesGraph._graph.node[parentNode]["divisionValue"] = 1
+                            hypothesesGraph._graph.nodes[parentNode]["divisionValue"] = 1
                             foundAllArcs = False
                             for child in children:
                                 for edge in hypothesesGraph._graph.out_edges(
@@ -763,6 +763,6 @@ class OpStructuredTracking(OpConservationTracking):
                 child = cls.getLabelT(childTrack, labels[t + 1])
                 traxelgraph._graph.edges[((t, parent), (t + 1, child))]["value"] = 1
                 traxelgraph._graph.edges[((t, parent), (t + 1, child))]["gap"] = 1
-            traxelgraph._graph.node[(t, parent)]["divisionValue"] = True
+            traxelgraph._graph.nodes[(t, parent)]["divisionValue"] = True
 
         return traxelgraph

--- a/ilastik/plugins_default/tracking_csv_export.py
+++ b/ilastik/plugins_default/tracking_csv_export.py
@@ -85,8 +85,8 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
 
         for rowIdx, node in enumerate(graph.nodes()):
             frame, label = node
-            trackId = graph.node[node]["trackId"]
-            lineageId = graph.node[node]["lineageId"]
+            trackId = graph.nodes[node]["trackId"]
+            lineageId = graph.nodes[node]["lineageId"]
 
             if trackId is None:
                 trackId = -1
@@ -100,14 +100,14 @@ class TrackingCSVExportFormatPlugin(TrackingExportFormatPlugin):
 
             # insert parent of a division
             try:
-                table[rowIdx, 4] = graph.node[graph.node[node]["parent"]]["trackId"]
+                table[rowIdx, 4] = graph.nodes[graph.nodes[node]["parent"]]["trackId"]
             except KeyError:
                 table[rowIdx, 4] = 0
 
             # insert merger
             try:
-                if isinstance(graph.node[node]["mergerValue"], int):
-                    table[rowIdx, 5] = graph.node[node]["mergerValue"]
+                if isinstance(graph.nodes[node]["mergerValue"], int):
+                    table[rowIdx, 5] = graph.nodes[node]["mergerValue"]
                 else:
                     table[rowIdx, 5] = 0
             except KeyError:

--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -39,21 +39,21 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
 
         for n in hypothesesGraph.nodeIterator():
             frameMapping = mappings.setdefault(n[0], {})
-            if "trackId" not in hypothesesGraph._graph.node[n]:
+            if "trackId" not in hypothesesGraph._graph.nodes[n]:
                 raise ValueError("You need to compute the Lineage of every node before accessing the trackId!")
-            trackId = hypothesesGraph._graph.node[n]["trackId"]
+            trackId = hypothesesGraph._graph.nodes[n]["trackId"]
             if trackId is not None:
                 frameMapping[n[1]] = trackId
             if trackId in tracks.keys():
                 tracks[trackId].append(n[0])
             else:
                 tracks[trackId] = [n[0]]
-            if "parent" in hypothesesGraph._graph.node[n]:
+            if "parent" in hypothesesGraph._graph.nodes[n]:
                 assert trackId not in trackParents
-                trackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]["parent"]]["trackId"]
-            if "gap_parent" in hypothesesGraph._graph.node[n]:
+                trackParents[trackId] = hypothesesGraph._graph.nodes[hypothesesGraph._graph.nodes[n]["parent"]]["trackId"]
+            if "gap_parent" in hypothesesGraph._graph.nodes[n]:
                 assert trackId not in trackParents
-                gapTrackParents[trackId] = hypothesesGraph._graph.node[hypothesesGraph._graph.node[n]["gap_parent"]][
+                gapTrackParents[trackId] = hypothesesGraph._graph.nodes[hypothesesGraph._graph.nodes[n]["gap_parent"]][
                     "trackId"
                 ]
 

--- a/ilastik/plugins_default/tracking_json_export.py
+++ b/ilastik/plugins_default/tracking_json_export.py
@@ -38,7 +38,7 @@ else:
 
             numStates = -1
             for n in hypothesesGraph.nodeIterator():
-                t = hypothesesGraph._graph.node[n]["traxel"]
+                t = hypothesesGraph._graph.nodes[n]["traxel"]
                 if "detProb" in t.Features:
                     numStates = len(t.Features["detProb"])
                     break
@@ -47,9 +47,9 @@ else:
 
             dummyVector = np.zeros(numStates)
             for n in hypothesesGraph.nodeIterator():
-                t = hypothesesGraph._graph.node[n]["traxel"]
+                t = hypothesesGraph._graph.nodes[n]["traxel"]
                 if "detProb" not in t.Features:
-                    logger.debug(f"replacing detProb of node with ID={hypothesesGraph._graph.node[n]['id']}")
+                    logger.debug(f"replacing detProb of node with ID={hypothesesGraph._graph.nodes[n]['id']}")
                     t.Features["detProb"] = dummyVector
 
             # now we can insert the energies into the graph

--- a/ilastik/plugins_default/tracking_mamut_export.py
+++ b/ilastik/plugins_default/tracking_mamut_export.py
@@ -68,8 +68,8 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         presentTrackIds = set([])
         for node in graph.nodes():
             frame, label = node
-            # print(f"Node {node} has value={graph.node[node]['value']} and trackId={graph.node[node]['trackId']}")
-            if graph.node[node]["value"] > 0:
+            # print(f"Node {node} has value={graph.nodes[node]['value']} and trackId={graph.nodes[node]['trackId']}")
+            if graph.nodes[node]["value"] > 0:
                 for category in list(features[frame].keys()):
                     for key in list(features[frame][category].keys()):
                         feature_string = convertKeyName(key)
@@ -100,8 +100,8 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         # insert edges
         for edge in graph.edges():
             if graph.edges[edge]["value"] > 0:
-                builder.addLink(graph.node[edge[0]]["trackId"], graph.node[edge[0]]["id"], graph.node[edge[1]]["id"])
-                presentTrackIds.add(int(graph.node[edge[0]]["trackId"]))
+                builder.addLink(graph.nodes[edge[0]]["trackId"], graph.nodes[edge[0]]["id"], graph.nodes[edge[1]]["id"])
+                presentTrackIds.add(int(graph.nodes[edge[0]]["trackId"]))
 
         # assign random colors to tracks that have at least one edge (empty tracks cause MaMuT errors)
         randomColorPerTrack = {}
@@ -112,9 +112,9 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
         # second pass over the nodes passes features and tracks to the builder
         for node in graph.nodes():
             frame, label = node
-            if graph.node[node]["value"] > 0:
-                t = graph.node[node]["traxel"]
-                trackId = int(graph.node[node]["trackId"])
+            if graph.nodes[node]["value"] > 0:
+                t = graph.nodes[node]["traxel"]
+                trackId = int(graph.nodes[node]["trackId"])
 
                 radius = 2 * features[frame]["Standard Object Features"]["RegionRadii"][label, 0]
 
@@ -161,7 +161,7 @@ class TrackingMamutExportFormatPlugin(TrackingExportFormatPlugin):
 
                 featureDict["LabelimageId"] = label
                 builder.addSpot(
-                    frame, "track-{}".format(trackId), graph.node[node]["id"], xpos, ypos, zpos, radius, featureDict
+                    frame, "track-{}".format(trackId), graph.nodes[node]["id"], xpos, ypos, zpos, radius, featureDict
                 )
 
         additional_plugin_args = pluginExportContext.additionalPluginArgumentsSlot.value

--- a/tests/test_applets/structuredLearningTracking/testOpStructuredTracking.py
+++ b/tests/test_applets/structuredLearningTracking/testOpStructuredTracking.py
@@ -1,4 +1,5 @@
 import pytest
+import networkx as nx
 from hytra.core.hypothesesgraph import HypothesesGraph
 from hytra.core.probabilitygenerator import Traxel
 from ilastik.applets.tracking.structured.opStructuredTracking import (
@@ -20,10 +21,10 @@ def tracklet_graph():
     # t:   0      1    2    3
 
     h = HypothesesGraph()
-    h._graph.add_path([(0, 0), (1, 1), (2, 2)])
-    h._graph.add_path([(1, 1), (2, 3), (3, 4)])
-    h._graph.add_path([(2, 3), (3, 5)])
-    h._graph.add_path([(1, 6), (2, 7), (3, 8)])
+    nx.add_path(h._graph, [(0, 0), (1, 1), (2, 2)])
+    nx.add_path(h._graph, [(1, 1), (2, 3), (3, 4)])
+    nx.add_path(h._graph, [(2, 3), (3, 5)])
+    nx.add_path(h._graph, [(1, 6), (2, 7), (3, 8)])
     for n in h._graph.nodes:
         h._graph.nodes[n]["id"] = n[1]
         h._graph.nodes[n]["traxel"] = Traxel()


### PR DESCRIPTION
* Replaced by nx.add_path(graph, [...]) since NetworkX 2.1
* https://github.com/networkx/networkx/commit/6b1ce03f485076d39994e8d624bbf6ca82466eb9
* graph.node -> graph.nodes