### PR TITLE
add proper unsubscribe callbacks to cleanup funcs

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -114,14 +114,13 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
         self._showDebug = False
 
         self._updateGuiFromOperator()
-        self.topLevelOperatorView.InputChannelColors.notifyReady(bind(self._updateGuiFromOperator))
+
         self.__cleanup_fns.append(
-            partial(self.topLevelOperatorView.InputImage.unregisterUnready, bind(self._updateGuiFromOperator))
+            self.topLevelOperatorView.InputChannelColors.notifyReady(bind(self._updateGuiFromOperator))
         )
 
-        self.topLevelOperatorView.InputChannelColors.notifyMetaChanged(bind(self._updateGuiFromOperator))
         self.__cleanup_fns.append(
-            partial(self.topLevelOperatorView.InputImage.unregisterMetaChanged, bind(self._updateGuiFromOperator))
+            self.topLevelOperatorView.InputChannelColors.notifyMetaChanged(bind(self._updateGuiFromOperator))
         )
 
     def _connectCallbacks(self):


### PR DESCRIPTION
There seems to be pattern common in the code that invites copy paste errors that are somehow hard to spot. Things like

```python
        self.topLevelOperatorView.InputChannelColors.notifyMetaChanged(bind(self._updateGuiFromOperator))
        self.__cleanup_fns.append(
            partial(self.topLevelOperatorView.InputImage.unregisterMetaChanged, bind(self._updateGuiFromOperator))
        )
```

This looks unsuspicious because of long mangled names. The problem there is that the signal is unregistered from a different slot that in has been subscribed to. The problem now is that the `_updateGuiFromOperator` function is not removed from the slot. GUI is destroyed first, then the operators are cleaned up. In the avalanche of notifications, functions might be fired that manipulate the gui and result in issues like #2376. I will take some time canvassing our source code to make sure this is not the case anywhere else.

I first wanted to make sure to raise if code tries to unsubscribe a signal that was not subscribed before, but this causes a lot of errors (and should be further investigated).

fixes #2376
fixes #777 (duplicate)


Potentially related: #2250 #2270 
