### PR TITLE
Add volumina submodule

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,25 @@
+name: make release
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    name: trigger-release
+    runs-on: ubuntu-latest
+    env:
+      GL_TOKEN: ${{ secrets.GL_TOKEN }}
+      GL_URL: ${{ secrets.GL_URL }}
+    steps:
+      - name: trigger
+        run: |
+          echo "Triggering release pipeline!"
+          curl \
+            --silent \
+            -X POST \
+            -F token=${GL_TOKEN} \
+            -F "ref=master" \
+            -F "variables[tag]=${GITHUB_REF}" \
+            --output /dev/null \
+            ${GL_URL}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "volumina"]
+	path = volumina
+	url = https://github.com/ilastik/volumina

--- a/scripts/devenv.py
+++ b/scripts/devenv.py
@@ -199,7 +199,7 @@ def main():
     create_ap.add_argument(
         "-l",
         "--location",
-        help="local ilastik-meta directory",
+        help="local ilastik directory",
         metavar="DIR",
         nargs="?",
         const=None,
@@ -251,7 +251,7 @@ def command_create(args: argparse.Namespace, env: CondaEnv) -> None:
     if location is None:
         return
 
-    packages = "volumina", "ilastik"
+    packages = "volumina", "."
 
     logging.info(f"Installing local ilastik packages in development mode.")
     for pkg in packages:


### PR DESCRIPTION
With the merge of lazyflow and ilastik ilastik-meta only governs two repos: ilastik and volumina.

I am trying to simplify making ilastik releases a bit and I don't see any benefit of the ilastik-meta package anymore. It practically usually means making an additional commit in an additional repo and somehow inferring the ilastik version from ilastik meta via ilastik again. That's too indirect. I propose not using ilastik-meta anymore and having everything in ilastik - adding volumina as a submodule there.

Todos:

- [ ] update conda recipes
- [ ] update package scripts

- [x] update `devenv.py`
- [x] update Contributing guidelines

P.S.: there seems to be some mess on master, where I didn't properly add version bumps :/

