### PR TITLE
use conda installed tifffile in plugin

### DIFF
--- a/ilastik/plugins_default/tracking_ctc_export.py
+++ b/ilastik/plugins_default/tracking_ctc_export.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import vigra
-from skimage.external import tifffile
+import tifffile
 from ilastik.plugins import TrackingExportFormatPlugin
 
 import logging
@@ -108,7 +108,7 @@ class TrackingCTCExportFormatPlugin(TrackingExportFormatPlugin):
             vigra.impex.writeImage(label_image.astype("uint16"), filename)
         elif len(label_image.shape) == 3:  # 3D
             label_image = np.transpose(label_image, axes=[2, 0, 1])
-            tifffile.imsave(filename, label_image.astype("uint16"))
+            tifffile.imwrite(filename, label_image.astype("uint16"))
         else:
             raise ValueError("Image had the wrong dimensions, can only save 2 or 3D images with a single channel")
 

--- a/lazyflow/operators/ioOperators/opTiffReader.py
+++ b/lazyflow/operators/ioOperators/opTiffReader.py
@@ -1,23 +1,8 @@
-from typing import Tuple
 import numpy
-
-# Note: tifffile can also be imported from skimage.external.tifffile.tifffile_local,
-#       but we can't use that module because it is based on a version of tifffile that has a bug.
-#       (It doesn't properly import the tifffile.c extension module.)
-# import skimage.external.tifffile.tifffile_local as tifffile
-
 import tifffile
-
-# import tifffile._tifffile
-# if tifffile.decode_lzw != tifffile._tifffile.decode_lzw:
-#     import warnings
-#     warnings.warn("tifffile C-extension is not working, probably due to a bug in tifffile._replace_by().\n"
-#                   "TIFF decompression will be VERY SLOW.")
-
 import vigra
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.roi import roiToSlice
-from lazyflow.request import RequestLock
 from lazyflow.utility.helpers import get_default_axisordering
 
 import logging


### PR DESCRIPTION
with tifffile 0.17 (that we currently distribute) tifffile is not longer shipped as part of skimage, but as a dependency.

also `tifffile.imsave` is deprecated in favor of `tifffile.imwrite`