### PR TITLE
Removes the range parameter from usage of volumina's NormalizableLayer

### DIFF
--- a/ilastik/applets/counting/countingDataExportGui.py
+++ b/ilastik/applets/counting/countingDataExportGui.py
@@ -139,8 +139,6 @@ class CountingResultsViewer(DataExportLayerViewerGui):
         #                predictsrc = createDataSource(channelSlot)
         #                predictLayer = AlphaModulatedLayer( predictsrc,
         #                                                    tintColor=QColor(*colors[channel]),
-        #                                                    # FIXME: This is weird.  Why are range and normalize both set to the same thing?
-        #                                                    range=drange,
         #                                                    normalize=drange )
         #                predictLayer.opacity = 0.25
         #                predictLayer.visible = True

--- a/ilastik/applets/networkClassification/nnClassGui.py
+++ b/ilastik/applets/networkClassification/nnClassGui.py
@@ -569,7 +569,7 @@ class NNClassGui(LabelingGui):
                 ref_label = labels[channel]
                 predictsrc = LazyflowSource(predictionSlot)
                 predictionLayer = AlphaModulatedLayer(
-                    predictsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    predictsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
                 predictionLayer.visible = self.labelingDrawerUi.livePrediction.isChecked()
                 predictionLayer.opacity = 0.25

--- a/ilastik/applets/networkClassification/nnClassificationDataExportGui.py
+++ b/ilastik/applets/networkClassification/nnClassificationDataExportGui.py
@@ -138,8 +138,6 @@ class NNClassificationResultsViewer(DataExportLayerViewerGui):
                 predictsrc = LazyflowSource(channelSlot)
                 predictLayer = AlphaModulatedLayer( predictsrc,
                                                     tintColor=QColor(*colors[channel]),
-                                                    # FIXME: This is weird.  Why are range and normalize both set to the same thing?
-                                                    range=drange,
                                                     normalize=drange )
                 predictLayer.opacity = 0.25
                 predictLayer.visible = True

--- a/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
@@ -146,8 +146,6 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
                 predictLayer = AlphaModulatedLayer(
                     predictsrc,
                     tintColor=QColor.fromRgba(self._colorTable16[channel + 1]),
-                    # FIXME: This is weird.  Why are range and normalize both set to the same thing?
-                    range=drange,
                     normalize=drange,
                 )
                 predictLayer.opacity = 1.0

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -578,7 +578,7 @@ class ObjectClassificationGui(LabelingGui):
                 ref_label = labels[channel]
                 probsrc = createDataSource(probSlot)
                 probLayer = AlphaModulatedLayer(
-                    probsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    probsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
                 probLayer.opacity = 0.25
                 # probLayer.visible = self.labelingDrawerUi.checkInteractive.isChecked()
@@ -664,7 +664,7 @@ class ObjectClassificationGui(LabelingGui):
         if uncertaintySlot.ready():
             uncertaintySrc = createDataSource(uncertaintySlot)
             uncertaintyLayer = AlphaModulatedLayer(
-                uncertaintySrc, tintColor=QColor(Qt.cyan), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                uncertaintySrc, tintColor=QColor(Qt.cyan), normalize=(0.0, 1.0)
             )
             uncertaintyLayer.name = "Uncertainty"
             uncertaintyLayer.visible = False

--- a/ilastik/applets/pixelClassification/pixelClassificationDataExportGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationDataExportGui.py
@@ -83,7 +83,6 @@ class PixelClassificationResultsViewer(DataExportLayerViewerGui):
                 previewLayer = AlphaModulatedLayer(
                     previewUncertaintySource,
                     tintColor=QColor(0, 255, 255),  # cyan
-                    range=(0.0, 1.0),
                     normalize=(0.0, 1.0),
                 )
                 previewLayer.opacity = 0.5
@@ -163,8 +162,6 @@ class PixelClassificationResultsViewer(DataExportLayerViewerGui):
                 predictLayer = AlphaModulatedLayer(
                     predictsrc,
                     tintColor=QColor(*colors[channel]),
-                    # FIXME: This is weird.  Why are range and normalize both set to the same thing?
-                    range=drange,
                     normalize=drange,
                 )
                 predictLayer.opacity = 0.25

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -679,7 +679,7 @@ class PixelClassificationGui(LabelingGui):
         if uncertaintySlot.ready():
             uncertaintySrc = createDataSource(uncertaintySlot)
             uncertaintyLayer = AlphaModulatedLayer(
-                uncertaintySrc, tintColor=QColor(Qt.cyan), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                uncertaintySrc, tintColor=QColor(Qt.cyan), normalize=(0.0, 1.0)
             )
             uncertaintyLayer.name = "Uncertainty"
             uncertaintyLayer.visible = False
@@ -705,7 +705,7 @@ class PixelClassificationGui(LabelingGui):
                 ref_label = labels[channel]
                 segsrc = createDataSource(segmentationSlot)
                 segLayer = AlphaModulatedLayer(
-                    segsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    segsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
 
                 segLayer.opacity = 1
@@ -754,7 +754,7 @@ class PixelClassificationGui(LabelingGui):
                 ref_label = labels[channel]
                 predictsrc = createDataSource(predictionSlot)
                 predictLayer = AlphaModulatedLayer(
-                    predictsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    predictsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
                 predictLayer.opacity = 0.25
                 predictLayer.visible = self.labelingDrawerUi.liveUpdateButton.isChecked()

--- a/ilastik/applets/predictionViewer/predictionViewerGui.py
+++ b/ilastik/applets/predictionViewer/predictionViewerGui.py
@@ -82,7 +82,7 @@ class PredictionViewerGui(LayerViewerGui):
             if channelSlot.ready() and channel < len(colors) and channel < len(names):
                 predictsrc = createDataSource(channelSlot)
                 predictLayer = AlphaModulatedLayer(
-                    predictsrc, tintColor=colors[channel], range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    predictsrc, tintColor=colors[channel], normalize=(0.0, 1.0)
                 )
                 predictLayer.opacity = 0.25
                 predictLayer.visible = True

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -359,7 +359,7 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
                 drange = (0.0, 1.0)
             channelSrc = createDataSource(channelProvider.Output)
             inputChannelLayer = AlphaModulatedLayer(
-                channelSrc, tintColor=input_channel_colors[channel], range=drange, normalize=drange
+                channelSrc, tintColor=input_channel_colors[channel], normalize=drange
             )
             inputChannelLayer.opacity = 0.5
             inputChannelLayer.visible = True

--- a/ilastik/workflows/voxelSegmentation/slicGui.py
+++ b/ilastik/workflows/voxelSegmentation/slicGui.py
@@ -50,7 +50,6 @@ class SlicGui(LayerViewerGui):
             layer = AlphaModulatedLayer(
                 LazyflowSource(superVoxelBoundarySlot),
                 tintColor=QColor(Qt.blue),
-                range=(0.0, 1.0),
                 normalize=(0.0, 1.0),
             )
             layer.name = "Supervoxel Boundaries"

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -316,7 +316,7 @@ class VoxelSegmentationGui(LabelingGui):
         if uncertaintySlot.ready():
             uncertaintySrc = LazyflowSource(uncertaintySlot)
             uncertaintyLayer = AlphaModulatedLayer(
-                uncertaintySrc, tintColor=QColor(Qt.cyan), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                uncertaintySrc, tintColor=QColor(Qt.cyan), normalize=(0.0, 1.0)
             )
             uncertaintyLayer.name = "Uncertainty"
             uncertaintyLayer.visible = False
@@ -339,7 +339,7 @@ class VoxelSegmentationGui(LabelingGui):
         if topUncertaintySlot.ready():
             topUncertaintySrc = LazyflowSource(topUncertaintySlot)
             topUncertaintyLayer = AlphaModulatedLayer(
-                topUncertaintySrc, tintColor=QColor(Qt.cyan), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                topUncertaintySrc, tintColor=QColor(Qt.cyan), normalize=(0.0, 1.0)
             )
             topUncertaintyLayer.name = "topUncertainty"
             topUncertaintyLayer.visible = True
@@ -365,7 +365,7 @@ class VoxelSegmentationGui(LabelingGui):
                 ref_label = labels[channel]
                 segsrc = LazyflowSource(segmentationSlot)
                 segLayer = AlphaModulatedLayer(
-                    segsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    segsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
 
                 segLayer.opacity = 1
@@ -414,7 +414,7 @@ class VoxelSegmentationGui(LabelingGui):
                 ref_label = labels[channel]
                 predictsrc = LazyflowSource(predictionSlot)
                 predictLayer = AlphaModulatedLayer(
-                    predictsrc, tintColor=ref_label.pmapColor(), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                    predictsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0)
                 )
                 predictLayer.opacity = 0.25
                 predictLayer.visible = self.labelingDrawerUi.liveUpdateButton.isChecked()
@@ -486,7 +486,7 @@ class VoxelSegmentationGui(LabelingGui):
         superVoxelSlot = self.topLevelOperatorView.SupervoxelBoundaries
         if superVoxelSlot.ready():
             layer = AlphaModulatedLayer(
-                LazyflowSource(superVoxelSlot), tintColor=QColor(Qt.black), range=(0.0, 1.0), normalize=(0.0, 1.0)
+                LazyflowSource(superVoxelSlot), tintColor=QColor(Qt.black), normalize=(0.0, 1.0)
             )
             layer.name = "SLIC segmentation"
             layer.visible = True


### PR DESCRIPTION
Adjusts usage of `NormalizableLayer` (and its descendants such as `AlphaModulatedLayer`) everywhere, removing he `range` parameter, which wasn't doing anything useful.

This PR only exists because of https://github.com/ilastik/volumina/pull/265 and therefore should be merged together with that.