### PR TITLE
Quickfix nn wf save servers

### DIFF
--- a/ilastik/applets/serverConfiguration/configStorage.py
+++ b/ilastik/applets/serverConfiguration/configStorage.py
@@ -127,11 +127,12 @@ class ServerConfigStorage:
         for srv in servers:
             self._write_server_entry(srv)
 
-        if isinstance(self._dst, str):
-            with open(self._dst, 'w+') as out:
-                self._config.write(out)
-        else:
-            self._config.write(self._dst)
+        if self._dst:
+            if isinstance(self._dst, str):
+                with open(self._dst, "w+") as out:
+                    self._config.write(out)
+            else:
+                self._config.write(self._dst)
 
 
 SERVER_CONFIG = ServerConfigStorage(config.cfg, str(config.cfg_path))


### PR DESCRIPTION
tiktorch servers were saved to ilastikrc instead of preferences.

In general nothing is ever written to ilastikrc, this is tackled in
#2348 with a proper fix.

This commit rather makes it not error out in the meantime - enabling tutorials
to go smoothly.

closes #2351