### PR TITLE
specify h5py/z5py file modes explicitly

### DIFF
--- a/bin/change_axisorder.py
+++ b/bin/change_axisorder.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     projectfile = sys.argv[1]
     axisorder = sys.argv[2]
 
-    with h5py.File(projectfile) as f:
+    with h5py.File(projectfile, "r+") as f:
         # Delete the old axisorder and replace it with our new one.
         try:
             del f["Input Data/infos/lane0000/Raw Data/axisorder"]

--- a/ilastik/applets/dataSelection/dataSelectionApplet.py
+++ b/ilastik/applets/dataSelection/dataSelectionApplet.py
@@ -318,7 +318,7 @@ class DataSelectionApplet(Applet):
                 if not os.path.exists(stackVolumeCacheDir):
                     os.makedirs(stackVolumeCacheDir)
 
-                with h5py.File(stackPath) as f:
+                with h5py.File(stackPath, "w") as f:
                     # Configure the conversion operator
                     opWriter = OpStackToH5Writer(graph=Graph())
                     opWriter.hdf5Group.setValue(f)

--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
     traceLogger.setLevel(logging.DEBUG)
     traceLogger.debug("HELLO")
 
-    f = h5py.File("/tmp/flyem_sample_stack.h5")
+    f = h5py.File("/tmp/flyem_sample_stack.h5", "r")
     internalPath = "volume/data"
 
     # OpStackToH5Writer

--- a/tests/test_ilastik/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
+++ b/tests/test_ilastik/test_applets/conservationTracking/testTrackingBaseDataExportAppletSerialization.py
@@ -27,10 +27,10 @@ def data_export_applet():
 
 
 def test_applet_serialization(project_path, data_export_applet):
-    with h5py.File(project_path) as project_file:
+    with h5py.File(project_path, "w") as project_file:
         data_export_applet.dataSerializers[0].serializeToHdf5(project_file, project_path)
 
-    with h5py.File(project_path) as project_file:
+    with h5py.File(project_path, "r") as project_file:
         assert project_file["Tracking Result Export/SelectedPlugin"][()].decode() == "Fiji-MaMuT"
         assert project_file["Tracking Result Export/SelectedExportSource"][()].decode() == "Plugin"
         assert (
@@ -39,13 +39,13 @@ def test_applet_serialization(project_path, data_export_applet):
 
 
 def test_applet_deserialization(project_path, data_export_applet):
-    with h5py.File(project_path) as project_file:
+    with h5py.File(project_path, "w") as project_file:
         data_export_applet.dataSerializers[0].serializeToHdf5(project_file, project_path)
 
     op = Operator(graph=Graph())
     data_export_applet = TrackingBaseDataExportApplet(op, "Tracking Result Export")
 
-    with h5py.File(project_path) as project_file:
+    with h5py.File(project_path, "r") as project_file:
         data_export_applet.dataSerializers[0].deserializeFromHdf5(project_file, project_path)
 
     opTrackingBaseDataExport = data_export_applet.dataSerializers[0].topLevelOperator

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -135,7 +135,7 @@ class TestOpDataSelection_Basic2D(object):
                 )
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName, "a")
+        cls.projectFile = h5py.File(cls.projectFileName, "w")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 2d+c data (above)
@@ -299,7 +299,7 @@ class TestOpDataSelection_Basic_native_3D(object):
         cls.generatedImages3Dc.append(testH5FileName)
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName, "a")
+        cls.projectFile = h5py.File(cls.projectFileName, "w")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -519,7 +519,7 @@ class TestOpDataSelection_3DStacks(object):
         # os.path.join(cls.tmpdir, "testimage2Dc_*.npy"),
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName, "a")
+        cls.projectFile = h5py.File(cls.projectFileName, "w")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -621,7 +621,7 @@ class TestOpDataSelection_SingleFileH5Stacks:
 
         cls.glob_string = "{}/g1/timeslice_*".format(cls.image_file_name)
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName, "a")
+        cls.projectFile = h5py.File(cls.projectFileName, "w")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -687,7 +687,7 @@ class TestOpDataSelection_FakeDataReader:
         numpy.save(cls.testRawDataFileName, cls.imgData)
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName, "a")
+        cls.projectFile = h5py.File(cls.projectFileName, "w")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 2d+c data (above)

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -135,7 +135,7 @@ class TestOpDataSelection_Basic2D(object):
                 )
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile = h5py.File(cls.projectFileName, "a")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 2d+c data (above)
@@ -299,7 +299,7 @@ class TestOpDataSelection_Basic_native_3D(object):
         cls.generatedImages3Dc.append(testH5FileName)
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile = h5py.File(cls.projectFileName, "a")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -519,7 +519,7 @@ class TestOpDataSelection_3DStacks(object):
         # os.path.join(cls.tmpdir, "testimage2Dc_*.npy"),
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile = h5py.File(cls.projectFileName, "a")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -621,7 +621,7 @@ class TestOpDataSelection_SingleFileH5Stacks:
 
         cls.glob_string = "{}/g1/timeslice_*".format(cls.image_file_name)
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile = h5py.File(cls.projectFileName, "a")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 3d+c data (above)
@@ -687,7 +687,7 @@ class TestOpDataSelection_FakeDataReader:
         numpy.save(cls.testRawDataFileName, cls.imgData)
 
         # Create a 'project' file and give it some data
