### PR TITLE
supply loaded axistags to PreloadedArray

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -24,7 +24,13 @@ from typing import List, Tuple, Callable
 from pathlib import Path
 
 
-from .opDataSelection import OpDataSelection, DatasetInfo, FilesystemDatasetInfo, RelativeFilesystemDatasetInfo
+from .opDataSelection import (
+    OpDataSelection,
+    DatasetInfo,
+    FilesystemDatasetInfo,
+    RelativeFilesystemDatasetInfo,
+    DummyDatasetInfo,
+)
 from .opDataSelection import PreloadedArrayDatasetInfo, ProjectInternalDatasetInfo
 from lazyflow.operators.ioOperators import OpInputDataReader, OpStackLoader, OpH5N5WriterBigDataset
 from lazyflow.operators.ioOperators.opTiffReader import OpTiffReader
@@ -273,12 +279,7 @@ class DataSelectionSerializer(AppletSerializer):
             datasetInfo = info_class.from_h5_group(infoGroup)
         except FileNotFoundError as e:
             if headless:
-                shape = tuple(infoGroup["shape"])
-                axistags = vigra.AxisTags.fromJSON(infoGroup["axistags"][()].decode("utf-8"))
-                return (
-                    PreloadedArrayDatasetInfo(preloaded_array=numpy.zeros(shape, dtype=numpy.uint8), axistags=axistags),
-                    True,
-                )
+                return (DummyDatasetInfo.from_h5_group(infoGroup), True)
 
             from PyQt5.QtWidgets import QMessageBox
             from ilastik.widgets.ImageFileDialog import ImageFileDialog

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -274,7 +274,11 @@ class DataSelectionSerializer(AppletSerializer):
         except FileNotFoundError as e:
             if headless:
                 shape = tuple(infoGroup["shape"])
-                return PreloadedArrayDatasetInfo(preloaded_array=numpy.zeros(shape, dtype=numpy.uint8)), True
+                axistags = vigra.AxisTags.fromJSON(infoGroup["axistags"][()].decode("utf-8"))
+                return (
+                    PreloadedArrayDatasetInfo(preloaded_array=numpy.zeros(shape, dtype=numpy.uint8), axistags=axistags),
+                    True,
+                )
 
             from PyQt5.QtWidgets import QMessageBox
             from ilastik.widgets.ImageFileDialog import ImageFileDialog

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -496,3 +496,29 @@ class OpZeroDefault(Operator):
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.Input:
             self.Output.setDirty(roi)
+
+
+class OpZeroSource(Operator):
+    """Operator that serves zeros on it's Output
+
+    This operator will never set anything dirty as it cannot be changed.
+    """
+
+    Output = OutputSlot()
+
+    def __init__(self, dtype, shape, *, graph=None, parent=None, **kwargs):
+        super().__init__(graph=graph, parent=parent)
+
+        self._meta = {"dtype": dtype, "shape": shape}
+        self._meta.update(kwargs)
+
+    def setupOutputs(self):
+        for k, v in self._meta.items():
+            self.Output.meta[k] = v
+
+    def execute(self, slot, subindex, roi, result):
+        result[...] = 0
+        return result
+
+    def propagateDirty(self, *args, **kwargs):
+        raise ValueError("Will never go here, no inputs...")

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -509,12 +509,15 @@ class OpZeroSource(Operator):
     def __init__(self, dtype, shape, *, graph=None, parent=None, **kwargs):
         super().__init__(graph=graph, parent=parent)
 
-        self._meta = {"dtype": dtype, "shape": shape}
-        self._meta.update(kwargs)
+        self.Output.meta["dtype"] = dtype
+        self.Output.meta["shape"] = shape
+        if kwargs:
+            for k, v in kwargs.items():
+                self.Output.meta[k] = v
 
     def setupOutputs(self):
-        for k, v in self._meta.items():
-            self.Output.meta[k] = v
+        # everything configured via init
+        pass
 
     def execute(self, slot, subindex, roi, result):
         result[...] = 0

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -310,6 +310,7 @@ def test_opZeroSource(graph, metadata):
     dtype = metadata.pop("dtype")
 
     op = OpZeroSource(shape=shape, dtype=dtype, graph=graph, **metadata)
