### PR TITLE
Force FilesystemDatasetInfo when recovering from missing files

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -302,7 +302,7 @@ class DataSelectionSerializer(AppletSerializer):
             if "filePath" in infoGroup:
                 del infoGroup["filePath"]
             infoGroup["filePath"] = os.path.pathsep.join(repaired_paths).encode("utf-8")
-            datasetInfo = info_class.from_h5_group(infoGroup)
+            datasetInfo = FilesystemDatasetInfo.from_h5_group(infoGroup)
 
         return datasetInfo, dirty
 


### PR DESCRIPTION
If the missing file was caused because the original link was relative
and the project file was moved, then the previous behavior was to
try to instantiate a RelativeFilesystemDatasetInfo from the fixed file
path. That file could very well exist in a path that could not be
expressed relative to the current project file (i.e. in the same folder
or in any subfolder), raising an exception.

This patch forces fixed missing files to use FilesystemFatasetInfo,
which is an absolute path and therefore cannot cause this problem.