-        cls.projectFile = h5py.File(cls.projectFileName)
+        cls.projectFile = h5py.File(cls.projectFileName, "a")
         cls.projectFile.create_group("DataSelection")
         cls.projectFile["DataSelection"].create_group("local_data")
         # Use the same data as the 2d+c data (above)

--- a/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationSerializer.py
+++ b/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationSerializer.py
@@ -195,7 +195,7 @@ class TestPixelClassificationSerializer(object):
                 pass
 
         # Create an empty project
-        with h5py.File(testProjectName) as testProject:
+        with h5py.File(testProjectName, "a") as testProject:
             testProject.create_dataset("ilastikVersion", data=b"1.0.0")
 
             # Create an operator to work with and give it some input

--- a/tests/test_ilastik/test_applets/thresholdMasking/testThreholdMaskingSerializer.py
+++ b/tests/test_ilastik/test_applets/thresholdMasking/testThreholdMaskingSerializer.py
@@ -42,7 +42,7 @@ class TestThresholdMaskingSerializer(object):
                 pass
 
         # Create an empty project
-        with h5py.File(testProjectName) as testProject:
+        with h5py.File(testProjectName, "a") as testProject:
             testProject.create_dataset("ilastikVersion", data=b"1.0.0")
 
             # Create an operator to work with and give it some input

--- a/tests/test_lazyflow/testH5py.py
+++ b/tests/test_lazyflow/testH5py.py
@@ -46,8 +46,8 @@ class TestH5Py(object):
         filename2 = "test2.h5"
         self.prepare_tstfile(shape, filename2)
 
-        f1 = h5py.File(filename1)
-        f2 = h5py.File(filename2)
+        f1 = h5py.File(filename1, "r")
+        f2 = h5py.File(filename2, "r")
 
         self.tst_multithread_greenlet([f1, f2])
 
@@ -78,7 +78,7 @@ class TestH5Py(object):
         f.close()
 
     def tst_multithread(self, filename):
-        f = h5py.File(filename)
+        f = h5py.File(filename, "r")
 
         threads = []
         for i in range(100):

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpH5N5WriterBigDataset.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpH5N5WriterBigDataset.py
@@ -60,8 +60,8 @@ class TestOpH5N5WriterBigDataset(object):
 
     def test_Writer(self):
         # Create the h5 file
-        hdf5File = h5py.File(self.testDataH5FileName)
-        n5File = z5py.N5File(self.testDataN5FileName)
+        hdf5File = h5py.File(self.testDataH5FileName, "w")
+        n5File = z5py.N5File(self.testDataN5FileName, "w")
 
         opPiper = OpArrayPiper(graph=self.graph)
         opPiper.Input.setValue(self.testData)
@@ -123,8 +123,8 @@ class TestOpH5N5WriterBigDataset_2(object):
     def test_Writer(self):
 
         # Create the h5 file
-        hdf5File = h5py.File(self.testDataH5FileName)
-        n5File = z5py.N5File(self.testDataN5FileName)
+        hdf5File = h5py.File(self.testDataH5FileName, "w")
+        n5File = z5py.N5File(self.testDataN5FileName, "w")
 
         opPiper = OpArrayPiper(graph=self.graph)
         opPiper.Input.setValue(self.testData)
@@ -189,8 +189,8 @@ class TestOpH5N5WriterBigDataset_3(object):
 
     def test_Writer(self):
         # Create the h5 file
-        hdf5File = h5py.File(self.testDataH5FileName)
-        n5File = z5py.N5File(self.testDataN5FileName)
+        hdf5File = h5py.File(self.testDataH5FileName, "w")
+        n5File = z5py.N5File(self.testDataN5FileName, "w")
 
         opPiper = OpArrayPiper(graph=self.graph)
         opPiper.Input.setValue(self.testData)

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -143,7 +143,7 @@ class TestOpInputDataReader(object):
 
     def test_h5(self):
         # Create HDF5 test data
