### PR TITLE
Update layers visibility in thresholding

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -287,9 +287,6 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
 
     def _onApplyButtonClicked(self):
         self._updateOperatorFromGui()
-        for layer in self.layerstack:
-            if "Final" in layer.name:
-                layer.visible = True
         self.updateAllLayers()
 
     def _onTabCurrentChanged(self):
@@ -341,7 +338,7 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
             outputSrc = createDataSource(op.CachedOutput)
             outputLayer = ColortableLayer(outputSrc, ct)
             outputLayer.name = "Final output"
-            outputLayer.visible = False
+            outputLayer.visible = True
             outputLayer.opacity = 1.0
             outputLayer.colortableIsRandom = True
             outputLayer.setToolTip("Object Identities: Results of thresholding, connected components and size filter")

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -288,6 +288,9 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
     def _onApplyButtonClicked(self):
         self._updateOperatorFromGui()
         self.updateAllLayers()
+        for layer in self.layerstack:
+            if "Final" in layer.name:
+                layer.visible = True
 
     def _onTabCurrentChanged(self):
         pass
@@ -338,7 +341,7 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
             outputSrc = createDataSource(op.CachedOutput)
             outputLayer = ColortableLayer(outputSrc, ct)
             outputLayer.name = "Final output"
-            outputLayer.visible = True
+            outputLayer.visible = False
             outputLayer.opacity = 1.0
             outputLayer.colortableIsRandom = True
             outputLayer.setToolTip("Object Identities: Results of thresholding, connected components and size filter")


### PR DESCRIPTION
Solves an issue with https://github.com/ilastik/volumina/pull/255
Two assignments to Final Layer visible property result in a race between signals
Is there a reason why this layer initially starts as hidden?