### PR TITLE
multiple hdf5 datasets

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -23,7 +23,7 @@ import glob
 import os
 import uuid
 from enum import Enum, unique
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Union
 from numbers import Number
 import re
 from pathlib import Path
@@ -245,20 +245,21 @@ class DatasetInfo(ABC):
         return sorted(internal_paths)
 
     @classmethod
-    def pathIsHdf5(cls, path: Path) -> bool:
+    def pathIsHdf5(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".ilp", ".h5", ".hdf5"]
 
     @classmethod
-    def pathIsNpz(cls, path: Path) -> bool:
+    def pathIsNpz(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".npz"]
 
     @classmethod
-    def pathIsN5(cls, path: Path) -> bool:
+    def pathIsN5(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".n5"]
 
     @classmethod
-    def fileHasInternalPaths(cls, path: str) -> bool:
-        return cls.pathIsHdf5(path) or cls.pathIsN5(path) or cls.pathIsNpz(path)
+    def fileHasInternalPaths(cls, path: Union[str, os.PathLike]) -> bool:
+        p = Path(path)
+        return cls.pathIsHdf5(p) or cls.pathIsN5(p) or cls.pathIsNpz(p)
 
     @classmethod
     def getPossibleInternalPathsFor(cls, file_path: Path, min_ndim=2, max_ndim=5) -> List[str]:

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -362,11 +362,9 @@ class PixelClassificationGui(LabelingGui):
             if len(internal_paths) == 1:
                 internal_path = internal_paths[0]
             else:
-                dlg = SubvolumeSelectionDlg(internal_paths, self)
-                if dlg.exec_() == QDialog.Rejected:
+                internal_path = SubvolumeSelectionDlg(internal_paths, self).selectPath()
+                if internal_path is None:
                     return
-                selected_index = dlg.combo.currentIndex()
-                internal_path = str(internal_paths[selected_index])
 
             path_components = PathComponents(file_path)
             path_components.internalPath = str(internal_path)

--- a/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
+++ b/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
@@ -18,49 +18,77 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
+
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
-    QDialogButtonBox,
     QButtonGroup,
     QComboBox,
     QDialog,
+    QDialogButtonBox,
     QLabel,
     QLineEdit,
+    QListWidget,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
-from PyQt5.QtCore import Qt
-
 from lazyflow.utility import globList
 
 
 class SubvolumeSelectionDlg(QDialog):