-        with h5py.File(self.testH5FileName) as f:
+        with h5py.File(self.testH5FileName, "w") as f:
             f.create_group("volume")
             shape = (1, 2, 3, 4, 5)
             f["volume"].create_dataset(
@@ -176,7 +176,7 @@ class TestOpInputDataReader(object):
         """Test stack/sequence reading in hdf5-files for given 'sequence_axis'"""
         shape = (4, 8, 16, 32, 3)  # assuming axis guess order is 'tzyxc'
         data = numpy.random.randint(0, 255, size=shape).astype(numpy.uint8)
-        with h5py.File(self.testH5FileName) as f:
+        with h5py.File(self.testH5FileName, "w") as f:
             data_group = f.create_group("volumes")
             for index, t_slice in enumerate(data):
                 data_group.create_dataset("timepoint-{index:02d}".format(index=index), data=t_slice)
@@ -206,7 +206,7 @@ class TestOpInputDataReader(object):
         data = numpy.random.randint(0, 255, size=shape).astype(numpy.uint8)
         for index, t_slice in enumerate(data):
             fname = self.testmultiH5FileName.format(index=index)
-            with h5py.File(fname) as f:
+            with h5py.File(fname, "w") as f:
                 data_group = f.create_group("volume")
                 data_group.create_dataset("data", data=t_slice)
 

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpStreamingH5N5SequenceReaderS.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpStreamingH5N5SequenceReaderS.py
@@ -34,8 +34,8 @@ class TestOpStreamingH5N5SequenceReaderS(unittest.TestCase):
             testDataN5FileName = f"{self.tempdir_normalized_name}/test.n5"
             # Write the dataset to an hdf5 and a n5 file
             # (Note: Don't use vigra to do this, which may reorder the axes)
-            h5File = h5py.File(testDataH5FileName)
-            n5File = z5py.N5File(testDataN5FileName)
+            h5File = h5py.File(testDataH5FileName, "w")
+            n5File = z5py.N5File(testDataN5FileName, "w")
             try:
                 h5File.create_group("volumes")
                 n5File.create_group("volumes")
@@ -87,8 +87,8 @@ class TestOpStreamingH5N5SequenceReaderS(unittest.TestCase):
             testDataN5FileName = f"{self.tempdir_normalized_name}/test.n5"
             # Write the dataset to an hdf5 and a n5 file
             # (Note: Don't use vigra to do this, which may reorder the axes)
-            h5File = h5py.File(testDataH5FileName)
-            n5File = z5py.N5File(testDataN5FileName)
+            h5File = h5py.File(testDataH5FileName, "w")
+            n5File = z5py.N5File(testDataN5FileName, "w")
             try:
                 h5File.create_group("volumes")
                 n5File.create_group("volumes")
@@ -140,8 +140,8 @@ class TestOpStreamingH5N5SequenceReaderS(unittest.TestCase):
             testDataN5FileName = f"{self.tempdir_normalized_name}/test.n5"
             # Write the dataset to an hdf5 file
             # (Note: Don't use vigra to do this, which may reorder the axes)
-            h5File = h5py.File(testDataH5FileName)
-            n5File = z5py.N5File(testDataN5FileName)
+            h5File = h5py.File(testDataH5FileName, "w")
+            n5File = z5py.N5File(testDataN5FileName, "w")
 
             try:
                 h5File.create_group("volumes")

--- a/tests/test_lazyflow/test_utility/testPathHelpers.py
+++ b/tests/test_lazyflow/test_utility/testPathHelpers.py
@@ -126,7 +126,7 @@ class TestPathHelpers(object):
 
     def createHdf5Data(self):
         """Creates Hdf5 file in memory for testHff5Glob"""
-        f = h5py.File(name="test", driver="core", backing_store=False)
+        f = h5py.File(name="test", driver="core", backing_store=False, mode="a")
         data_group = f.create_group("here/is/the/data")
         data_group2 = f.create_group("this/is/also/some/data")
 


### PR DESCRIPTION
`h5py.File` default file mode will be changed from `a` -> `r` and our code seemed to rely on this default behavior explicitly.
I went through the code and inserted appropriate modes if not specified before.
 
gets rid of
```
H5pyDeprecationWarning: The default file mode will change to 'r' (read-only) in
h5py 3.0. To suppress this warning, pass the mode you need to h5py.File(), or
set the global default h5.get_config().default_file_mode, or set the environment
variable H5PY_DEFAULT_READONLY=1. Available modes are: 'r', 'r+', 'w', 'w-'/'x',
'a'. See the docs for details.
```