### PR TITLE
fixed error when adding more than 15 objects in object count classifier

### DIFF
--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -24,7 +24,6 @@ from builtins import filter
 import os
 import re
 import logging
-import itertools
 from functools import partial
 
 # Third-party

--- a/ilastik/workflows/tracking/common.py
+++ b/ilastik/workflows/tracking/common.py
@@ -1,0 +1,48 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2020, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from dataclasses import dataclass
+from typing import SupportsInt
+
+
+@dataclass(frozen=True)
+class PluralInflector:
+    zero: str
+    one: str
+    many: str
+
+    # arbitrarily defined maximum in case list() is called on this object
+    max_index: int = 256
+
+    def __getitem__(self, i: SupportsInt) -> str:
+        i = int(i)
+        if i < 0:
+            raise ValueError("cannot inflect negative numbers")
+        if i > self.max_index:
+            raise IndexError(f"values above {self.max_index} not supported (got {i}).")
+        if i == 0:
+            return self.zero
+        return f"{i} {self.one if i == 1 else self.many}"
+
+    def __len__(self) -> int:
+        return self.max_index
+
+
+DIVISION_CLASSIFIER_LABEL_NAMES = PluralInflector(zero="False Detection", one="Object", many="Objects")

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -16,7 +16,7 @@ from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBas
 from ilastik.applets.batchProcessing import BatchProcessingApplet
 from ilastik.plugins import pluginManager
 from ilastik.config import cfg as ilastik_config
-
+from ilastik.workflows.tracking.common import DIVISION_CLASSIFIER_LABEL_NAMES
 import logging
 
 logger = logging.getLogger(__name__)
@@ -114,9 +114,8 @@ class ConservationTrackingWorkflowBase(Workflow):
 
         opCellClassification = self.cellClassificationApplet.topLevelOperator
         opCellClassification.SelectedFeatures.setValue(configConservation.selectedFeaturesObjectCount)
-        opCellClassification.SuggestedLabelNames.setValue(
-            ["False Detection"] + [str(1) + " Object"] + [str(i) + " Objects" for i in range(2, 10)]
-        )
+
+        opCellClassification.SuggestedLabelNames.setValue(DIVISION_CLASSIFIER_LABEL_NAMES)
         opCellClassification.AllowDeleteLastLabelOnly.setValue(True)
         opCellClassification.EnableLabelTransfer.setValue(False)
 

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -40,6 +40,7 @@ from ilastik.applets.trackingFeatureExtraction.trackingFeatureExtractionApplet i
 from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBaseDataExport
 from ilastik.applets.batchProcessing import BatchProcessingApplet
 from ilastik.plugins import pluginManager
+from ilastik.workflows.tracking.common import DIVISION_CLASSIFIER_LABEL_NAMES
 
 import logging
 
@@ -199,9 +200,7 @@ class StructuredTrackingWorkflowBase(Workflow):
 
         opCellClassification = self.cellClassificationApplet.topLevelOperator
         opCellClassification.SelectedFeatures.setValue(configConservation.selectedFeaturesObjectCount)
-        opCellClassification.SuggestedLabelNames.setValue(
-            ["False Detection"] + [str(1) + " Object"] + [str(i) + " Objects" for i in range(2, 10)]
-        )
+        opCellClassification.SuggestedLabelNames.setValue(DIVISION_CLASSIFIER_LABEL_NAMES)
         opCellClassification.AllowDeleteLastLabelOnly.setValue(True)
         opCellClassification.EnableLabelTransfer.setValue(False)
 


### PR DESCRIPTION
I guess someone buried the knowledge that it's not very beneficial for solving the tracking problem to have a lot of merge objects somehow implicitly in the assumption that no one will add more than 14 objects. If we want to discourage it, we should make it explicit somewhere and not rely on "people just not doing it".
This PR allows users to add as many merged objects as they want. We should deal with the algorithmic problems this imposes somewhere else.

* made sure new colors are added to colortable when initial size is exceeded.
* made sure naming of new labels follows the scheme `x Objects`.

fixes #2294