### PR TITLE
Fixes pixel label deserialization

### DIFF
--- a/ilastik/__init__.py
+++ b/ilastik/__init__.py
@@ -41,7 +41,7 @@ def _format_version(t):
     return ".".join(str(i) for i in t)
 
 
-__version_info__ = (1, 4, "0b7")
+__version_info__ = (1, 4, "0b8")
 
 __version__ = _format_version(__version_info__)
 

--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -523,6 +523,7 @@ class SerialBlockSlot(SerialSlot):
                     slicing = roiToSlice(*slicing)
 
                 block = self.slot[index][slicing].wait()
+                block_tags = self.slot[index].meta.axistags
                 blockName = "block{:04d}".format(blockIndex)
 
                 if self._shrink_to_bb:
@@ -556,9 +557,11 @@ class SerialBlockSlot(SerialSlot):
                     block_group.create_dataset("fill_value", data=block.fill_value)
 
                     block_group.attrs["blockSlice"] = slicingToString(slicing)
+                    block_group.attrs["axistags"] = block_tags.toJSON()
                 else:
                     subgroup.create_dataset(blockName, data=block)
                     subgroup[blockName].attrs["blockSlice"] = slicingToString(slicing)
+                    subgroup[blockName].attrs["axistags"] = block_tags.toJSON()
 
     def reshape_datablock_and_slicing_for_input(
         self, block: numpy.ndarray, slicing: List[slice], slot: Slot, project: Project

--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -539,7 +539,6 @@ class SerialBlockSlot(SerialSlot):
                         slicing = roiToSlice(*bounding_box_roi)
                         block = block[block_slicing]
 
-                block, slicing = self.reshape_datablock_and_slicing_for_output(block, slicing, slot[index])
                 # If we have a masked array, convert it to a structured array so that h5py can handle it.
                 if slot[index].meta.has_mask:
                     mygroup.attrs["meta.has_mask"] = True
@@ -560,13 +559,6 @@ class SerialBlockSlot(SerialSlot):
                 else:
                     subgroup.create_dataset(blockName, data=block)
                     subgroup[blockName].attrs["blockSlice"] = slicingToString(slicing)
-
-    def reshape_datablock_and_slicing_for_output(
-        self, block: numpy.ndarray, slicing: List[slice], slot: Slot
-    ) -> Tuple[numpy.ndarray, List[slice]]:
-        """Reshapes a block of data and its corresponding slicing relative to the whole data into a shape that is
-           adequate for serialization (out)"""
-        return block, slicing
 
     def reshape_datablock_and_slicing_for_input(
         self, block: numpy.ndarray, slicing: List[slice], slot: Slot, project: Project

--- a/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
@@ -44,14 +44,14 @@ class BackwardsCompatibleLabelSerialBlockSlot(SerialBlockSlot):
     def get_corresponding_input_image_slot(self, labelSlot: OutputSlot) -> OutputSlot:
         return labelSlot.operator.InputImages[labelSlot.subindex]
 
-    def get_input_image_original_axiskeys(self, labelSlot: OutputSlot) -> str:
-        return "".join(self.get_corresponding_input_image_slot(labelSlot).meta.getOriginalAxisKeys())
-
     def get_input_image_current_axiskeys(self, labelSlot: OutputSlot) -> str:
         return "".join(self.get_corresponding_input_image_slot(labelSlot).meta.getAxisKeys())
 
+    def get_input_image_original_axiskeys(self, labelSlot: OutputSlot) -> str:
+        return "".join(self.get_corresponding_input_image_slot(labelSlot).meta.getOriginalAxisKeys())
+
     def deserialization_requires_data_conversion(self, project) -> bool:
-        return self.labels_were_saved_in_forced_canonical_order(project)
+        return self.get_saved_data_axiskeys(slot, project) != self.get_input_image_current_axiskeys(slot)
 
     def labels_were_saved_in_forced_canonical_order(self, project: Project) -> bool:
         pixel_plus_object_workflow_name = "Object Classification (from pixel classification)"
@@ -62,45 +62,33 @@ class BackwardsCompatibleLabelSerialBlockSlot(SerialBlockSlot):
             v1_3_3 <= project.ilastikVersion < v1_3_3post2 and project.workflowName == pixel_plus_object_workflow_name
         )
 
+    def labels_were_saved_in_slot_original_order(self, project: Project):
+        v1_3_3post2 = parse_version("1.3.3post2")
+        v1_4_0b7 = parse_version("1.4.0b7")
+
+        return v1_3_3post2 <= project.ilastikVersion <= v1_4_0b7
+
     def get_saved_data_axiskeys(self, slot: OutputSlot, project: Project) -> str:
         if self.labels_were_saved_in_forced_canonical_order(project):
             return "txyzc"
-        else:
+        if self.labels_were_saved_in_slot_original_order(project):
             return self.get_input_image_original_axiskeys(slot)
+        return self.get_input_image_current_axiskeys(slot)
 
     def reshape_datablock_and_slicing_for_input(
         self, block: numpy.ndarray, slicing: List[slice], slot: OutputSlot, project: Project
     ) -> Tuple[numpy.ndarray, List[slice]]:
-        """Reshapes a block of data and its corresponding slicing into the slot's current shape, so as to be
-        compatible with versions of ilastik that saved and loaded block slots in their original shape
-
-        Checks for version 1.3.3 and 1.3.3post1 because those were the versions that saved labels in 5D
-        """
+        """Reshapes a block of data and its corresponding slicing into the slot's current shape"""
         current_axiskeys = self.get_input_image_current_axiskeys(slot)
         saved_data_axiskeys = self.get_saved_data_axiskeys(slot, project)
         fixed_slicing = Slice5D.zero(**dict(zip(saved_data_axiskeys, slicing))).to_slices(current_axiskeys)
         fixed_block = Array5D(block, saved_data_axiskeys).raw(current_axiskeys)
-        return fixed_block, fixed_slicing
 
-    def reshape_datablock_and_slicing_for_output(
-        self, block: numpy.ndarray, slicing: List[slice], slot: OutputSlot
-    ) -> Tuple[numpy.ndarray, List[slice]]:
-        """Reshapes a block of data and its corresponding slicing into the slot's original shape, so as to be
-        compatible with versions of ilastik that saved and loaded block slots in their original shape
-
-        Always save using original shape to be backwards compatible with 1.3.2
-        """
-        original_axiskeys = self.get_input_image_original_axiskeys(slot)
-        current_axiskeys = self.get_input_image_current_axiskeys(slot)
-        fixed_block = Array5D(block, current_axiskeys).raw(original_axiskeys)
-        fixed_slicing = Slice5D.zero(**dict(zip(current_axiskeys, slicing))).to_slices(original_axiskeys)
-        return fixed_block, fixed_slicing
-
-    def deserialize(self, group):
-        super().deserialize(group)
-        if self.deserialization_requires_data_conversion(Project(group.file)):
+        if current_axiskeys != saved_data_axiskeys:
             self.ignoreDirty = False
             self.dirty = True
+
+        return fixed_block, fixed_slicing
 
 
 class PixelClassificationSerializer(AppletSerializer):

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -201,7 +201,7 @@ class ObjectClassificationWorkflow(Workflow):
             "Input Data",
             "Input Data",
             batchDataGui=False,
-            forceAxisOrder=["txyzc"],
+            forceAxisOrder=None,
             instructionText=self.data_instructions,
         )
 
