### PR TITLE
mnt: numpy.fromstring -> numpy.frombuffer

### DIFF
--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -166,7 +166,7 @@ def _read_array(fd, buf_remaining):
     n_bytes, = struct.unpack("<L", n_bytes_buf)
 
     data_buf, buf_remaining = _read_min_chars(fd, n_bytes, buf_remaining)
-    larr = numpy.fromstring(data_buf, dtype=dtype_char)
+    larr = numpy.frombuffer(data_buf, dtype=dtype_char)
     return larr, buf_remaining
 
 
@@ -256,7 +256,7 @@ class UfmfV1(UfmfBase):
         (self._version, self._image_radius, self._timestamp0, self._width, self._height) = intup
         # extract background
         bg_im_buf = self._fd.read(self._width * self._height)
-        self._bg_im = numpy.fromstring(bg_im_buf, dtype=numpy.uint8)
+        self._bg_im = numpy.frombuffer(bg_im_buf, dtype=numpy.uint8)
         self._bg_im.shape = self._height, self._width
         if hasattr(self, "handle_bg"):
             self.handle_bg(self._timestamp0, self._bg_im)
@@ -350,7 +350,7 @@ class UfmfV1(UfmfBase):
                     read_length = chunkwidth * chunkheight
                     bufshape = chunkheight, chunkwidth
                 buf = self._fd.read(read_length)
-                bufim = numpy.fromstring(buf, dtype=numpy.uint8)
+                bufim = numpy.frombuffer(buf, dtype=numpy.uint8)
                 bufim.shape = bufshape
                 regions.append((xmin, ymin, bufim))
             yield timestamp, regions
@@ -407,13 +407,13 @@ class _UFmfV3LowLevelReader:
         if self._coding == b"rgb24":
             read_len = width * height * sz * self._bytesperpixel
             buf = self._fd_read(read_len)
-            frame = numpy.fromstring(buf, dtype=dtype)
+            frame = numpy.frombuffer(buf, dtype=dtype)
             frame.shape = (3, height, width)
             frame = frame.transpose((1, 2, 0))
         elif self._coding == b"mono8":
             read_len = width * height * sz
             buf = self._fd_read(read_len)
-            frame = numpy.fromstring(buf, dtype=dtype)
+            frame = numpy.frombuffer(buf, dtype=dtype)
             frame.shape = (height, width)
         else:
             raise NotImplementedError("Color coding %s not yet implemented" % self._coding)
@@ -439,13 +439,13 @@ class _UFmfV3LowLevelReader:
             if self._coding == b"rgb24":
                 lenbuf = w * h * self._bytesperpixel
                 buf = self._fd_read(lenbuf)
-                im = numpy.fromstring(buf, dtype=numpy.uint8)
+                im = numpy.frombuffer(buf, dtype=numpy.uint8)
                 im.shape = (self._bytesperpixel, h, w)
                 im = im.transpose((1, 2, 0))
             elif self._coding == b"mono8":
                 lenbuf = w * h
                 buf = self._fd_read(lenbuf)
-                im = numpy.fromstring(buf, dtype=numpy.uint8)
+                im = numpy.frombuffer(buf, dtype=numpy.uint8)
                 im.shape = (h, w)
             else:
                 raise NotImplementedError("Color coding %s not yet implemented" % self._coding)
@@ -502,13 +502,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
             # all pixel values.
             lenbuf = n_pts * self._points2_sz
             buf = self._fd_read(lenbuf)
-            locs = numpy.fromstring(buf, dtype=numpy.uint16)
+            locs = numpy.frombuffer(buf, dtype=numpy.uint16)
             locs.shape = (2, n_pts)
             # the pixel values are indexed by box number, followed by
             # column, followed by row, followed by color
             lenbuf = n_pts * self._w * self._h * self._bytesperpixel
             buf = self._fd_read(lenbuf)
-            im = numpy.fromstring(buf, dtype=numpy.uint8)
+            im = numpy.frombuffer(buf, dtype=numpy.uint8)
             im.shape = (self._bytesperpixel, self._h, self._w, n_pts)
             im = im.transpose(1, 2, 0, 3)
             # if we need regions to be backwards compatible, we
@@ -530,13 +530,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
                 if self._coding == b"rgb24":
                     lenbuf = w * h * self._bytesperpixel
                     buf = self._fd_read(lenbuf)
-                    im = numpy.fromstring(buf, dtype=numpy.uint8)
+                    im = numpy.frombuffer(buf, dtype=numpy.uint8)
                     im.shape = (self._bytesperpixel, h, w)
                     im = im.transpose((1, 2, 0))
                 elif self._coding == b"mono8":
                     lenbuf = w * h
                     buf = self._fd_read(lenbuf)