-    """
-    A window to ask the user to choose between multiple HDF5 datasets in a single file.
+    """A window to ask the user to choose between multiple HDF5 datasets in a single file.
+
+    If multi is True, user can select multiple datasets at once.
     """
 
-    def __init__(self, datasetNames, parent):
+    def __init__(self, datasetNames, parent, *, multi=False):
         super().__init__(parent)
-        label = QLabel(
-            "Your HDF5/N5 File contains multiple image volumes.\n" "Please select the one you would like to open."
-        )
-
-        self.combo = QComboBox()
-        for name in datasetNames:
-            self.combo.addItem(name)
-
-        buttonbox = QDialogButtonBox(Qt.Horizontal, parent=self)
-        buttonbox.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        buttonbox.accepted.connect(self.accept)
-        buttonbox.rejected.connect(self.reject)
+        self.multi = multi
 
         layout = QVBoxLayout()
-        layout.addWidget(label)
-        layout.addWidget(self.combo)
-        layout.addWidget(buttonbox)
-
         self.setLayout(layout)
+
+        label_lines = ["<p>Your file contains multiple images.</p>"]
+        if multi:
+            label_lines.append("<p>Select images that you would like to open.</p>")
+        else:
+            label_lines.append("<p>Select image that you would like to open.</p>")
+        layout.addWidget(QLabel("".join(label_lines), parent=self))
+
+        if multi:
+            self.items = QListWidget(parent=self)
+            self.items.setSelectionMode(QListWidget.MultiSelection)
+            self.items.insertItems(0, datasetNames)
+            layout.addWidget(self.items)
+        else:
+            self.combo = QComboBox(parent=self)
+            self.combo.addItems(datasetNames)
+            layout.addWidget(self.combo)
+
+        buttons = QDialogButtonBox(Qt.Horizontal, parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def selectPath(self) -> Optional[str]:
+        """Select and return an item text, or None if the dialog has not been accepted."""
+        if self.multi:
+            raise ValueError("selectedPath can be used only when multi=False")
+        if self.exec_() != self.Accepted:
+            return None
+        return self.combo.currentText()
+
+    def selectPaths(self) -> Optional[List[str]]:
+        """Select and return item texts, or None if the dialog has not been accepted."""
+        if not self.multi:
+            raise ValueError("selectedPaths can be used only when multi=True")
+        if self.exec_() != self.Accepted:
+            return None
+        return [item.text() for item in self.items.selectedItems()]
 
 
 class Hdf5StackSelectionWidget(QWidget):
@@ -147,12 +175,3 @@ class H5N5StackingDlg(QDialog):
 
     def get_globstring(self):
         return self.stack_widget.input_text.text()
-
-
-if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
-
-    app = QApplication([])
-    w = H5N5StackingDlg(list_of_paths=["a/1", "a/2", "a/3", "b/1", "b/2"])
-    w.show()
-    app.exec_()

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -168,24 +168,23 @@ class StackFileSelectionWidget(QDialog):
                 if ext in h5exts + n5exts:
                     # be even more helpful and try to find a common internal path
                     internal_paths = self._h5N5FindCommonInternal(new_filenames)
+
                     if len(internal_paths) == 0:
                         msg += "Could not find a unique common internal path in"
                         msg += directory + "\n"
                         raise StackFileSelectionWidget.DetermineStackError(msg)
+
                     elif len(internal_paths) == 1:
-                        new_filenames = ["{}/{}".format(fn, internal_paths[0]) for fn in new_filenames]
-                        globstring = "{}/{}".format(globstring, internal_paths[0])
+                        new_filenames = [f"{fn}/{internal_paths[0]}" for fn in new_filenames]
+                        globstring = f"{globstring}/{internal_paths[0]}"
+
                     elif len(internal_paths) > 1:
                         # Ask the user which dataset to choose
-                        dlg = SubvolumeSelectionDlg(internal_paths, self)
-                        if dlg.exec_() == QDialog.Accepted:
-                            selected_index = dlg.combo.currentIndex()
-                            selected_dataset = str(internal_paths[selected_index])
-                            new_filenames = ["{}/{}".format(fn, selected_dataset) for fn in new_filenames]
-                            globstring = "{}/{}".format(globstring, selected_dataset)
-                        else:
-                            msg = "No valid internal path selected."
-                            raise StackFileSelectionWidget.DetermineStackError(msg)
+                        selected_dataset = SubvolumeSelectionDlg(internal_paths, self).selectPath()
+                        if selected_dataset is None:
+                            raise StackFileSelectionWidget.DetermineStackError("No valid internal path selected.")
+                        new_filenames = [f"{fn}/{selected_dataset}" for fn in new_filenames]
+                        globstring = f"{globstring}/{selected_dataset}"
 
                 globstrings.append(globstring)
                 all_filenames += new_filenames
@@ -326,19 +325,18 @@ class StackFileSelectionWidget(QDialog):
                     msg += directory + "\n"
                     QMessageBox.warning(self, "Invalid selection", msg)
                     return None
+
                 elif len(internal_paths) == 1:
-                    fileNames = ["{}/{}".format(fn, internal_paths[0]) for fn in fileNames]
+                    fileNames = [f"{fn}/{internal_paths[0]}" for fn in fileNames]
+
                 else:
                     # Ask the user which dataset to choose
-                    dlg = SubvolumeSelectionDlg(internal_paths, self)
-                    if dlg.exec_() == QDialog.Accepted:
-                        selected_index = dlg.combo.currentIndex()
-                        selected_dataset = str(internal_paths[selected_index])
-                        fileNames = ["{}/{}".format(fn, selected_dataset) for fn in fileNames]
-                    else:
-                        msg = "No valid internal path selected."
-                        QMessageBox.warning(self, "Invalid selection", msg)
+                    selected_dataset = SubvolumeSelectionDlg(internal_paths, self).selectPath()
+                    if selected_dataset is None:
+                        QMessageBox.warning(self, "Invalid selection", "No valid internal path selected.")
                         return None
+                    fileNames = [f"{fn}/{selected_dataset}" for fn in fileNames]
+
         self._updateFileList(fileNames)
 
     def _applyPattern(self):

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -27,8 +27,8 @@ from ilastik.utility import bind
 # ilastik
 from ilastik.config import cfg as ilastik_config
 from ilastik.utility.gui import threadRouted
-from ilastik.widgets.stackFileSelectionWidget import SubvolumeSelectionDlg
-from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui, SubvolumeSelectionDlg
+from ilastik.widgets.hdf5SubvolumeSelectionDialog import SubvolumeSelectionDlg
+from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui
 from ilastik.shell.gui.variableImportanceDialog import VariableImportanceDialog
 
 # Loggers
@@ -199,11 +199,9 @@ class VoxelSegmentationGui(LabelingGui):
             if len(internal_paths) == 1:
                 internal_path = internal_paths[0]
             else:
-                dlg = SubvolumeSelectionDlg(internal_paths, self)
-                if dlg.exec_() == QDialog.Rejected:
+                internal_path = SubvolumeSelectionDlg(internal_paths, self).selectPath()
+                if internal_path is None:
                     return
-                selected_index = dlg.combo.currentIndex()
-                internal_path = str(internal_paths[selected_index])
 
             path_components = PathComponents(file_path)
             path_components.internalPath = str(internal_path)


### PR DESCRIPTION
- version bump 1.4.0b6
- fixes path setup (for windows binary)
- Version bum 1.4.0b7
- specify h5py/z5py file modes explicitly
- Bug fix for computing block RAM size
- Fixes axes mismatch when (de)serializng labels
- Saves axistags with labels
- Restores slot dirtyness by label conversion
- PR review, mode "a" not necessary
- Removes the range parameter from usage of volumina's NormalizableLayer
- Add multi mode to subvolume selection dialog