@@ -740,7 +740,9 @@ class ObjectClassificationWorkflowBinary(ObjectClassificationWorkflow):
 
     def connectInputs(self, laneIndex):
         opData = self.dataSelectionApplet.topLevelOperator.getLane(laneIndex)
-        return self.createRawDataSourceSlot(laneIndex), opData.ImageGroup[self.InputImageRoles.SEGMENTATION_IMAGE]
+        canonicalRawDataSlot = self.createRawDataSourceSlot(laneIndex)
+        canonicalSegmentationSlot = self.toDefaultAxisOrder(opData.ImageGroup[self.InputImageRoles.SEGMENTATION_IMAGE])
+        return canonicalRawDataSlot, canonicalSegmentationSlot
 
     def handleAppletStateUpdateRequested(self):
         """


### PR DESCRIPTION
As [pointed out](https://forum.image.sc/t/ilastik-project-file-cannot-be-loaded-on-another-computer/40545) by user JesseDicello,  deserialization of Pixel Labels still had some problems leftover from the big 1.3.3 object classification workflow cleanup.

This PR  fixes axis reordering in Object Classification Workflows so that they are identical to 1.3.2, and so that they will be serialized in an identical manner.

It also corrects the bad assumption that all pixel labels were being saved without dropping dummy axis; labels will now be read back using the current axis keys of the label slot (except for some version-specific exceptions needed for backwards compatibility).

Finally, labels are being saved with their axistags as attributes in the H5 dataset, so that at least this part of the .ilp is no longer dependent on ilastik's internal state.