### PR TITLE
fix Object Classsification Gui test: make sure to get current final layer

### DIFF
--- a/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
+++ b/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
@@ -186,9 +186,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
             gui.currentGui()._drawer.lowThresholdSpinBox.setValue(threshold)
 
             # get the final layer and check that it is not visible yet
-            layermatch = [x.name.startswith("Final") for x in gui.currentGui().layerstack]
-            assert sum(layermatch) == 1, "Only a single layer with 'Final' in the name expected."
-            final_layer = gui.currentGui().layerstack[layermatch.index(True)]
+            final_layer = gui.currentGui().getLayerByName("Final output")
             assert not final_layer.visible, "Expected the final layer not to be visible before apply is triggered."
 
             gui.currentGui()._drawer.applyButton.click()
@@ -196,6 +194,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
             saveThread = self.shell.onSaveProjectActionTriggered()
             saveThread.join()
 
+            final_layer = gui.currentGui().getLayerByName("Final output")
             assert final_layer.visible
 
             op_sigmas = op_threshold.SmootherSigma.value

--- a/tests/test_ilastik/widgets/test_ImageFileDialog.py
+++ b/tests/test_ilastik/widgets/test_ImageFileDialog.py
@@ -1,5 +1,5 @@
+import json
 import pathlib
-import pickle
 from pathlib import Path
 
 import pytest
@@ -11,11 +11,11 @@ from volumina.utility import preferences
 
 @pytest.fixture(autouse=True)
 def tmp_preferences(tmp_path) -> pathlib.Path:
-    old = preferences.get_location()
+    old = preferences.get_path()
     new = tmp_path / "tmp_preferences"
-    preferences.set_location(new)
+    preferences.set_path(new)
     yield new
-    preferences.set_location(old)
+    preferences.set_path(old)
 
 
 @pytest.fixture
@@ -43,8 +43,8 @@ def test_picking_file_updates_default_image_directory_to_previously_used(image: 
     QTimer.singleShot(0, handle_dialog)
     assert dialog.getSelectedPaths() == [image]
 
-    with open(tmp_preferences, "rb") as f:
-        assert pickle.load(f) == {dialog.preferences_group: {dialog.preferences_setting: image.as_posix()}}
+    with open(tmp_preferences, "r") as f:
+        assert json.load(f) == {"DataSelection": {"recent image": image.as_posix()}}
 
 
 def test_picking_n5_json_file_returns_directory_path(tmp_n5_file: Path):
@@ -57,7 +57,6 @@ def test_picking_n5_json_file_returns_directory_path(tmp_n5_file: Path):
             QApplication.processEvents()
 
         dialog.accept()
-
 
     QTimer.singleShot(0, handle_dialog)
 


### PR DESCRIPTION
final layer is recreated when setupLayers is called (this is triggered by
clicking the apply threshold button).