### PR TITLE
multicut: show solver selection only in debug mode

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -131,8 +131,15 @@ class EdgeTrainingGui(LayerViewerGui):
         self.train_from_gt_button.clicked.connect(lambda: op.FreezeClassifier.setValue(False))
 
         def enable_live_update_on_edges_available(*args, **kwargs):
-            have_edges = op.EdgeLabelsDict.ready() and bool(op.EdgeLabelsDict.value)
-            self.live_update_button.setEnabled(have_edges)
+            any_have_edges = False
+            top_level_edge_labels_dict = op.EdgeLabelsDict.top_level_slot
+            assert top_level_edge_labels_dict.level == 1
+            for subslot in op.EdgeLabelsDict.top_level_slot:
+                any_have_edges = subslot.ready() and bool(subslot.value)
+                if any_have_edges:
+                    break
+
+            self.live_update_button.setEnabled(any_have_edges)
 
         cleanup_fn = op.EdgeLabelsDict.notifyDirty(enable_live_update_on_edges_available)
         self.__cleanup_fns.append(cleanup_fn)

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -137,6 +137,10 @@ class EdgeTrainingGui(LayerViewerGui):
         cleanup_fn = op.EdgeLabelsDict.notifyDirty(enable_live_update_on_edges_available)
         self.__cleanup_fns.append(cleanup_fn)
 
+        # call once when instantiating with a saved project to make the live update button available
+        # if there are annotations loaded from file.
+        enable_live_update_on_edges_available()
+
         # Layout
         label_layout = QHBoxLayout()
         label_layout.addWidget(self.clear_labels_button)

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -144,7 +144,11 @@ class MulticutGuiMixin(object):
         for solver_name in AVAILABLE_SOLVER_NAMES:
             solver_name_combo.addItem(solver_name)
         configure_update_handlers(solver_name_combo.currentIndexChanged, op.SolverName)
-        drawer_layout.addLayout(control_layout("Solver", solver_name_combo))
+
+        # Only add the solver checkbox in debug mode
+        if dbg:
+            drawer_layout.addLayout(control_layout("Solver", solver_name_combo))
+
         self.solver_name_combo = solver_name_combo
 
         button_layout = QHBoxLayout()


### PR DESCRIPTION
We only have a single solver to choose from these days anyway.
SO it's just overcrowding the ui for normal users.

Also addresses the problem of live-update being disabled when loading a file with annotations present #2062