### PR TITLE
deprecated undocumented command line args

### DIFF
--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -76,6 +76,20 @@ OUTPUT_COLUMNS = [
 ]
 
 
+class _DeprecatedStoreConstAction(argparse._StoreConstAction):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        warnings.warn(
+            f"Using the {self.option_strings} argument is deprecated. Please consult "
+            "https://www.ilastik.org/documentation/basics/headless#headless-mode-for-object-classification "
+            "for information on setting the source for the output."
+        )
+
+        super().__call__(parser, namespace, values, option_string)
+
+
 class ObjectClassificationWorkflow(Workflow):
     workflowName = "Object Classification Workflow Base"
     defaultAppletIndex = 0  # show DataSelection by default
@@ -212,13 +226,13 @@ class ObjectClassificationWorkflow(Workflow):
         exportImageArgGroup.add_argument(
             "--export_object_prediction_img",
             dest="export_source",
-            action="store_const",
+            action=_DeprecatedStoreConstAction,
             const=self.ExportNames.OBJECT_PREDICTIONS.displayName,
         )
         exportImageArgGroup.add_argument(
             "--export_object_probability_img",
             dest="export_source",
-            action="store_const",
+            action=_DeprecatedStoreConstAction,
             const=self.ExportNames.OBJECT_PROBABILITIES.displayName,
         )
         return parser, exportImageArgGroup
@@ -586,7 +600,7 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         exportImageArgGroup.add_argument(
             "--export_pixel_probability_img",
             dest="export_source",
-            action="store_const",
+            action=_DeprecatedStoreConstAction,
             const=self.ExportNames.PIXEL_PROBABILITIES.displayName,
         )
         return parser, exportImageArgGroup


### PR DESCRIPTION
In object classification headless mode, using either of
 * `--export_object_prediction_img`
 * `--export_object_probability_img`
 * `--export_pixel_probability_img`

will now produce a warning. We should aim at removing those options in the future. They are not mentioned in our docs and

> There should be one-- and preferably only one --obvious way to do it.

We have the `--export_source` param to do that.