### PR TITLE
open project files as readonly per default in headless

### DIFF
--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -27,6 +27,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import ilastik.config
 from ilastik.config import cfg as ilastik_config
+from ilastik.utility.commandLineProcessing import str2bool
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +39,14 @@ def _argparser() -> argparse.ArgumentParser:
     ap.add_argument("--project", help="A project file to open on startup.")
     ap.add_argument(
         "--readonly",
-        help="Open all projects in read-only mode, to ensure you don't " "accidentally make changes.",
-        action="store_true",
+        nargs="?",
+        default=None,
+        const="true",
+        type=str2bool,
+        help=(
+            "Open all projects in read-only mode, to ensure you don't accidentally make changes. "
+            "Per default projects are opened with read access in GUI mode, without read access in headless mode."
+        ),
     )
     ap.add_argument(
         "--new_project", help="Create a new project with the specified name. Must also specify " "--workflow."
@@ -352,6 +359,10 @@ def _prepare_auto_open_project(parsed_args):
     parsed_args.project = os.path.expanduser(parsed_args.project)
     # convert path to convenient format
     path = PathComponents(parsed_args.project).totalPath()
+
+    # readonly
+    if parsed_args.readonly is None:
+        parsed_args.readonly = parsed_args.headless
 
     def loadProject(shell):
         # This should work for both the IlastikShell and the HeadlessShell

--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -27,7 +27,7 @@ from typing import List, Optional, Sequence, Tuple
 
 import ilastik.config
 from ilastik.config import cfg as ilastik_config
-from ilastik.utility.commandLineProcessing import str2bool
+from ilastik.utility.commandLineProcessing import OptionalFlagAction
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +39,8 @@ def _argparser() -> argparse.ArgumentParser:
     ap.add_argument("--project", help="A project file to open on startup.")
     ap.add_argument(
         "--readonly",
-        nargs="?",
-        default=None,
-        const="true",
-        type=str2bool,
+        action=OptionalFlagAction,
+        const=True,
         help=(
             "Open all projects in read-only mode, to ensure you don't accidentally make changes. "
             "Per default projects are opened with read access in GUI mode, without read access in headless mode."

--- a/ilastik/utility/commandLineProcessing.py
+++ b/ilastik/utility/commandLineProcessing.py
@@ -26,6 +26,27 @@ import argparse
 import json
 
 
+def str2bool(some_string: str) -> bool:
+    """Helper function to convert a string to a boolean
+
+    Args:
+        some_string: typically an argument supplied to a command line option
+
+    Returns:
+        bool: result follows the `configparser` convention
+
+    Raises:
+        ValueError: Description
+    """
+    t = some_string.strip().lower()
+    if t in {"false", "0", "no", "off"}:
+        return False
+    if t in {"true", "1", "yes", "on"}:
+        return True
+
+    raise ValueError(f"{some_string!r} cannot be converted to bool")
+
+
 def convertStringToList(some_string):
     """Helper function in order to parse lists encoded as strings
 


### PR DESCRIPTION
Removes a major annoyance from ilastik's headless mode: allowing for concurrent access to project files per default.

Summary:
* `--readonly` flag kept. Projects will be opened per default with read access in GUI mode, without read access in headless mode. the `--readonly` flag now takes a parameter to allow changing this behavior.

fixes #1870