+    assert op.Output.ready()
     assert op.Output.meta.dtype == dtype
     assert op.Output.meta.shape == shape
 

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -1,6 +1,3 @@
-from builtins import range
-from builtins import object
-
 ###############################################################################
 #   lazyflow: data flow based lazy parallel computation framework
 #
@@ -23,7 +20,6 @@ from builtins import object
 # 		   http://ilastik.org/license/
 ###############################################################################
 import time
-import random
 import threading
 from functools import partial
 import numpy
@@ -37,10 +33,12 @@ from lazyflow.operators.valueProviders import (
     OpValueCache,
     OpMetadataMerge,
     OpZeroDefault,
+    OpZeroSource,
 )
+import pytest
 
 
-class TestOpMetadataInjector(object):
+class TestOpMetadataInjector:
     def test(self):
         g = lazyflow.graph.Graph()
         op = OpMetadataInjector(graph=g)
@@ -69,7 +67,7 @@ class TestOpMetadataInjector(object):
         assert len(dirtyList) == 1
 
 
-class TestOpOutputProvider(object):
+class TestOpOutputProvider:
     def test(self):
         from lazyflow.graph import Graph, MetaDict
 
@@ -90,7 +88,7 @@ class TestOpOutputProvider(object):
                 assert opProvider.Output.meta[k] == v
 
 
-class TestOpMetadataSelector(object):
+class TestOpMetadataSelector:
     def test(self):
         from lazyflow.graph import Graph, MetaDict
 
@@ -116,7 +114,7 @@ class TestOpMetadataSelector(object):
         assert op.Output.value == meta.axistags
 
 
-class TestOpMetadataMerge(object):
+class TestOpMetadataMerge:
     def test(self):
         from lazyflow.graph import Graph, MetaDict
         from lazyflow.operators import OpArrayPiper
@@ -146,7 +144,7 @@ class TestOpMetadataMerge(object):
         assert op.Output.meta.notsospecial is None
 
 
-class TestOpValueCache(object):
+class TestOpValueCache:
     class OpSlowComputation(lazyflow.graph.Operator):
         Input = lazyflow.graph.InputSlot()
         Output = lazyflow.graph.OutputSlot()
@@ -263,7 +261,7 @@ class TestOpValueCache(object):
         assert opCache.Output.value == 100
 
 
-class TestOpZeroDefault(object):
+class TestOpZeroDefault:
     def test_basic(self):
         graph = lazyflow.graph.Graph()
         data = numpy.indices((100, 100), dtype=numpy.uint8).sum(0)
@@ -297,3 +295,28 @@ class TestOpZeroDefault(object):
         op.Input.disconnect()
         output_data = op.Output[:].wait()
         assert (output_data == 0).all()
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"shape": (15, 1, 2), "dtype": numpy.bool},
+        {"shape": (200, 100, 42), "dtype": numpy.uint8, "axistags": vigra.defaultAxistags("xyz")},
+        {"shape": (10, 20, 30, 1, 2), "dtype": numpy.float32, "something_else": "blah", "one_more": 42},
+    ],
+)
+def test_opZeroSource(graph, metadata):
+    shape = metadata.pop("shape")
+    dtype = metadata.pop("dtype")
+
+    op = OpZeroSource(shape=shape, dtype=dtype, graph=graph, **metadata)
+    assert op.Output.meta.dtype == dtype
+    assert op.Output.meta.shape == shape
+
+    for k, v in metadata.items():
+        assert op.Output.meta[k] == v
+
+    full_out = op.Output[:].wait()
+    assert full_out.shape == shape
+    assert full_out.dtype == dtype
+    assert full_out.sum() == 0


### PR DESCRIPTION
when deserializing a project in headless mode with the training data missing,
the axistags have to be deserialized, too. Otherwise ilastik guesses them.
If this guess is wrong, the data doesn't fit the workflow anymore.

* fixes running ilastik projects in headless without the data.
* fixes memory allocation for data for missing data in headless (previously an array of the same size as the missing image would have been allocated in memory).
