### PR TITLE
completely removed persisting servers to .ilastikrc

### DIFF
--- a/ilastik/applets/serverConfiguration/configStorage.py
+++ b/ilastik/applets/serverConfiguration/configStorage.py
@@ -127,12 +127,5 @@ class ServerConfigStorage:
         for srv in servers:
             self._write_server_entry(srv)
 
-        if self._dst:
-            if isinstance(self._dst, str):
-                with open(self._dst, "w+") as out:
-                    self._config.write(out)
-            else:
-                self._config.write(self._dst)
-
 
 SERVER_CONFIG = ServerConfigStorage(config.cfg, str(config.cfg_path))

--- a/tests/test_ilastik/test_applets/test_serverConfiguration/test_configStore.py
+++ b/tests/test_ilastik/test_applets/test_serverConfiguration/test_configStore.py
@@ -205,6 +205,7 @@ class TestStoringServers:
             types.ServerConfig(id='myid1', name='Server1', type='local', address='127.0.0.1', port='3123', devices=[types.Device(id='cpu0', name='MyCpu1', enabled=True), types.Device(id='gpu1', name='GPU1', enabled=False)])
         ]
 
+    @pytest.mark.xfail(reason="Disabled buggy persistence to .ilastikrc")
     def test_me(self, store, servers):
         out = StringIO()
         store(out, servers)
@@ -231,6 +232,8 @@ devices =
    gpu1::GPU6::enabled
 """
 
+
+@pytest.mark.xfail(reason="Disabled buggy persistence to .ilastikrc")
 def test_server_config_storing_server():
     conf = ConfigParser()
     conf.read_string(CONFIG)


### PR DESCRIPTION
quickfix! Completely remove saving configured server to .ilastikrc

this is properly tackled in  #2331 by saving to prefs

removing the save action fixes #2355 