### PR TITLE
Change default file mode when writing hdf5/n5 image files

### DIFF
--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -27,6 +27,7 @@ from builtins import object
 import os
 import shutil
 import collections
+import contextlib
 from functools import partial
 
 import numpy
@@ -265,7 +266,7 @@ class OpExportSlot(Operator):
             with OpStreamingH5N5Reader.get_h5_n5_file(export_components.externalPath, mode="a") as h5N5File:
                 # Create a temporary operator to do the work for us
                 opH5N5Writer = OpH5N5WriterBigDataset(parent=self)
-                if export_components.internalPath in h5N5File:
+                with contextlib.suppress(KeyError):
                     del h5N5File[export_components.internalPath]
                 try:
                     opH5N5Writer.CompressionEnabled.setValue(compress)

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -262,18 +262,11 @@ class OpExportSlot(Operator):
         # Create and open the hdf5/n5 file
         export_components = PathComponents(self.ExportPath.value)
         try:
-            if os.path.isdir(export_components.externalPath):  # externalPath leads to a n5 file
-                shutil.rmtree(export_components.externalPath)  # n5 is stored as a directory structure
-            else:
-                os.remove(export_components.externalPath)
-        except OSError as ex:
-            # It's okay if the file isn't there.
-            if ex.errno != 2:
-                raise
-        try:
-            with OpStreamingH5N5Reader.get_h5_n5_file(export_components.externalPath, "w") as h5N5File:
+            with OpStreamingH5N5Reader.get_h5_n5_file(export_components.externalPath, mode="a") as h5N5File:
                 # Create a temporary operator to do the work for us
                 opH5N5Writer = OpH5N5WriterBigDataset(parent=self)
+                if export_components.internalPath in h5N5File:
+                    del h5N5File[export_components.internalPath]
                 try:
                     opH5N5Writer.CompressionEnabled.setValue(compress)
                     opH5N5Writer.h5N5File.setValue(h5N5File)


### PR DESCRIPTION
I don't think there is an issue about this, but @constantinpape brought this up:

currently we overwrite image files with the same file name. In general this makes sense, of course, but for hdf5/n5 files, it is possible to add multiple datasets to the result file.

This PR changes the behavior; hdf5/n5 files are now opened in append mode, datasets are overwritten if already present.

I have opened #2410 in order to keep track of progress on hdf5 table export. I think we should merge this already and live with not being able to do the same for the h5 table export for now.