### PR TITLE
Add multi mode to subvolume selection dialog

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -23,7 +23,7 @@ import glob
 import os
 import uuid
 from enum import Enum, unique
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Union
 from numbers import Number
 import re
 from pathlib import Path
@@ -245,20 +245,21 @@ class DatasetInfo(ABC):
         return sorted(internal_paths)
 
     @classmethod
-    def pathIsHdf5(cls, path: Path) -> bool:
+    def pathIsHdf5(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".ilp", ".h5", ".hdf5"]
 
     @classmethod
-    def pathIsNpz(cls, path: Path) -> bool:
+    def pathIsNpz(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".npz"]
 
     @classmethod
-    def pathIsN5(cls, path: Path) -> bool:
+    def pathIsN5(cls, path: Union[str, os.PathLike]) -> bool:
         return PathComponents(Path(path).as_posix()).extension in [".n5"]
 
     @classmethod
-    def fileHasInternalPaths(cls, path: str) -> bool:
-        return cls.pathIsHdf5(path) or cls.pathIsN5(path) or cls.pathIsNpz(path)
+    def fileHasInternalPaths(cls, path: Union[str, os.PathLike]) -> bool:
+        p = Path(path)
+        return cls.pathIsHdf5(p) or cls.pathIsN5(p) or cls.pathIsNpz(p)
 
     @classmethod
     def getPossibleInternalPathsFor(cls, file_path: Path, min_ndim=2, max_ndim=5) -> List[str]:

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -362,11 +362,9 @@ class PixelClassificationGui(LabelingGui):
             if len(internal_paths) == 1:
                 internal_path = internal_paths[0]
             else:
-                dlg = SubvolumeSelectionDlg(internal_paths, self)
-                if dlg.exec_() == QDialog.Rejected:
+                internal_path = SubvolumeSelectionDlg(internal_paths, self).select_path()
+                if internal_path is None:
                     return
-                selected_index = dlg.combo.currentIndex()
-                internal_path = str(internal_paths[selected_index])
 
             path_components = PathComponents(file_path)
             path_components.internalPath = str(internal_path)

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -27,8 +27,8 @@ from ilastik.utility import bind
 # ilastik
 from ilastik.config import cfg as ilastik_config
 from ilastik.utility.gui import threadRouted
-from ilastik.widgets.stackFileSelectionWidget import SubvolumeSelectionDlg
-from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui, SubvolumeSelectionDlg
+from ilastik.widgets.hdf5SubvolumeSelectionDialog import SubvolumeSelectionDlg
+from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui
 from ilastik.shell.gui.variableImportanceDialog import VariableImportanceDialog
 
 # Loggers
@@ -199,11 +199,9 @@ class VoxelSegmentationGui(LabelingGui):
             if len(internal_paths) == 1:
                 internal_path = internal_paths[0]
             else:
-                dlg = SubvolumeSelectionDlg(internal_paths, self)
-                if dlg.exec_() == QDialog.Rejected:
+                internal_path = SubvolumeSelectionDlg(internal_paths, self).select_path()
+                if internal_path is None:
                     return
-                selected_index = dlg.combo.currentIndex()
-                internal_path = str(internal_paths[selected_index])
 
             path_components = PathComponents(file_path)
             path_components.internalPath = str(internal_path)


### PR DESCRIPTION
Multiple dataset selection can be used to add multiple
datasets when opening an HDF5/N5/etc. files.

Also, clean up some surrounding code and remove
direct accesses to dialog widgets.

Closes https://github.com/ilastik/ilastik/issues/2283.