### PR TITLE
Disable multilane for multicut

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -511,7 +511,7 @@ class DataSelectionGui(QWidget):
             endingLane = min(startingLaneNum + len(infos) - 1, len(self.topLevelOperator.DatasetGroup))
 
         if self._max_lanes and endingLane >= self._max_lanes:
-            raise Exception("You may not add more than {self._max_lanes} file(s) to this workflow.  Please try again.")
+            raise Exception("You may not add more than {self._max_lanes} file(s) to this workflow.")
 
         return (startingLaneNum, endingLane)
 

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -77,7 +77,9 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
 
         # -- DataSelection applet
         #
-        self.dataSelectionApplet = DataSelectionApplet(self, "Input Data", "Input Data", forceAxisOrder=["zyxc", "yxc"])
+        self.dataSelectionApplet = DataSelectionApplet(
+            self, "Input Data", "Input Data", forceAxisOrder=["zyxc", "yxc"], max_lanes=1
+        )
 
         # Dataset inputs
         opDataSelection = self.dataSelectionApplet.topLevelOperator


### PR DESCRIPTION
Multicut will currently freeze when used with more than one lane. See #2189 for more background. This PR disables the multi-lane functionality for now until the issue is fixed.