### PR TITLE
mnt: hdf5dataset.value -> hdf5dataset[()]

### DIFF
--- a/bin/labelcounts.py
+++ b/bin/labelcounts.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 
         # Now print the findings for each image
         try:
-            label_names = f["PixelClassification/LabelNames"].value
+            label_names = f["PixelClassification/LabelNames"][()]
         except KeyError:
             label_names = [f"Label {n}" for n in range(1, num_bins)]
 

--- a/ilastik/applets/counting/countingSerializer.py
+++ b/ilastik/applets/counting/countingSerializer.py
@@ -293,7 +293,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
            with the saved parameters and datasets."""
         # The group we were given is the root (file).
         # Check the version
-        ilastikVersion = hdf5File["ilastikVersion"].value
+        ilastikVersion = hdf5File["ilastikVersion"][()]
 
         # The pixel classification workflow supports importing projects in the old 0.5 format
         if ilastikVersion == 0.5:

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -382,7 +382,7 @@ class Ilastik05DataSelectionDeserializer(AppletSerializer):
 
     def deserializeFromHdf5(self, hdf5File, projectFilePath, headless=False):
         # Check the overall file version
-        ilastikVersion = hdf5File["ilastikVersion"].value
+        ilastikVersion = hdf5File["ilastikVersion"][()]
 
         # This is the v0.5 import deserializer.  Don't work with 0.6 projects (or anything else).
         if ilastikVersion != 0.5:

--- a/ilastik/applets/featureSelection/featureSelectionSerializer.py
+++ b/ilastik/applets/featureSelection/featureSelectionSerializer.py
@@ -88,18 +88,18 @@ class FeatureSelectionSerializer(AppletSerializer):
     @timeLogged(logger, logging.DEBUG)
     def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
         try:
-            scales = topGroup["Scales"].value
+            scales = topGroup["Scales"][()]
             scales = list(map(float, scales))
 
             # Restoring 'feature computation in 2d' only makes sense, if scales were recovered...
             try:
-                computeIn2d = topGroup["ComputeIn2d"].value
+                computeIn2d = topGroup["ComputeIn2d"][()]
                 computeIn2d = list(map(bool, computeIn2d))
                 self.topLevelOperator.ComputeIn2d.setValue(computeIn2d)
             except KeyError:
                 pass  # older ilastik versions did not support feature computation in 2d
 
-            featureIds = list(map(lambda s: s.decode("utf-8"), topGroup["FeatureIds"].value))
+            featureIds = list(map(lambda s: s.decode("utf-8"), topGroup["FeatureIds"][()]))
         except KeyError:
             pass
         else:
@@ -119,7 +119,7 @@ class FeatureSelectionSerializer(AppletSerializer):
             else:
                 # If the matrix isn't there, just return
                 try:
-                    savedMatrix = topGroup["SelectionMatrix"].value
+                    savedMatrix = topGroup["SelectionMatrix"][()]
                     # Check matrix dimensions
                     assert savedMatrix.shape[0] == len(
                         featureIds
@@ -166,7 +166,7 @@ class Ilastik05FeatureSelectionDeserializer(AppletSerializer):
 
     def deserializeFromHdf5(self, hdf5File, filePath, headless=False):
         # Check the overall file version
-        ilastikVersion = hdf5File["ilastikVersion"].value
+        ilastikVersion = hdf5File["ilastikVersion"][()]
 
         # This is the v0.5 import deserializer.  Don't work with 0.6 projects (or anything else).
         if ilastikVersion != 0.5:
@@ -195,7 +195,7 @@ class Ilastik05FeatureSelectionDeserializer(AppletSerializer):
         try:
             # In ilastik 0.5, features were grouped into user-friendly selections.  We have to split these
             #  selections apart again into the actual features that must be computed.
-            userFriendlyFeatureMatrix = hdf5File["Project"]["FeatureSelection"]["UserSelection"].value
+            userFriendlyFeatureMatrix = hdf5File["Project"]["FeatureSelection"]["UserSelection"][()]
         except KeyError:
             # If the project file doesn't specify feature selections,
             #  we'll just use the default (blank) selections as initialized above

--- a/ilastik/applets/fillMissingSlices/fillMissingSlicesSerializer.py
+++ b/ilastik/applets/fillMissingSlices/fillMissingSlicesSerializer.py
@@ -55,7 +55,7 @@ class FillMissingSlicesSerializer(AppletSerializer):
 
     def _getDataset(self, group, dataName):
         try:
-            result = group[dataName].value
+            result = group[dataName][()]
         except KeyError:
             result = ""
         return result

--- a/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
@@ -224,7 +224,7 @@ class Ilastik05ImportDeserializer(AppletSerializer):
            with the saved parameters and datasets."""
         # The group we were given is the root (file).
         # Check the version
-        ilastikVersion = hdf5File["ilastikVersion"].value
+        ilastikVersion = hdf5File["ilastikVersion"][()]
 
         # The pixel classification workflow supports importing projects in the old 0.5 format
         if ilastikVersion == 0.5:

--- a/ilastik/applets/predictionViewer/predictionViewerSerializer.py
+++ b/ilastik/applets/predictionViewer/predictionViewerSerializer.py
@@ -39,14 +39,14 @@ class PredictionViewerSerializer(AppletSerializer):
         pmapColors = None
         labelNames = None
         try:
-            pmapColors = predictionGroup["PmapColors"].value
+            pmapColors = predictionGroup["PmapColors"][()]
             self._topLevelOperator.PmapColors.setValue(list(pmapColors))
 
         except KeyError:
             pass
 
         try:
-            labelNames = predictionGroup["LabelNames"].value
+            labelNames = predictionGroup["LabelNames"][()]
             self._topLevelOperator.LabelNames.setValue(list(labelNames))
         except KeyError:
             pass

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsSerializer.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsSerializer.py
@@ -60,7 +60,7 @@ class ThresholdTwoLevelsSerializer(AppletSerializer):
         # but now we re-use the 'low threshold' slot for both 'simple' and 'hysteresis' modes.
         method = self.operator.CurOperator.value
         if method == ThresholdMethod.SIMPLE and "SingleThreshold" in list(topGroup.keys()):
-            threshold = topGroup["SingleThreshold"].value
+            threshold = topGroup["SingleThreshold"][()]
             self.operator.LowThreshold.setValue(threshold)
 
         # We used to always compute cores from the same channel as the 'final' threshold input.
@@ -70,5 +70,5 @@ class ThresholdTwoLevelsSerializer(AppletSerializer):
             and "Channel" in list(topGroup.keys())
             and "CoreChannel" not in list(topGroup.keys())
         ):
-            channel = topGroup["Channel"].value
+            channel = topGroup["Channel"][()]
             self.operator.CoreChannel.setValue(channel)

--- a/ilastik/applets/tracking/base/trackingUtilities.py
+++ b/ilastik/applets/tracking/base/trackingUtilities.py
@@ -205,13 +205,13 @@ class LineageH5(h5py.File):
 
     def get_moves(self):
         if self.has_tracking() and path.basename(self.mov_ds) in list(self[self.track_gn].keys()):
-            return self[self.mov_ds].value
+            return self[self.mov_ds][()]
         else:
             return np.empty(0)
 
     def get_move_energies(self):
         if path.basename(self.mov_ener_ds) in list(self[self.track_gn].keys()):
-            e = self[self.mov_ener_ds].value
+            e = self[self.mov_ener_ds][()]
             if isinstance(e, np.ndarray):
                 return e
             else:
@@ -221,7 +221,7 @@ class LineageH5(h5py.File):
 
     def get_divisions(self):
         if self.has_tracking() and path.basename(self.div_ds) in list(self[self.track_gn].keys()):
-            return self[self.div_ds].value
+            return self[self.div_ds][()]
         else:
             return np.empty(0)
 
@@ -233,7 +233,7 @@ class LineageH5(h5py.File):
 
     def get_division_energies(self):
         if path.basename(self.div_ener_ds) in list(self[self.track_gn].keys()):
-            e = self[self.div_ener_ds].value
+            e = self[self.div_ener_ds][()]
             if isinstance(e, np.ndarray):
                 return e
             else:
@@ -243,7 +243,7 @@ class LineageH5(h5py.File):
 
     def get_disappearances(self):
         if self.has_tracking() and path.basename(self.dis_ds) in list(self[self.track_gn].keys()):
-            dis = self[self.dis_ds].value
+            dis = self[self.dis_ds][()]
             if isinstance(dis, np.ndarray):
                 return dis
             else:
@@ -259,7 +259,7 @@ class LineageH5(h5py.File):
 
     def get_disappearance_energies(self):
         if path.basename(self.dis_ener_ds) in list(self[self.track_gn].keys()):
-            e = self[self.dis_ener_ds].value
+            e = self[self.dis_ener_ds][()]
             if isinstance(e, np.ndarray):
                 return e
             else:
@@ -269,7 +269,7 @@ class LineageH5(h5py.File):
 
     def get_appearances(self):
         if self.has_tracking() and path.basename(self.app_ds) in list(self[self.track_gn].keys()):
-            app = self[self.app_ds].value
+            app = self[self.app_ds][()]
             if isinstance(app, np.ndarray):
                 return app
             else:
@@ -285,7 +285,7 @@ class LineageH5(h5py.File):
 
     def get_appearance_energies(self):
         if path.basename(self.app_ener_ds) in list(self[self.track_gn].keys()):
-            e = self[self.app_ener_ds].value
+            e = self[self.app_ener_ds][()]
             if isinstance(e, np.ndarray):
                 return e
             else:
@@ -313,7 +313,7 @@ class LineageH5(h5py.File):
 
     def get_ids(self):
         features_group = self[self.feat_gn]
-        labelcontent = features_group["labelcontent"].value
+        labelcontent = features_group["labelcontent"][()]
         valid_labels = (np.arange(len(labelcontent)) + 1)[labelcontent == 1]
         return valid_labels
 

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1598,7 +1598,7 @@ class IlastikShell(QMainWindow):
                 self.enableWorkflow = True
 
                 if "currentApplet" in list(hdf5File.keys()):
-                    appletName = hdf5File["currentApplet"].value
+                    appletName = hdf5File["currentApplet"][()]
                     self.setSelectedAppletDrawer(appletName)
                 else:
                     self.setSelectedAppletDrawer(self.projectManager.workflow.defaultAppletIndex)

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -155,7 +155,7 @@ class ProjectManager(object):
 
         projectVersion = "0.5"
         if "ilastikVersion" in list(hdf5File.keys()):
-            projectVersion = hdf5File["ilastikVersion"].value.decode("utf-8")
+            projectVersion = hdf5File["ilastikVersion"][()].decode("utf-8")
 
         # FIXME: version comparison
         if not isVersionCompatible(projectVersion):
@@ -165,7 +165,7 @@ class ProjectManager(object):
         workflow_class = None
         if "workflowName" in list(hdf5File.keys()):
             # if workflow is found in file, take it
-            workflowName = hdf5File["workflowName"].value.decode("utf-8")
+            workflowName = hdf5File["workflowName"][()].decode("utf-8")
             workflow_class = getWorkflowFromName(workflowName)
 
         return (hdf5File, workflow_class, readOnly)

--- a/ilastik/workflows/carving/carvingSerializer.py
+++ b/ilastik/workflows/carving/carvingSerializer.py
@@ -130,14 +130,14 @@ class CarvingSerializer(AppletSerializer):
                     fg_voxels = [fg_voxels[:, k] for k in range(3)]
                     bg_voxels = [bg_voxels[:, k] for k in range(3)]
 
-                    sv = g["sv"].value
+                    sv = g["sv"][()]
 
                     mst.object_names[name] = i + 1
                     mst.object_seeds_fg_voxels[name] = fg_voxels
                     mst.object_seeds_bg_voxels[name] = bg_voxels
                     mst.object_lut[name] = sv
