### PR TITLE
Quickfix export objectids

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
@@ -89,6 +89,7 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
             "Object Probabilities",
             "Blockwise Object Predictions",
             "Blockwise Object Probabilities",
+            "Object Identities",
             "Pixel Probabilities",
         ]
 
@@ -113,6 +114,10 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
                 layer.visible = False
                 layer.name = layer.name + "- Preview"
             layers += previewLayers
+        elif selection == "Object Identities":
+            previewSlot = self.topLevelOperatorView.ImageToExport
+            layer = self._initColortableLayer(previewSlot)
+            layers += layer
         else:
             assert False, "Unknown selection."
 
@@ -151,3 +156,16 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
                 layers.append(predictLayer)
 
         return layers
+
+    def _initColortableLayer(self, labelSlot):
+        objectssrc = createDataSource(labelSlot)
+        objectssrc.setObjectName("LabelImage LazyflowSrc")
+        ct = colortables.create_default_16bit()
+        ct[0] = QColor(0, 0, 0, 0).rgba()  # make 0 transparent
+        layer = ColortableLayer(objectssrc, ct)
+        layer.name = "Object Identities - Preview"
+        layer.setToolTip("Segmented objects, shown in different colors")
+        layer.visible = False
+        layer.opacity = 0.5
+        layer.colortableIsRandom = True
+        return [layer]

--- a/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
@@ -117,7 +117,7 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
         elif selection == "Object Identities":
             previewSlot = self.topLevelOperatorView.ImageToExport
             layer = self._initColortableLayer(previewSlot)
-            layers += layer
+            layers.append(layer)
         else:
             assert False, "Unknown selection."
 
@@ -168,4 +168,4 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
         layer.visible = False
         layer.opacity = 0.5
         layer.colortableIsRandom = True
-        return [layer]
+        return layer

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,23 +18,17 @@ from __future__ import print_function
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
 from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QObject, pyqtBoundSignal, QSize
+from PyQt5.QtCore import pyqtSlot, Qt
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QFileDialog, QTableWidget, QTableWidgetItem, QGridLayout, QProgressBar
 from ilastik.shell.gui.ipcManager import IPCFacade, Protocol
 
-from ilastik.widgets.featureTableWidget import FeatureEntry
-from ilastik.widgets.featureDlg import FeatureDlg
-from ilastik.widgets.exportObjectInfoDialog import ExportObjectInfoDialog
 from ilastik.applets.objectExtraction.opObjectExtraction import default_features_key
-from ilastik.applets.objectClassification.opObjectClassification import OpObjectClassification
 
 import os
-import sys
 import copy
 import vigra
 
@@ -55,19 +47,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.shell.gui.iconMgr import ilastikIcons
 
 import volumina.colortables as colortables
-from volumina.api import (
-    createDataSource,
-    GrayscaleLayer,
-    ColortableLayer,
-    AlphaModulatedLayer,
-    ClickableColortableLayer,
-    LazyflowSinkSource,
-)
+from volumina.api import createDataSource, ColortableLayer, AlphaModulatedLayer, LazyflowSinkSource
 
 from volumina.interpreter import ClickInterpreter
 from volumina.utility import ShortcutManager

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -653,10 +653,11 @@ class ObjectClassificationGui(LabelingGui):
             objectssrc = createDataSource(segmentedSlot)
             ct[0] = QColor(0, 0, 0, 0).rgba()  # make 0 transparent
             objLayer = ColortableLayer(objectssrc, ct)
-            objLayer.name = "Objects"
+            objLayer.name = "Object Identities"
             objLayer.opacity = 0.5
             objLayer.visible = False
-            objLayer.setToolTip("Segmented objects (labeled image/connected components)")
+            objLayer.setToolTip("Segmented objects, shown in different colors")
+            objLayer.colortableIsRandom = True
             layers.append(objLayer)
 
         uncertaintySlot = self.op.UncertaintyEstimateImage
@@ -683,8 +684,6 @@ class ObjectClassificationGui(LabelingGui):
             layers.append(uncertaintyLayer)
 
         if binarySlot.ready():
-            ct_binary = [0, QColor(255, 255, 255, 255).rgba()]
-
             # white foreground on transparent background, even for labeled images
             binct = [QColor(255, 255, 255, 255).rgba()] * 65536
             binct[0] = 0
@@ -693,7 +692,7 @@ class ObjectClassificationGui(LabelingGui):
             binLayer.name = "Binary image"
             binLayer.visible = True
             binLayer.opacity = 1.0
-            binLayer.setToolTip("Segmentation results as a binary mask")
+            binLayer.setToolTip("Segmented objects, binary mask")
             layers.append(binLayer)
 
         if atlas_slot.ready():

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -446,8 +446,9 @@ class ObjectExtractionGui(LayerViewerGui):
             self.objectssrc.setObjectName("LabelImage LazyflowSrc")
             ct[0] = QColor(0, 0, 0, 0).rgba()  # make 0 transparent
             layer = ColortableLayer(self.objectssrc, ct)
-            layer.name = "Objects (connected components)"
+            layer.name = "Object Identities"
             layer.setToolTip("Segmented objects, shown in different colors")
+            layer.colortableIsRandom = True
             layer.visible = False
             layer.opacity = 0.5
             layers.append(layer)

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -343,7 +343,8 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
             outputLayer.name = "Final output"
             outputLayer.visible = False
             outputLayer.opacity = 1.0
