### PR TITLE
API changes for tifffile upgrade

### DIFF
--- a/lazyflow/operators/ioOperators/opExportMultipageTiff.py
+++ b/lazyflow/operators/ioOperators/opExportMultipageTiff.py
@@ -79,7 +79,7 @@ class OpExportMultipageTiff(Operator):
         if isinstance(dtype, type):
             dtype = dtype().dtype
 
-        page_buf = RoiRequestBufferIter(self._opReorderAxes.Output, self._batch_size)
+        page_buf = RoiRequestBufferIter(self._opReorderAxes.Output, self._batch_size, iterate_axes="tzc")
         page_buf.progress_signal.subscribe(self.progressSignal)
 
         with tifffile.TiffWriter(self.Filepath.value, byteorder="<", ome=True) as writer:

--- a/lazyflow/operators/ioOperators/opExportMultipageTiff.py
+++ b/lazyflow/operators/ioOperators/opExportMultipageTiff.py
@@ -85,7 +85,7 @@ class OpExportMultipageTiff(Operator):
         with tifffile.TiffWriter(self.Filepath.value, byteorder="<", ome=True) as writer:
             writer.write(
                 data=page_buf,
-                shape=self._opReorderAxes.Output.meta.shape,
+                shape=self._opReorderAxes.Output,
                 dtype=dtype,
                 software="ilastik",
                 metadata={"axes": "".join(self._opReorderAxes.Output.meta.getAxisKeys())},

--- a/lazyflow/operators/ioOperators/opExportMultipageTiff.py
+++ b/lazyflow/operators/ioOperators/opExportMultipageTiff.py
@@ -29,7 +29,7 @@ import tifffile
 
 from lazyflow.graph import InputSlot, Operator
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-from lazyflow.utility import OrderedSignal, RoiRequestBuffer
+from lazyflow.utility import OrderedSignal, RoiRequestBufferIter
 
 
 logger = logging.getLogger(__name__)
@@ -79,13 +79,13 @@ class OpExportMultipageTiff(Operator):
         if isinstance(dtype, type):
             dtype = dtype().dtype
 
-        page_buf = RoiRequestBuffer(self._opReorderAxes.Output, self._batch_size)
+        page_buf = RoiRequestBufferIter(self._opReorderAxes.Output, self._batch_size)
         page_buf.progress_signal.subscribe(self.progressSignal)
 
         with tifffile.TiffWriter(self.Filepath.value, byteorder="<", ome=True) as writer:
             writer.write(
                 data=page_buf,
-                shape=self._opReorderAxes.Output,
+                shape=self._opReorderAxes.Output.meta.shape,
                 dtype=dtype,
                 software="ilastik",
                 metadata={"axes": "".join(self._opReorderAxes.Output.meta.getAxisKeys())},

--- a/lazyflow/operators/ioOperators/opExportMultipageTiff.py
+++ b/lazyflow/operators/ioOperators/opExportMultipageTiff.py
@@ -22,19 +22,15 @@
 
 import logging
 import pathlib
-import textwrap
-import uuid
-import xml.etree.ElementTree as ET
-from typing import Any, Iterable, Sequence
 
 import numpy as np
 import psutil
 import tifffile
-import vigra
 
 from lazyflow.graph import InputSlot, Operator
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-from lazyflow.utility import OrderedSignal, RoiRequestBatch
+from lazyflow.utility import OrderedSignal, RoiRequestBuffer
+
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +60,6 @@ class OpExportMultipageTiff(Operator):
         self._opReorderAxes.Input.connect(self.Input)
         self._opReorderAxes.AxisOrder.setValue(self._EXPORT_AXES)
 
-        self._page_buf = None
-
     def setupOutputs(self):
         pass
 
@@ -81,54 +75,21 @@ class OpExportMultipageTiff(Operator):
         if path.exists():
             path.unlink()
 
-        self._page_buf = _NdBuf(self._opReorderAxes.Output.meta.shape[:-2])
-
-        batch = RoiRequestBatch(
-            outputSlot=self._opReorderAxes.Output,
-            roiIterator=_page_rois(*self._opReorderAxes.Output.meta.shape),
-            totalVolume=np.prod(self._opReorderAxes.Output.meta.shape),
-            batchSize=self._batch_size,
-        )
-        batch.progressSignal.subscribe(self.progressSignal)
-        batch.resultSignal.subscribe(self._write_buffered_pages)
-        batch.execute()
-
-    def _write_buffered_pages(self, roi, page) -> None:
-        """Store a new page in the buffer and write all in-order buffered pages to the file."""
-        page_axes = self._EXPORT_AXES[-2:]
-        page = vigra.taggedView(page, self._EXPORT_AXES).withAxes(page_axes)
-
-        page_idx = roi[0][:-2]
-        self._page_buf[page_idx] = page
-
-        for i, page in self._page_buf:
-            if not i:
-                self._write_first_page(page)
-            else:
-                vigra.impex.writeImage(page, self.Filepath.value, dtype="", compression="NONE", mode="a")
-
-    def _write_first_page(self, page) -> None:
-        """Write the first page differently: it needs the OME-XML `ImageDescription` field."""
         dtype = self._opReorderAxes.Output.meta.dtype
         if isinstance(dtype, type):
             dtype = dtype().dtype
 
-        desc = _image_desc_xml(
-            dtype=dtype,
-            axes=self._opReorderAxes.Output.meta.getAxisKeys(),
-            shape=self._opReorderAxes.Output.meta.shape,
-            file_uuid=str(uuid.uuid1()),
-            file_name=pathlib.Path(self.Filepath.value).name,
-        )
+        page_buf = RoiRequestBuffer(self._opReorderAxes.Output, self._batch_size)
+        page_buf.progress_signal.subscribe(self.progressSignal)
 
-        if logger.isEnabledFor(logging.DEBUG):
-            import xml.dom.minidom
-
-            pretty_desc = xml.dom.minidom.parseString(desc).toprettyxml()
-            logger.debug(f"Generated OME-TIFF metadata:\n{pretty_desc}")
-
-        with tifffile.TiffWriter(self.Filepath.value, software="ilastik", byteorder="<") as writer:
-            writer.save(page, description=desc, planarconfig="planar")
+        with tifffile.TiffWriter(self.Filepath.value, byteorder="<", ome=True) as writer:
+            writer.write(
+                data=page_buf,
+                shape=self._opReorderAxes.Output.meta.shape,
+                dtype=dtype,
+                software="ilastik",
+                metadata={"axes": "".join(self._opReorderAxes.Output.meta.getAxisKeys())},
+            )
 
     @property
     def _batch_size(self) -> int:
@@ -147,135 +108,3 @@ class OpExportMultipageTiff(Operator):
 
         npages = np.prod(shape[:-2])
         return min(batch_size, npages)
-
-
-class _NdBuf:
-    """Store ND-indexed items and give them back in the strict ND-ascending order."""
-
-    def __init__(self, shape: Iterable[int]):
-        self._items = {}
-        self._index = 0
-        self._shape = tuple(shape)
-
-    def __setitem__(self, key: Iterable[int], value: Any):
-        i = np.ravel_multi_index(key, self._shape)
-        self._items[i] = value
-
-    def __iter__(self) -> Iterable[Any]:
-        while self._index in self._items:
-            i = self._index
-            item = self._items.pop(i)
-            self._index += 1
-            yield i, item
-
-
-def _page_rois(*shape: int):
-    """Yield ROIs matching the TIFF pages from the input image shape."""
-    for page_idx in np.ndindex(*shape[:-2]):
-        start = page_idx + (0, 0)
-        stop = tuple(i + 1 for i in page_idx) + shape[-2:]
-        yield start, stop
-
-
-def _image_desc_xml(*, dtype: np.dtype, axes: Sequence[str], shape: Sequence[int], file_uuid="", file_name="") -> str:
-    """Create XML string for the OME-TIFF `ImageDescription` field."""
-    ome_types = {
-        "B": "uint8",
-        "H": "uint16",
-        "I": "uint32",
-        "b": "int8",
-        "h": "int16",
-        "i": "int32",
-        "f": "float",
-        "d": "double",
-        "F": "complex",
-        "D": "double-complex",
-    }
-    ome_type = ome_types.get(dtype.char)
-    if ome_type is None:
-        raise ValueError(f"dtype {dtype.name} does not have a matching OME-XML type")
-
-    if len(axes) != len(shape):
-        raise ValueError(f"axes and shape have different lengths: {len(axes)} != {len(shape)}")
-    if len(axes) < 2:
-        raise ValueError(f"expected at least 2 dimensions, got {len(axes)}")
-    # OME-XML uses Fortran order.
-    dims = "".join(reversed(axes)).upper()
-    sizes = tuple(reversed(shape))
-
-    if file_name and not file_uuid:
-        raise ValueError("file_name requires file_uuid")
-
-    ome = ET.Element("OME")
-    ome.set("xmlns", "http://www.openmicroscopy.org/Schemas/OME/2015-01")
-    ome.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
-    ome.set(
-        "xsi:schemaLocation",
-        "http://www.openmicroscopy.org/Schemas/OME/2015-01 "
-        "http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd",
-    )
-    if file_uuid:
-        ome.set("UUID", f"urn:uuid:{file_uuid}")
-
-    image = ET.SubElement(ome, "Image")
-    image.set("ID", "Image:0")
-    image.set("Name", "exported-data")
-
-    pixels = ET.SubElement(image, "Pixels")
-    pixels.set("ID", "Pixels:0")
-    pixels.set("BigEndian", "true")  # TODO: Figure out what endianness we actually use.
-    pixels.set("Type", ome_type)
-    pixels.set("DimensionOrder", dims)
-    for dim, size in zip(dims, sizes):
-        pixels.set(f"Size{dim}", str(size))
-
-    npages = np.prod(sizes[2:])
-    for i in range(npages):
-        tiff_data = ET.SubElement(pixels, "TiffData")
-        tiff_data.set("PlaneCount", "1")
-        tiff_data.set("IFD", str(i))
-
-        offsets = ()
-        if npages > 1:
-            offsets = np.unravel_index(i, sizes[2:], order="F")
-        for dim, offset in zip(dims[2:], offsets):
-            tiff_data.set(f"First{dim}", str(offset))
-
-        if file_uuid:
-            uuid_elem = ET.SubElement(tiff_data, "UUID")
-            uuid_elem.text = ome.get("UUID")
-            if file_name:
-                uuid_elem.set("FileName", file_name)
-
-    header = textwrap.dedent(
-        """\
-        <?xml version="1.0" encoding="utf-8"?>
-        <!-- Warning: this comment is an OME-XML metadata block, which contains
-        crucial dimensional parameters and other important metadata. Please edit
-        cautiously (if at all), and back up the original data before doing so.
-        For more information, see the OME-TIFF documentation:
-        https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/ -->
-        """
-    )
-    return header + ET.tostring(ome, encoding="unicode")
-
-
-if __name__ == "__main__":
-    import sys
-
-    logger.addHandler(logging.StreamHandler(sys.stdout))
-    logger.setLevel(logging.DEBUG)
-
-    from lazyflow.graph import Graph
-    from lazyflow.operators.ioOperators import OpTiffReader
-
-    graph = Graph()
-    opReader = OpTiffReader(graph=graph)
-    opReader.Filepath.setValue("/tmp/xyz.ome.tiff")
-
-    opWriter = OpExportMultipageTiff(graph=graph)
-    opWriter.Filepath.setValue("/tmp/xyz-converted.ome.tiff")
-    opWriter.Input.connect(opReader.Output)
-
-    opWriter.run_export()
-    print("DONE.")

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -33,7 +33,7 @@ from .tracer import Tracer, traceLogged
 from .pathHelpers import PathComponents, getPathVariants, isUrl, make_absolute, globH5N5, globList, mkdir_p, lsH5N5
 
 from .roiRequestBatch import RoiRequestBatch
-from .roiRequestBuffer import RoiRequestBuffer
+from .roiRequestBuffer import RoiRequestBufferIter
 from .bigRequestStreamer import BigRequestStreamer
 from . import io_util
 from .format_known_keys import format_known_keys

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -33,6 +33,7 @@ from .tracer import Tracer, traceLogged
 from .pathHelpers import PathComponents, getPathVariants, isUrl, make_absolute, globH5N5, globList, mkdir_p, lsH5N5
 
 from .roiRequestBatch import RoiRequestBatch
+from .roiRequestBuffer import RoiRequestBuffer
 from .bigRequestStreamer import BigRequestStreamer
 from . import io_util
 from .format_known_keys import format_known_keys

--- a/lazyflow/utility/roiRequestBuffer.py
+++ b/lazyflow/utility/roiRequestBuffer.py
@@ -1,0 +1,98 @@
+from typing import Any, Dict, Iterator, Tuple, Type
+from queue import Queue
+
+import numpy
+
+from lazyflow.graph import Slot
+from lazyflow.utility.roiRequestBatch import RoiRequestBatch
+
+
+ROI = Tuple[int, int, int, int, int]
+SHAPE = ROI
+ROI_TUPLE = Tuple[ROI, ROI]
+
+
+class _RoiIter:
+    """Iterate over rois for a given shape"""
+
+    def __init__(self, shape: SHAPE):
+        self._shape = shape
+
+    def to_index(self, roi: ROI_TUPLE) -> int:
+        """Convert ROI_TUPLE to index
+
+        first ROI_TUPLE -> index = 0
+        last ROI_TUPLE -> index = len(self) - 1
+        """
+        return numpy.ravel_multi_index(roi[0][:-2], self._shape[:-2])
+
+    def __len__(self) -> int:
+        return numpy.prod(self._shape[:-2])
+
+    def __iter__(self) -> Iterator[ROI_TUPLE]:
+        """iterate in ascending order, according to to_index"""
+        for partial_start in numpy.ndindex(self._shape[:-2]):
+            start: ROI = partial_start + (0, 0)
+            stop: ROI = tuple(i + 1 for i in partial_start) + self._shape[-2:]
+            yield start, stop
+
+
+class RoiRequestBuffer:
+    """Iterate over first 3 dims of a 5D slot in nd-ascending order."""
+
+    def __init__(self, slot: Slot, batchsize: int, roi_iter_cls: Type[_RoiIter] = _RoiIter):
+        """
+        Args:
+            slot: slot to request data from
+            batchsize: maximum number of requests to launch in parallel
+            roi_iter_cls: mainly exposed for testing, class that produces iterators\
+            given a shape
+        """
+        self._slot = slot
+        self._batchsize = batchsize
+
+        self._items: Dict[int, numpy.ndarray] = {}
+        self._q: Queue[Tuple[ROI_TUPLE, numpy.ndarray]] = Queue()
+        self._index = 0
+        self._roi_iter = roi_iter_cls(self._slot.meta.shape)
+        self._max = len(self._roi_iter)
+
+        self._roi_request_batch = self._config_batch_request()
+
+    def _config_batch_request(self) -> RoiRequestBatch:
+        self._items = {}
+        self._index = 0
+        roi_request_batch = RoiRequestBatch(
+            outputSlot=self._slot,
+            roiIterator=iter(self._roi_iter),
+            totalVolume=numpy.prod(self._slot.meta.shape),
+            batchSize=self._batchsize,
+            allowParallelResults=False,
+        )
+        roi_request_batch.resultSignal.subscribe(self._put)
+        return roi_request_batch
+
+    def _put(self, *val):
+        self._q.put(val)
+
+    @property
+    def progress_signal(self):
+        return self._roi_request_batch.progressSignal
+
+    def __iter__(self) -> Iterator[numpy.ndarray]:
+        self._roi_request_batch.execute()
+        slot_shape = self._slot.meta.shape
+        while True:
+            if self._index not in self._items:
+                k, v = self._q.get()
+                idx = self._roi_iter.to_index(k)
+                self._items[idx] = v
+                continue
+
+            i = self._index
+            item = self._items.pop(i)
+            self._index = i + 1
+
+            yield item
+            if self._index >= self._max:
+                return

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpTiffReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpTiffReader.py
@@ -5,6 +5,7 @@ import contextlib
 
 import numpy
 from numpy.testing import assert_array_equal
+import pytest
 import vigra
 
 from lazyflow.graph import Graph
@@ -64,7 +65,11 @@ class TestOpTiffReader(object):
             assert op.Output.ready()
             assert (op.Output[20:30, 50:100, 50:150].wait() == data[20:30, 50:100, 50:150]).all()
 
-    def test_unknown_axes_tags(self):
+    @pytest.mark.parametrize(
+        "test_shape,axisorder",
+        [((10, 20), "yx"), ((10, 20, 30), "zyx"), ((10, 20, 30, 3), "zyxc"), ((5, 10, 20, 30, 3), "tzyxc")],
+    )
+    def test_unknown_axes_tags(self, test_shape, axisorder):
         """
         This test is related to https://github.com/ilastik/ilastik/issues/1487
 
@@ -73,30 +78,15 @@ class TestOpTiffReader(object):
         import tifffile
         from distutils import version
 
-        # TODO(Dominik) remove version checking once tifffile dependency is fixed
-        # ilastik tiffile version >= 2000.0.0
-        # latest tifffile version is 0.13.0 right now
-        tifffile_version_ilastik_ref = version.StrictVersion("2000.0.0")
-        tifffile_version_ref = version.StrictVersion("0.7.0")
-        tifffile_version = version.StrictVersion(tifffile.__version__)
-
-        testshapes = [((10, 20), "yx"), ((10, 20, 30), "zyx"), ((10, 20, 30, 3), "zyxc"), ((5, 10, 20, 30, 3), "tzyxc")]
-
         with tempdir() as d:
-            for test_shape, test_axes in testshapes:
-                data = numpy.random.randint(0, 256, test_shape).astype(numpy.uint8)
-                tiff_path = "{}/myfile_{}.tiff".format(d, test_axes)
-                # TODO(Dominik) remove version checking once dependencies for
-                # skimage are >= 0.13.0 for all flavours of ilastik
-                if (tifffile_version > tifffile_version_ilastik_ref) or (tifffile_version < tifffile_version_ref):
-                    tifffile.imsave(tiff_path, data)
-                else:
-                    tifffile.imsave(tiff_path, data, metadata={"axes": "QQQ"})
-                op = OpTiffReader(graph=Graph())
-                op.Filepath.setValue(tiff_path)
-                assert op.Output.ready()
-                assert_array_equal(data, op.Output[:].wait())
-                assert op.Output.meta.axistags == vigra.defaultAxistags(test_axes)
+            data = numpy.random.randint(0, 256, test_shape).astype(numpy.uint8)
+            tiff_path = "{}/myfile_{}.tiff".format(d, axisorder)
+            tifffile.imsave(tiff_path, data)
+            op = OpTiffReader(graph=Graph())
+            op.Filepath.setValue(tiff_path)
+            assert op.Output.ready()
+            assert_array_equal(data, op.Output[:].wait())
+            assert op.Output.meta.axistags == vigra.defaultAxistags(axisorder)
 
     def test_lzw_compressed_file(self, inputdata_dir):
         """

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpTiffReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpTiffReader.py
@@ -1,8 +1,3 @@
-from builtins import object
-import tempfile
-import shutil
-import contextlib
-
 import numpy
 from numpy.testing import assert_array_equal
 import pytest
@@ -12,38 +7,30 @@ from lazyflow.graph import Graph
 from lazyflow.operators.ioOperators import OpTiffReader
 
 
-@contextlib.contextmanager
-def tempdir():
-    d = tempfile.mkdtemp()
-    yield d
-    shutil.rmtree(d)
+class TestOpTiffReader:
+    def test_2d(self, tmp_path):
+        data = numpy.random.randint(0, 255, (100, 200, 3), dtype="uint8")
 
+        tiff_path = str(tmp_path / "test-2d.tiff")
+        vigra.impex.writeImage(vigra.taggedView(data, "yxc"), tiff_path, dtype="NATIVE", mode="w")
 
-class TestOpTiffReader(object):
-    def test_2d(self):
-        data = numpy.random.randint(0, 255, (100, 200, 3)).astype(numpy.uint8)
-        with tempdir() as d:
-            tiff_path = d + "/test-2d.tiff"
-            vigra.impex.writeImage(vigra.taggedView(data, "yxc"), tiff_path, dtype="NATIVE", mode="w")
+        op = OpTiffReader(graph=Graph())
+        op.Filepath.setValue(tiff_path)
+        assert op.Output.ready()
+        assert (op.Output[50:100, 50:150].wait() == data[50:100, 50:150]).all()
 
-            op = OpTiffReader(graph=Graph())
-            op.Filepath.setValue(tiff_path)
-            assert op.Output.ready()
-            assert (op.Output[50:100, 50:150].wait() == data[50:100, 50:150]).all()
-
-    def test_3d(self):
+    def test_3d(self, tmp_path):
         data = numpy.random.randint(0, 255, (50, 100, 200, 3)).astype(numpy.uint8)
-        with tempdir() as d:
-            tiff_path = d + "/test-3d.tiff"
-            for z_slice in data:
-                vigra.impex.writeImage(vigra.taggedView(z_slice, "yxc"), tiff_path, dtype="NATIVE", mode="a")
+        tiff_path = str(tmp_path / "test-3d.tiff")
+        for z_slice in data:
+            vigra.impex.writeImage(vigra.taggedView(z_slice, "yxc"), tiff_path, dtype="NATIVE", mode="a")
 
-            op = OpTiffReader(graph=Graph())
-            op.Filepath.setValue(tiff_path)
-            assert op.Output.ready()
-            assert (op.Output[20:30, 50:100, 50:150].wait() == data[20:30, 50:100, 50:150]).all()
+        op = OpTiffReader(graph=Graph())
+        op.Filepath.setValue(tiff_path)
+        assert op.Output.ready()
+        assert (op.Output[20:30, 50:100, 50:150].wait() == data[20:30, 50:100, 50:150]).all()
 
-    def test_3d_with_compression(self):
+    def test_3d_with_compression(self, tmp_path):
         """
         This tests that we can read a compressed (LZW) TIFF file.
 
@@ -52,41 +39,39 @@ class TestOpTiffReader(object):
         'series' in it, so the thing seems to have twice as many planes as it should.
         Furthermore, vigra doesn't seem to read it back correctly, or maybe I'm missing something...
         """
-        data = numpy.random.randint(0, 255, (50, 100, 200, 3)).astype(numpy.uint8)
-        with tempdir() as d:
-            tiff_path = d + "/test-3d.tiff"
-            for z_slice in data:
-                vigra.impex.writeImage(
-                    vigra.taggedView(z_slice, "yxc"), tiff_path, dtype="NATIVE", compression="LZW", mode="a"
-                )
+        data = numpy.random.randint(0, 255, (50, 100, 200, 3), dtype="uint8")
 
-            op = OpTiffReader(graph=Graph())
-            op.Filepath.setValue(tiff_path)
-            assert op.Output.ready()
-            assert (op.Output[20:30, 50:100, 50:150].wait() == data[20:30, 50:100, 50:150]).all()
+        tiff_path = str(tmp_path / "test-3d.tiff")
+        for z_slice in data:
+            vigra.impex.writeImage(
+                vigra.taggedView(z_slice, "yxc"), tiff_path, dtype="NATIVE", compression="LZW", mode="a"
+            )
+
+        op = OpTiffReader(graph=Graph())
+        op.Filepath.setValue(tiff_path)
+        assert op.Output.ready()
+        assert (op.Output[20:30, 50:100, 50:150].wait() == data[20:30, 50:100, 50:150]).all()
 
     @pytest.mark.parametrize(
         "test_shape,axisorder",
         [((10, 20), "yx"), ((10, 20, 30), "zyx"), ((10, 20, 30, 3), "zyxc"), ((5, 10, 20, 30, 3), "tzyxc")],
     )
-    def test_unknown_axes_tags(self, test_shape, axisorder):
+    def test_unknown_axes_tags(self, test_shape, axisorder, tmp_path):
         """
         This test is related to https://github.com/ilastik/ilastik/issues/1487
 
         Here, we generate a 3D tiff file with scikit-learn and try to read it
         """
         import tifffile
-        from distutils import version
 
-        with tempdir() as d:
-            data = numpy.random.randint(0, 256, test_shape).astype(numpy.uint8)
-            tiff_path = "{}/myfile_{}.tiff".format(d, axisorder)
-            tifffile.imsave(tiff_path, data)
-            op = OpTiffReader(graph=Graph())
-            op.Filepath.setValue(tiff_path)
-            assert op.Output.ready()
-            assert_array_equal(data, op.Output[:].wait())
-            assert op.Output.meta.axistags == vigra.defaultAxistags(axisorder)
+        data = numpy.random.randint(0, 256, test_shape, dtype="uint8")
+        tiff_path = str(tmp_path / f"myfile_{axisorder}.tiff")
+        tifffile.imsave(tiff_path, data)
+        op = OpTiffReader(graph=Graph())
+        op.Filepath.setValue(tiff_path)
+        assert op.Output.ready()
+        assert_array_equal(data, op.Output[:].wait())
+        assert op.Output.meta.axistags == vigra.defaultAxistags(axisorder)
 
     def test_lzw_compressed_file(self, inputdata_dir):
         """
@@ -97,7 +82,7 @@ class TestOpTiffReader(object):
         """
         compressed_tiff_file = f"{inputdata_dir}/compressed_lzw.tiff"
         # generate checker-board, as in the file
-        data = numpy.zeros((10, 20, 3)).astype(numpy.uint8)
+        data = numpy.zeros((10, 20, 3), dtype="uint8")
         for i in range(data.shape[0]):
             if i % 2 == 0:
                 data[i, 1::2, :] = 255

--- a/tests/test_lazyflow/test_utility/conftest.py
+++ b/tests/test_lazyflow/test_utility/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+import numpy
+
+from lazyflow.operators import OpArrayPiper
+
+
+class ProcessingException(Exception):
+    pass
+
+
+class OpArrayPiperError(OpArrayPiper):
+    def __init__(self, raise_exception_on_req_no, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raise_exception_on_req_no = raise_exception_on_req_no
+        self._execution_count = 0
+
+    def execute(self, slot, subindex, roi, result):
+        self._execution_count += 1
+        if self._execution_count == self._raise_exception_on_req_no:
+            raise ProcessingException()
+        super().execute(slot, subindex, roi, result)
+
+
+@pytest.fixture
+def op_raising_at_3(graph):
+    op = OpArrayPiperError(3, graph=graph)
+    data = numpy.arange(10 * 20 * 30).reshape((10, 20, 30))
+    op.Input.setValue(data)
+    return op

--- a/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
+++ b/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
@@ -35,16 +35,35 @@ def raising_op(graph):
     return op
 
 
-def test_RoiIter():
+def test_RoiIter_default():
     mockslot = mock.Mock()
     shape = (200, 42, 3, 15, 27)
     mockslot.meta.shape = (200, 42, 3, 15, 27)
     mockslot.meta.getAxisKeys.return_value = ["t", "z", "c", "y", "x"]
-    r_iter = _RoiIter(mockslot)
+    mockslot.meta.getTaggedShape.return_value = {"t": 200, "z": 42, "c": 3, "y": 15, "x": 27}
+    r_iter = _RoiIter(mockslot, iterate_axes="tzc")
 
     assert len(r_iter) == numpy.prod(shape[:-2])
     assert all(x[-2:] == (0, 0) for x, _ in r_iter)
     assert all(x[0] == y + (0, 0) for x, y in zip(r_iter, numpy.ndindex(*shape[:-2])))
+
+
+@pytest.mark.parametrize(
+    "tagged_shape,iterate_axes,axisorder,expected",
+    [
+        ({"x": 4}, "x", "x", (((0,), (1,)), ((1,), (2,)), ((2,), (3,)), ((3,), (4,)))),
+        ({"x": 1, "y": 2, "z": 3}, "y", "zxy", (((0, 0, 0), (3, 1, 1)), ((0, 0, 1), (3, 1, 2)))),
+    ],
+)
+def test_RoiIter(tagged_shape, iterate_axes, axisorder, expected):
+    mockslot = mock.Mock()
+    mockslot.meta.shape = tuple(tagged_shape[x] for x in axisorder)
+    mockslot.meta.getAxisKeys.return_value = list(axisorder)
+    mockslot.meta.getTaggedShape.return_value = tagged_shape
+
+    r_iter = _RoiIter(mockslot, iterate_axes=iterate_axes)
+    for gen, exp in zip(r_iter, expected):
+        assert gen == exp
 
 
 def test_in_ascending_order(graph, monkeypatch):
@@ -59,7 +78,7 @@ def test_in_ascending_order(graph, monkeypatch):
     class RI:
         """Roi iter class that returns rois over the last dimension in descending order"""
 
-        def __init__(self, slot):
+        def __init__(self, slot, iterate_axes):
             self._shape = slot.meta.shape
 
         def to_index(self, roi):
@@ -75,7 +94,7 @@ def test_in_ascending_order(graph, monkeypatch):
                 yield start, stop
 
     monkeypatch.setattr(lazyflow.utility.roiRequestBuffer, "_RoiIter", RI)
-    rb = RoiRequestBufferIter(op.Output, batchsize=2)
+    rb = RoiRequestBufferIter(op.Output, batchsize=2, iterate_axes="tzc")
 
     for i, item in enumerate(rb):
         assert item.shape == (3, 2, 10, 16, 1)
@@ -85,7 +104,7 @@ def test_in_ascending_order(graph, monkeypatch):
 
 def test_raises(raising_op):
     """Make sure iterator does not block indefinitely if exception occurs in thread"""
-    rb = RoiRequestBufferIter(raising_op.Output, batchsize=2)
+    rb = RoiRequestBufferIter(raising_op.Output, batchsize=2, iterate_axes="tzc")
 
     with pytest.raises(ProcessingException):
         for item in rb:

--- a/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
+++ b/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
@@ -5,7 +5,7 @@ from unittest import mock
 import vigra
 
 from lazyflow.operators import OpArrayPiper
-from lazyflow.utility import RoiRequestBuffer
+from lazyflow.utility import RoiRequestBufferIter
 from lazyflow.utility.roiRequestBuffer import _RoiIter
 import lazyflow.utility.roiRequestBuffer
 
@@ -75,7 +75,7 @@ def test_in_ascending_order(graph, monkeypatch):
                 yield start, stop
 
     monkeypatch.setattr(lazyflow.utility.roiRequestBuffer, "_RoiIter", RI)
-    rb = RoiRequestBuffer(op.Output, batchsize=2)
+    rb = RoiRequestBufferIter(op.Output, batchsize=2)
 
     for i, item in enumerate(rb):
         assert item.shape == (3, 2, 10, 16, 1)
@@ -85,7 +85,7 @@ def test_in_ascending_order(graph, monkeypatch):
 
 def test_raises(raising_op):
     """Make sure iterator does not block indefinitely if exception occurs in thread"""
-    rb = RoiRequestBuffer(raising_op.Output, batchsize=2)
+    rb = RoiRequestBufferIter(raising_op.Output, batchsize=2)
 
     with pytest.raises(ProcessingException):
         for item in rb:

--- a/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
+++ b/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
@@ -1,0 +1,80 @@
+import numpy
+import pytest
+
+from lazyflow.operators import OpArrayPiper
+from lazyflow.utility import RoiRequestBuffer
+from lazyflow.utility.roiRequestBuffer import _RoiIter
+import lazyflow.utility.roiRequestBuffer
+
+
+class ProcessingException(Exception):
+    pass
+
+
+class OpArrayPiperError(OpArrayPiper):
+    def __init__(self, raise_exception_on_req_no, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._raise_exception_on_req_no = raise_exception_on_req_no
+        self._execution_count = 0
+
+    def execute(self, slot, subindex, roi, result):
+        self._execution_count += 1
+        if self._execution_count == self._raise_exception_on_req_no:
+            raise ProcessingException()
+        super().execute(slot, subindex, roi, result)
+
+
+@pytest.fixture
+def raising_op(graph):
+    op = OpArrayPiperError(3, graph=graph)
+    data = numpy.ones((3, 2, 10, 16, 32))  # tczyx
+    op.Input.setValue(data)
+    return op
+
+
+def test_RoiIter():
+    shape = (200, 42, 3, 15, 27)
+    r_iter = _RoiIter(shape)
+
+    assert len(r_iter) == numpy.prod(shape[:-2])
+    assert all(x[-2:] == (0, 0) for x, _ in r_iter)
+    assert all(x[0] == y + (0, 0) for x, y in zip(r_iter, numpy.ndindex(*shape[:-2])))
+
+
+def test_in_ascending_order(graph):
+    """Make sure iterator returns data slices in ascending order"""
+    op = OpArrayPiper(graph=graph)
+    data = numpy.ones((3, 2, 10, 16, 32), dtype="uint8") * numpy.arange(32, dtype="uint8")
+
+    op.Input.setValue(data)
+
+    class RI(_RoiIter):
+        """Roi iter class that returns rois over the last dimension in descending order"""
+
+        def to_index(self, roi):
+            return roi[0][-1]
+
+        def __len__(self):
+            return self._shape[-1]
+
+        def __iter__(self):
+            for i in range(self._shape[-1], 0, -1):
+                start = (0, 0, 0, 0) + (i - 1,)
+                stop = self._shape[:-1] + (i,)
+                yield start, stop
+
+    rb = RoiRequestBuffer(op.Output, batchsize=2, roi_iter_cls=RI)
+
+    for i, item in enumerate(rb):
+        assert item.shape == (3, 2, 10, 16, 1)
+        assert item.min() == i
+        assert item.max() == i
+
+
+def test_raises(raising_op):
+    """Make sure iterator does not block indefinitely if exception occurs in thread"""
+    rb = RoiRequestBuffer(raising_op.Output, batchsize=2)
+
+    with pytest.raises(ProcessingException):
+        for item in rb:
+            assert item.shape == (1, 1, 1, 16, 32)


### PR DESCRIPTION
With this PR we finally switch from `tifffile 0.4.post2` which we have been building ourselves. `tifffile` even changed there versioning scheme in the meantime :o . I tried to keep the changes minimal as possible (e.g. still using vigra to read the pages), but ended up having to modify `OpExportMultipageTiff` quite a bit.

TODO:
- [x] rebuild deps package on OSX
- [x] move latest deps version to main
- [x] remove `tifffile` from ilastik-forge