### PR TITLE
Remove filepath in h5 before updating

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -98,7 +98,7 @@ class DataSelectionSerializer(AppletSerializer):
 
     @timeLogged(logger, logging.DEBUG)
     def _serializeToHdf5(self, topGroup, hdf5File, projectFilePath):
-        getOrCreateGroup(topGroup, 'local_data')
+        getOrCreateGroup(topGroup, "local_data")
         deleteIfPresent(topGroup, "Role Names")
         role_names = [name.encode("utf-8") for name in self.topLevelOperator.DatasetRoles.value]
         topGroup.create_dataset("Role Names", data=role_names)
@@ -261,9 +261,9 @@ class DataSelectionSerializer(AppletSerializer):
 
         if "__class__" in infoGroup:
             info_class = self.InfoClassNames[infoGroup["__class__"][()].decode("utf-8")]
-        else: #legacy support
+        else:  # legacy support
             location = infoGroup["location"][()].decode("utf-8")
-            if location == "FileSystem" and isRelative(infoGroup['filePath'][()].decode("utf-8")):
+            if location == "FileSystem" and isRelative(infoGroup["filePath"][()].decode("utf-8")):
                 info_class = RelativeFilesystemDatasetInfo
             else:
                 info_class = self.LocationStrings[location]
@@ -298,7 +298,10 @@ class DataSelectionSerializer(AppletSerializer):
                     raise e
                 dirty = True
                 repaired_paths.extend([str(p) for p in paths])
-            infoGroup["filePath"] = os.path.pathsep.join(repaired_paths)
+
+            if "filePath" in infoGroup:
+                del infoGroup["filePath"]
+            infoGroup["filePath"] = os.path.pathsep.join(repaired_paths).encode("utf-8")
             datasetInfo = info_class.from_h5_group(infoGroup)
 
         return datasetInfo, dirty

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,7 +275,7 @@ def tmp_h5_multiple_dataset(tmp_path: Path) -> Path:
 @pytest.fixture
 def tmp_n5_file(tmp_path: Path) -> Path:
     n5_dir_path = tmp_path / "my_tmp_file.n5"
-    f = z5py.File(n5_dir_path)
+    f = z5py.File(str(n5_dir_path))
     ds = f.create_dataset("data", shape=(1000, 1000), chunks=(100, 100), dtype="float32")
 
     # write array to a roi


### PR DESCRIPTION
This fixes our functionality of replacing the path of an image file after it has been moved.

Checks whether `filepath` is in the h5 group already and removes it before
updating if necessary. Also made sure to save the new filepath utf-8 encoded.


"+" some sneaky black changes courtesy of my pre-commit hook...