-            outputLayer.setToolTip("Results of thresholding and size filter")
+            outputLayer.colortableIsRandom = True
+            outputLayer.setToolTip("Object Identities: Results of thresholding, connected components and size filter")
             layers.append(outputLayer)
 
         if op.InputChannelColors.ready():

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -78,6 +78,7 @@ class ObjectClassificationWorkflow(Workflow):
             OBJECT_PROBABILITIES = enum.auto()
             BLOCKWISE_OBJECT_PREDICTIONS = enum.auto()
             BLOCKWISE_OBJECT_PROBABILITIES = enum.auto()
+            OBJECT_IDENTITIES = enum.auto()
 
         return ExportNames
 
@@ -304,6 +305,7 @@ class ObjectClassificationWorkflow(Workflow):
         opDataExport.Inputs[self.ExportNames.BLOCKWISE_OBJECT_PROBABILITIES].connect(
             opBlockwiseObjectClassification.ProbabilityChannelImage
         )
+        opDataExport.Inputs[self.ExportNames.OBJECT_IDENTITIES].connect(opObjClassification.SegmentationImagesOut)
 
         opObjClassification = self.objectClassificationApplet.topLevelOperator.getLane(laneIndex)
         opBlockwiseObjectClassification = self.blockwiseObjectClassificationApplet.topLevelOperator.getLane(laneIndex)

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -22,7 +22,6 @@ from abc import abstractmethod
 import sys
 import os
 import enum
-import warnings
 import argparse
 import csv
 
@@ -30,29 +29,20 @@ import numpy
 import h5py
 
 from ilastik.workflow import Workflow
-from ilastik.applets.dataSelection import DataSelectionApplet, DatasetInfo
+from ilastik.applets.dataSelection import DataSelectionApplet
 from ilastik.applets.featureSelection import FeatureSelectionApplet
 from ilastik.applets.pixelClassification import PixelClassificationApplet
-from ilastik.applets.featureSelection.opFeatureSelection import OpFeatureSelection
-from ilastik.applets.pixelClassification.opPixelClassification import OpPredictionPipeline
-from ilastik.applets.thresholdTwoLevels import ThresholdTwoLevelsApplet, OpThresholdTwoLevels
+from ilastik.applets.thresholdTwoLevels import ThresholdTwoLevelsApplet
 from ilastik.applets.objectExtraction import ObjectExtractionApplet
 from ilastik.applets.objectClassification import ObjectClassificationApplet, ObjectClassificationDataExportApplet
 from ilastik.applets.objectClassification.opObjectClassification import TableExporter
 from ilastik.applets.fillMissingSlices import FillMissingSlicesApplet
-from ilastik.applets.fillMissingSlices.opFillMissingSlices import OpFillMissingSlicesNoCache
-from ilastik.applets.blockwiseObjectClassification import (
-    BlockwiseObjectClassificationApplet,
-    OpBlockwiseObjectClassification,
-)
+from ilastik.applets.blockwiseObjectClassification import BlockwiseObjectClassificationApplet
 from ilastik.applets.batchProcessing import BatchProcessingApplet
 
-from lazyflow.graph import Graph, OperatorWrapper, OutputSlot
+from lazyflow.graph import Graph, OutputSlot
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-from lazyflow.operators.generic import OpTransposeSlots, OpSelectSubslot
-from lazyflow.operators.valueProviders import OpAttributeSelector
 from lazyflow.roi import TinyVector
-from lazyflow.utility import PathComponents
 from ilastik.applets.objectExtraction.opObjectExtraction import default_features_key
 from ilastik.utility import SlotNameEnum
 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -131,7 +131,7 @@ class ConservationTrackingWorkflowBase(Workflow):
         )
 
         opDataExport = self.dataExportApplet.topLevelOperator
-        opDataExport.SelectionNames.setValue(["Object-Identities", "Tracking-Result", "Merger-Result"])
+        opDataExport.SelectionNames.setValue(["Tracking-Result", "Merger-Result", "Object-Identities"])
         opDataExport.WorkingDirectory.connect(opDataSelection.WorkingDirectory)
 
         # Extra configuration for object export table (as CSV table or HDF5 table)
@@ -293,9 +293,9 @@ class ConservationTrackingWorkflowBase(Workflow):
         opTracking.NumLabels.connect(opCellClassification.NumLabels)
 
         opDataExport.Inputs.resize(3)
-        opDataExport.Inputs[0].connect(opTracking.RelabeledImage)
-        opDataExport.Inputs[1].connect(opTracking.Output)
-        opDataExport.Inputs[2].connect(opTracking.MergerOutput)
+        opDataExport.Inputs[0].connect(opTracking.Output)
+        opDataExport.Inputs[1].connect(opTracking.MergerOutput)
+        opDataExport.Inputs[2].connect(opTracking.RelabeledImage)
         opDataExport.RawData.connect(op5Raw.Output)
         opDataExport.RawDatasetInfo.connect(opData.DatasetGroup[0])
 


### PR DESCRIPTION
Added the "object identities" layer to the set of exportable sources.

In order to enable some workflows that take might take object identities as an input (e.g. atlas/prediction mask) it is really beneficial to have this output in object classification available not only via right click export.

fixes #2106, fixes #1868 