-                    im = numpy.fromstring(buf, dtype=numpy.uint8)
+                    im = numpy.frombuffer(buf, dtype=numpy.uint8)
                     im.shape = (h, w)
                 else:
                     raise NotImplementedError("Color coding %s not yet implemented" % self._coding)

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -1,31 +1,23 @@
 # This file was copied from the motmot ufmf GitHub repository: https://github.com/motmot/ufmf commit c795ffe369b7e58de69d34926388af33ce71b711
 
-from __future__ import division
-from __future__ import absolute_import
-from builtins import range
-from builtins import object
-
 # TODO: Convert this file to use bytes instead of str
 # from builtins import chr
 #
 
-import sys
-import struct, collections
+import struct
+import collections
 import warnings
-import os.path, hashlib
-import os, stat
+import hashlib
+import os
 
 import numpy
-from numpy import nan
 import logging
 
-logger = logging.getLogger(__name__)
-
-import time
-
-import math
 
 from . import FlyMovieFormat as FMF
+
+
+logger = logging.getLogger(__name__)
 
 
 class UfmfError(Exception):
@@ -100,46 +92,6 @@ class NoMoreFramesException(Exception):
 
 class InvalidMovieFileException(Exception):
     pass
-
-
-class UfmfParser(object):
-    """derive from this class to create your own parser
-
-    you will need to implemented the following functions:
-
-    def handle_bg(self, timestamp0, bg_im):
-        pass
-
-    def handle_frame(self, timestamp, regions):
-        pass
-    """
-
-    def parse(self, filename):
-        ufmf = Ufmf(filename)
-        bg_im, timestamp0 = ufmf.get_bg_image()
-
-        self.handle_bg(timestamp0, bg_im)
-
-        while 1:
-            buf = fd.read(chunkheadsz)
-            if len(buf) != chunkheadsz:
-                # no more frames (EOF)
-                break
-            intup = struct.unpack(FMT[1].CHUNKHEADER, buf)
-            (timestamp, n_pts) = intup
-            regions = []
-            for ptnum in range(n_pts):
-                subbuf = fd.read(subsz)
-                intup = struct.unpack(FMT[1].SUBHEADER, subbuf)
-                xmin, ymin = intup
-
-                buf = fd.read(chunkimsize)
-                bufim = numpy.fromstring(buf, dtype=numpy.uint8)
-                bufim.shape = chunkheight, chunkwidth
-                regions.append((xmin, ymin, bufim))
-
-            self.handle_frame(timestamp, regions)
-        fd.close()
 
 
 def identify_ufmf_version(filename):
@@ -283,7 +235,7 @@ def Ufmf(filename, **kwargs):
         raise ValueError("unknown .ufmf version %d" % version)
 
 
-class UfmfBase(object):
+class UfmfBase:
     pass
 
 
@@ -407,7 +359,7 @@ class UfmfV1(UfmfBase):
         self._fd.close()
 
 
-class _UFmfV3LowLevelReader(object):
+class _UFmfV3LowLevelReader:
     def __init__(self, fd, version):
         self._fd = fd
         self._version = version
@@ -592,7 +544,7 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
         return timestamp, regions
 
 
-class _UFmfV3Indexer(object):
+class _UFmfV3Indexer:
     """create an index from an un-unindexed .ufmf v3 file"""
 
     def __init__(self, fd, version, ignore_preexisting_index=False, short_file_ok=False, index_progress=False):
@@ -857,7 +809,7 @@ class UfmfV3(UfmfBase):
 
     def get_progress(self):
         locs = self._index[b"frame"][b"loc"]
-        return float(self._next_frame) / len(locs)
+        return self._next_frame / len(locs)
 
     def set_next_frame(self, fno):
         self._next_frame = fno
@@ -1084,7 +1036,7 @@ def md5sum_headtail(filename):
     return m.digest()
 
 
-class FlyMovieEmulator(object):
+class FlyMovieEmulator:
     def __init__(
         self, filename, darken=0, allow_no_such_frame_errors=False, white_background=False, abs_diff=False, **kwargs
     ):
@@ -1347,7 +1299,7 @@ def UfmfSaver(file, frame0=None, timestamp0=None, **kwargs):
         raise ValueError("unknown version %s" % version)
 
 
-class UfmfSaverBase(object):
+class UfmfSaverBase:
     def __init__(self, version):
         self.version = version
 


### PR DESCRIPTION
the quest of reducing number of warnings during tests...

gets rid of

`DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead`