### PR TITLE
add possibility to silently force cache values

### DIFF
--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -242,7 +242,7 @@ class NewAutocontextWorkflowBase(Workflow):
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifers:
             for pcApplet, classifier in zip(self.pcApplets, self.stored_classifers):
-                pcApplet.topLevelOperator.classifier_cache.forceValue(classifier)
+                pcApplet.topLevelOperator.classifier_cache.forceValue(classifier, set_dirty=False)
 
             # Release references
             self.stored_classifers = []
@@ -532,8 +532,8 @@ class NewAutocontextWorkflowBase(Workflow):
         distribute_action.triggered.connect(self.distribute_labels_from_current_stage)
 
         self._autocontext_menu = (
-            autocontext_menu
-        )  # Must retain here as a member or else reference disappears and the menu is deleted.
+            autocontext_menu  # Must retain here as a member or else reference disappears and the menu is deleted.
+        )
         return [self._autocontext_menu]
 
     def distribute_labels_from_current_stage(self):

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -355,15 +355,17 @@ class OpValueCache(Operator, ObservableCache):
             if self.fixAtCurrent.value is False and self._dirty:
                 self.Output.setDirty()
 
-    def forceValue(self, value):
+    def forceValue(self, value, set_dirty=True):
         """
         Allows a 'back door' to force data into this cache.
-        Note: Use this function carefully.
+        Note: Use this function carefully. Even more when using set_dirty=False,
+        which could leave workflows in an inconsistent state.
         """
         with self._lock:
             self._value = value
             self._dirty = False
-        self.Output.setDirty()
+        if set_dirty:
+            self.Output.setDirty()
 
     def resetValue(self):
         """


### PR DESCRIPTION
probably not elegant, and possibly dangerous, open to suggestions here. But at least it works.

Currently, autocontext will start retraining in batch processing (starting with the second image), [user report](https://forum.image.sc/t/ilastik-autocontext-stage2-probability-output-range-incorrect-in-headless-mode/46603). This costs time, and even worse - will retrain without the data...

This only pops up in autocontext (the same is done in pixel classification, too) because one classifier output is input for the next stage :/

cache value can now be forced, without setting it's output to dirty.