-                    mst.bg_priority[name] = g["bg_prio"].value
-                    mst.no_bias_below[name] = g["no_bias_below"].value
+                    mst.bg_priority[name] = g["bg_prio"][()]
+                    mst.no_bias_below[name] = g["no_bias_below"][()]
 
                     logger.info(
                         "[CarvingSerializer] de-serializing %s, with opCarving=%d, mst=%d"

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -137,14 +137,14 @@ class OpCarving(Operator):
             except Exception as e:
                 logger.info("Could not open hint overlay '%s'" % hintOverlayFile)
                 raise e
-            self._hints = f["/hints"].value[numpy.newaxis, :, :, :, numpy.newaxis]
+            self._hints = f["/hints"][numpy.newaxis, :, :, :, numpy.newaxis]
 
         if pmapOverlayFile is not None:
             try:
                 f = h5py.File(pmapOverlayFile, "r")
             except Exception as e:
                 raise RuntimeError("Could not open pmap overlay '%s'" % pmapOverlayFile)
-            self._pmap = f["/data"].value[numpy.newaxis, :, :, :, numpy.newaxis]
+            self._pmap = f["/data"][numpy.newaxis, :, :, :, numpy.newaxis]
 
         self._setCurrObjectName("<not saved yet>")
         self.HasSegmentation.setValue(False)

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -62,15 +62,15 @@ class PreprocessingSerializer(AppletSerializer):
         assert "sigma" in list(topGroup.keys())
         assert "filter" in list(topGroup.keys())
 
-        sigma = topGroup["sigma"].value
-        sfilter = topGroup["filter"].value
+        sigma = topGroup["sigma"][()]
+        sfilter = topGroup["filter"][()]
 
         if "graph" in list(topGroup.keys()):
             graphgroup = topGroup["graph"]
         else:
             assert "graphfile" in list(topGroup.keys())
             # feature: load preprocessed graph from file
-            filePath = topGroup["graphfile"].value
+            filePath = topGroup["graphfile"][()]
             if not os.path.exists(filePath):
                 if headless:
                     raise RuntimeError("Could not find data at " + filePath)

--- a/tests/test_ilastik/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_ilastik/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -114,7 +114,7 @@ class TestConservationTrackingHeadless(object):
             assert "exported_data" in f, "Dataset does not exist in tracking result file"
             shape = f["exported_data"].shape
             assert shape == self.EXPECTED_SHAPE, "Exported data has wrong shape: {}".format(shape)
-            data = f["exported_data"].value
+            data = f["exported_data"][()]
             assert len(np.unique(data)) == self.EXPECTED_NUM_LINEAGES + 1  # background also shows up, hence + 1
 
     @timeLogged(logger)

--- a/tests/test_ilastik/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
+++ b/tests/test_ilastik/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
@@ -31,11 +31,10 @@ def test_applet_serialization(project_path, data_export_applet):
         data_export_applet.dataSerializers[0].serializeToHdf5(project_file, project_path)
 
     with h5py.File(project_path) as project_file:
-        assert project_file["Tracking Result Export/SelectedPlugin"].value.decode() == "Fiji-MaMuT"
-        assert project_file["Tracking Result Export/SelectedExportSource"].value.decode() == "Plugin"
+        assert project_file["Tracking Result Export/SelectedPlugin"][()].decode() == "Fiji-MaMuT"
+        assert project_file["Tracking Result Export/SelectedExportSource"][()].decode() == "Plugin"
         assert (
-            project_file["Tracking Result Export/AdditionalPluginArguments/bdvFilePath"].value.decode()
-            == "/tmp/bdv.xml"
+            project_file["Tracking Result Export/AdditionalPluginArguments/bdvFilePath"][()].decode() == "/tmp/bdv.xml"
         )
 
 

--- a/tests/test_ilastik/test_applets/featureSelection/testFeatureSelectionSerializer.py
+++ b/tests/test_ilastik/test_applets/featureSelection/testFeatureSelectionSerializer.py
@@ -66,12 +66,12 @@ class TestFeatureSelectionSerializer(object):
 
         with h5py.File(testProjectName, "r") as testProject:
             file_feature_ids = numpy.asarray(
-                list(map(lambda s: s.decode("utf-8"), testProject["FeatureSelections/FeatureIds"].value))
+                list(map(lambda s: s.decode("utf-8"), testProject["FeatureSelections/FeatureIds"][()]))
             )
 
-            assert (testProject["FeatureSelections/Scales"].value == scales).all()
+            assert (testProject["FeatureSelections/Scales"][()] == scales).all()
             assert (file_feature_ids == featureIds).all()
-            assert (testProject["FeatureSelections/SelectionMatrix"].value == selectionMatrix).all()
+            assert (testProject["FeatureSelections/SelectionMatrix"][()] == selectionMatrix).all()
 
             # Deserialize into a fresh operator
             operatorToLoad = OpFeatureSelection(graph=graph)


### PR DESCRIPTION
accessing the `.value` member on h5py groups is deprecated.
Gets rid of
```
H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.
```