### PR TITLE
Execute legacy GUI tests before anything else

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   VOLUMINA_SHOW_3D_WIDGET: 0
 
 cache:
-  - '%MINICONDA%\pkgs' -> appveyor.yml
+  - C:\Miniconda37-x64\pkgs -> appveyor.yml
 
 install:
   - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
   IlASTIK_ROOT: C:\ilastik
   VOLUMINA_SHOW_3D_WIDGET: 0
 
+cache:
+  - '%MINICONDA%\pkgs' -> appveyor.yml
 
 install:
   - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%

--- a/ilastik/utility/gui/threadRouter.py
+++ b/ilastik/utility/gui/threadRouter.py
@@ -21,8 +21,13 @@ from __future__ import print_function
 # 		   http://ilastik.org/license.html
 ###############################################################################
 import threading
+import logging
+
 from functools import partial, wraps
 from PyQt5.QtCore import QObject, pyqtSignal, Qt
+
+
+logger = logging.getLogger(__name__)
 
 
 class ThreadRouter(QObject):
@@ -65,6 +70,7 @@ def threadRoutedWithRouter(threadRouter):
         @wraps(func)
         def routed(*args, **kwargs):
             if ThreadRouter.app_is_shutting_down:
+                logger.warning("Won't execute threadRouted function %s because app is shutting down", func)
                 return
 
             router = threadRouter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,7 @@ def pytest_runtestloop(session):
     if session.config.getoption("run_legacy_gui"):
         for tstcls, gui_test_bag in itertools.groupby(_sorted_guitests(guitests), get_guitest_cls):
             run_gui_tests(tstcls, gui_test_bag)
+            ThreadRouter.app_is_shutting_down = False
 
     elif guitests:
         warnings.warn("Skipping legacy GUI test to enable please use --run-legacy-gui option\n")
@@ -184,7 +185,6 @@ def run_gui_tests(tstcls, gui_test_bag):
     tst_queue = queue.Queue()
     app = tstcls.app = QApplication([])
     app.setQuitOnLastWindowClosed(False)
-    ThreadRouter.app_is_shutting_down = False
     app.thread_router = ThreadRouter(app)
     tstcls.shell = launchShell(None, [], [])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,6 @@ def pytest_runtestloop(session):
     # Modify session leaving only normal tests as session.items
     # Gui test should be run separately
     guitests, session.items = split_guitests(session.items)
-    _pytest_runtestloop(session)
 
     if session.config.getoption("run_legacy_gui"):
         for tstcls, gui_test_bag in itertools.groupby(_sorted_guitests(guitests), get_guitest_cls):
@@ -174,6 +173,8 @@ def pytest_runtestloop(session):
 
     elif guitests:
         warnings.warn("Skipping legacy GUI test to enable please use --run-legacy-gui option\n")
+
+    _pytest_runtestloop(session)
 
     return True
 


### PR DESCRIPTION
It seems like there is slowdown because when GUI tests run in the end which may result in timeouts. 