### PR TITLE
Ilastik distributed

### DIFF
--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -172,7 +172,7 @@ class BatchProcessingApplet(Applet):
         return opDataExport.run_export_to_array()
 
     def do_distributed_export(self, opDataExport, *, block_size: int = 256):
-        logger.info("Exporting to distributed command line...")
+        logger.info("Running ilastik distributed...")
         return opDataExport.run_distributed_export(block_shape=Shape5D.hypercube(block_size))
 
     def export_dataset(

--- a/ilastik/applets/dataExport/opDataExport.py
+++ b/ilastik/applets/dataExport/opDataExport.py
@@ -19,8 +19,12 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 import os
+from pathlib import Path
+from typing import Dict, List
 import collections
 import numpy
+import z5py
+from ndstructs import Shape5D
 
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.utility import PathComponents, getPathVariants, format_known_keys
@@ -43,10 +47,7 @@ class DataExportPathFormatter:
         if os.path.pathsep in nickname:
             nickname = PathComponents(nickname.split(os.path.pathsep)[0]).fileNameBase
 
-        known_keys = {
-            "dataset_dir": abs_dataset_dir,
-            "nickname": nickname,
-        }
+        known_keys = {"dataset_dir": abs_dataset_dir, "nickname": nickname}
 
         if self._result_type:
             known_keys["result_type"] = self._result_type
@@ -211,9 +212,7 @@ class OpDataExport(Operator):
         result_types = self.SelectionNames.value
 
         path_formatter = DataExportPathFormatter(
-            dataset_info=rawInfo,
-            working_dir=self.WorkingDirectory.value,
-            result_type=result_types[selection_index]
+            dataset_info=rawInfo, working_dir=self.WorkingDirectory.value, result_type=result_types[selection_index]
         )
 
         self._opFormattedExport.TransactionSlot.disconnect()
@@ -255,6 +254,9 @@ class OpDataExport(Operator):
         # This function can be used to export the results to an in-memory array, instead of to disk
         # (Typically used from pure-python clients in batch mode.)
         return self._opFormattedExport.run_export_to_array()
+
+    def run_distributed_export(self, block_shape: Shape5D):
+        return self._opFormattedExport.run_distributed_export(block_shape)
 
 
 class OpRawSubRegionHelper(Operator):

--- a/ilastik/workflows/examples/dataConversion/dataConversionWorkflow.py
+++ b/ilastik/workflows/examples/dataConversion/dataConversionWorkflow.py
@@ -106,9 +106,7 @@ class DataConversionWorkflow(Workflow):
         # Command-line args are applied in onProjectLoaded(), below.
         if workflow_cmdline_args:
             self._data_export_args, unused_args = self.dataExportApplet.parse_known_cmdline_args(workflow_cmdline_args)
-            self._batch_input_args, unused_args = self.dataSelectionApplet.parse_known_cmdline_args(
-                unused_args, role_names
-            )
+            self._batch_input_args, unused_args = self.batchProcessingApplet.parse_known_cmdline_args(unused_args)
         else:
             unused_args = None
             self._batch_input_args = None

--- a/lazyflow/distributed/TaskOrchestrator.py
+++ b/lazyflow/distributed/TaskOrchestrator.py
@@ -1,0 +1,78 @@
+from mpi4py import MPI
+from threading import Thread
+import enum
+from typing import Generator, TypeVar, Generic, Callable, Tuple
+import uuid
+
+END = "END-eb23ae13-709e-4ac3-931d-99ab059ef0c2"
+TASK_DATUM = TypeVar("TASK_DATUM")
+
+
+@enum.unique
+class Tags(enum.IntEnum):
+    TASK_DONE = 13
+    TO_WORKER = enum.auto()
+
+
+class _Worker(Generic[TASK_DATUM]):
+    def __init__(self, comm, rank: int):
+        self.comm = comm
+        self.rank = rank
+        self.stopped = False
+
+    def send(self, datum: TASK_DATUM):
+        print(f"Sending datum {datum} to worker {self.rank}...")
+        self.comm.send(datum, dest=self.rank, tag=Tags.TO_WORKER)
+
+    def stop(self):
+        self.send(END)
+        self.stopped = True
+
+
+class TaskOrchestrator(Generic[TASK_DATUM]):
+    def __init__(self, comm=None):
+        self.comm = comm or MPI.COMM_WORLD
+        self.rank = self.comm.Get_rank()
+        num_workers = self.comm.size - 1
+        if num_workers <= 0:
+            raise Exception("Trying to orchestrate tasks with no workers!!!")
+        self.workers = {rank: _Worker(self.comm, rank) for rank in range(1, num_workers + 1)}
+
+    def get_finished_worker(self) -> _Worker[TASK_DATUM]:
+        status = MPI.Status()
+        self.comm.recv(source=MPI.ANY_SOURCE, tag=Tags.TASK_DONE, status=status)
+        return self.workers[status.Get_source()]
+
+    def orchestrate(self, task_data: Generator[TASK_DATUM, None, None]):
+        print(f"ORCHESTRATOR: Starting orchestration of {len(self.workers)}...")
+        num_busy_workers = 0
+        for worker in self.workers.values():
+            try:
+                worker.send(next(task_data))
+                num_busy_workers += 1
+            except StopIteration:
+                break
+
+        while True:
+            worker = self.get_finished_worker()
+            try:
+                worker.send(next(task_data))
+            except StopIteration:
+                worker.stop()
+                num_busy_workers -= 1
+                if num_busy_workers == 0:
+                    break
+
+        for worker in self.workers.values():
+            if not worker.stopped:
+                worker.stop()
+
+    def start_as_worker(self, target: Callable[[TASK_DATUM, int], None]):
+        print(f"WORKER {self.rank}: Started")
+        while True:
+            status = MPI.Status()
+            datum = self.comm.recv(source=MPI.ANY_SOURCE, tag=Tags.TO_WORKER, status=status)
+            if datum == END:
+                break
+            self.comm.send(target(datum, self.rank), dest=status.Get_source(), tag=Tags.TASK_DONE)
+        print(f"WORKER {self.rank}: Terminated")

--- a/lazyflow/metaDict.py
+++ b/lazyflow/metaDict.py
@@ -25,6 +25,7 @@ from builtins import zip
 import copy
 import numpy
 from collections import OrderedDict, defaultdict
+from ndstructs import Shape5D
 
 
 class MetaDict(defaultdict):
@@ -152,6 +153,9 @@ class MetaDict(defaultdict):
         assert self.shape is not None
         keys = self.getAxisKeys()
         return OrderedDict(list(zip(keys, self.shape)))
+
+    def getShape5D(self):
+        return Shape5D(**self.getTaggedShape())
 
     def getAxisKeys(self):
         assert self.axistags is not None


### PR DESCRIPTION
Combines (and therefore, supersedes)
https://github.com/ilastik/ilastik/pull/2178
https://github.com/ilastik/lazyflow/pull/335

## TODO:
~~Verify that the simplification of axistags guessing covers all of our needs~~ Reverted for now. https://github.com/ilastik/ilastik/pull/2223 should cover our HPC needs for now

## Description
This PR adds the ability to run ilastik with `mpirun`, by passing in the `--distributed` flag when running in headless mode. Also,  one can use the `--distributed-block-size=<integer>` to determine the size of the tiles that are worked on by each individual worker, so e.g. `--distributed-block-size=512` will operate on tiles of shape `Shape5D(x=512, y=512, z=512, c=512, t=512)`, clamped to the maximum size of the raw data on each dimension.

- Reworks argparser creation in `DataSelectionApplet` so it's easier for the `BatchProcessingApplet` to add the new `--distributed` flag;
- Creates `--distributed` and `--distributed-block-size` command line options
- Creates the `OpFormattedDataExport.run_distributed_export()` method, which allows lazyflow to query the ilastik workflows from multiple processes at the same time, and write results concurrently to a `n5` file.
- Adds OpFormattedDataExport.run_distributed_export()
- Creates `TaskOrchestrator` class to facilitate tile processing management

This also includes some changes in the way ilastik guesses axiskeys for its datasources. This was needed for the batch processing service, but might not fit perfectly with common ilastik usage.
TODO: Test new axiskeys guessing


## Running
0 - Install `mpi4py`: `conda install mpi4py` (Install via `pip` on the HPCs, though, so that it gets a chance to compile using the native implementation of mpi)
1 - Train your classifier as usual in interactive mode;
2 - Run headless like so:
```
export HDF5_USE_FILE_LOCKING=FALSE # multiple processes will open the .ilp file
NUM_PROCESSES=8
mpirun -N ${NUM_PROCESSES} python ilastik.py --headless \
    --project ~/MyProject.ilp \
    --distributed --distributed_block_size=256 \
    /path/to/your/data.png
```
    
