### PR TITLE
fix drag and drop

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -399,9 +399,9 @@ class DataSelectionGui(QWidget):
         """
         # Launch the "Open File" dialog
         paths = ImageFileDialog(self).getSelectedPaths()
-        self.addFileNames(paths, roleIndex, startingLaneNum)
+        self.addFileNames(paths, startingLaneNum, roleIndex)
 
-    def addFileNames(self, paths: List[Path], roleIndex: int, startingLaneNum: int):
+    def addFileNames(self, paths: List[Path], startingLaneNum: int, roleIndex: int):
         # If the user didn't cancel
         if paths:
             try:
@@ -653,7 +653,7 @@ class DataSelectionGui(QWidget):
             return
 
         precomputed_url = browser.selected_url
-        self.addFileNames([precomputed_url], roleIndex, laneIndex)
+        self.addFileNames([precomputed_url], laneIndex, roleIndex)
 
     def addDvidVolume(self, roleIndex, laneIndex):
         group = "DataSelection"


### PR DESCRIPTION
* determine row position for drop events
* convert paths to `pathlib.Path objects` (assumed by consuming function)
* changed signature of `DataSelectionGui.addFilePaths` in order to use with
  two-parameter signal and partial (moved `rowIndex` to last position in
  parameters).

fixes #2143, fixes #1251, fixes #1013