### PR TITLE
fix leaving cplex and gurobi in PATH

### DIFF
--- a/ilastik.py
+++ b/ilastik.py
@@ -52,8 +52,13 @@ def _clean_paths(root: pathlib.Path) -> None:
 
     def isvalidpath_win(path):
         """Whether an element of PATH is "clean" on Windows."""
-        patterns = "*/cplex/*", "*/guirobi/*", "/windows/system32/*"
-        return any(map(pathlib.PurePath(path).match, patterns))
+
+        def partial_match(path, pattern):
+            """allow arbitrary nesting within those patterns"""
+            return any(p.match(pattern) for p in path.parents)
+
+        patterns = "**/cplex_studio*", "**/gurobi*", "/windows/system32/*"
+        return any(partial_match(pathlib.PurePath(path), pat) for pat in patterns)
 
     # Remove undesired paths from PYTHONPATH and add ilastik's submodules.
     sys_path = list(filter(issubdir, sys.path))


### PR DESCRIPTION
The previous method of filtering would not leave even the default installation paths of cplex or gurobi in PATH.

This commit allows for paths like
`C:\something\arbitrary\gurobi*\**`
`C:\something\arbitrary\cplex*\**`

which is not possible with `pathlib.PurePath.match` alone.