### PR TITLE
Cleanup/Fix of Multicut Gui Code

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -54,7 +54,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class EdgeTrainingGui(LayerViewerGui):
+class EdgeTrainingMixin:
 
     ###########################################
     ### AppletGuiInterface Concrete Methods ###
@@ -69,23 +69,23 @@ class EdgeTrainingGui(LayerViewerGui):
             fn()
 
         # Base class
-        super(EdgeTrainingGui, self).stopAndCleanUp()
+        super().stopAndCleanUp()
 
     ###########################################
     ###########################################
 
-    def __init__(self, parentApplet, topLevelOperatorView):
+    def __init__(self, parentApplet, topLevelOperatorView, **kwargs):
         self._currently_updating = False
         self.__cleanup_fns = []
         self.parentApplet = parentApplet
         self.topLevelOperatorView = topLevelOperatorView
-        super(EdgeTrainingGui, self).__init__(parentApplet, topLevelOperatorView, crosshair=False)
+        super().__init__(parentApplet, topLevelOperatorView, **kwargs)
 
         self._init_edge_label_colortable()
         self._init_probability_colortable()
 
     def _after_init(self):
-        super(EdgeTrainingGui, self)._after_init()
+        super()._after_init()
         self.update_probability_edges()
 
         # Initialize everything with the operator's initial values
@@ -188,8 +188,6 @@ class EdgeTrainingGui(LayerViewerGui):
         """
         Overridden from base class (LayerViewerGui)
         """
-        # Save these members for later use
-        self._drawer = self.createDrawerControls()
 
         op = self.topLevelOperatorView
         cleanup_fn = op.GroundtruthSegmentation.notifyReady(self.configure_gui_from_operator, defer=True)
@@ -528,3 +526,18 @@ class EdgeTrainingGui(LayerViewerGui):
             del layer
 
         return layers
+
+
+class EdgeTrainingGui(EdgeTrainingMixin, LayerViewerGui):
+    def appletDrawer(self):
+        return self.__drawer
+
+    def initAppletDrawerUi(self):
+        """
+        Overridden from base class (LayerViewerGui)
+        """
+        # Save these members for later use
+        self.__drawer = self.createDrawerControls()
+
+        # Initialize everything with the operator's initial values
+        self.configure_gui_from_operator()

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -73,6 +73,10 @@ class EdgeTrainingMixin:
 
     ###########################################
     ###########################################
+    def __init_subclass__(cls, **kwargs):
+        """Make sure Mixin can only be used with LayerViewerGui"""
+        assert issubclass(cls, LayerViewerGui), "Mixin should only be used with LayerViewerGui"
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, parentApplet, topLevelOperatorView, **kwargs):
         self._currently_updating = False

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -130,23 +130,12 @@ class EdgeTrainingGui(LayerViewerGui):
 
         self.train_from_gt_button.clicked.connect(lambda: op.FreezeClassifier.setValue(False))
 
-        def enable_live_update_on_edges_available(*args, **kwargs):
-            any_have_edges = False
-            top_level_edge_labels_dict = op.EdgeLabelsDict.top_level_slot
-            assert top_level_edge_labels_dict.level == 1
-            for subslot in op.EdgeLabelsDict.top_level_slot:
-                any_have_edges = subslot.ready() and bool(subslot.value)
-                if any_have_edges:
-                    break
-
-            self.live_update_button.setEnabled(any_have_edges)
-
-        cleanup_fn = op.EdgeLabelsDict.notifyDirty(enable_live_update_on_edges_available)
+        cleanup_fn = op.EdgeLabelsDict.notifyDirty(self.enable_live_update_on_edges_available)
         self.__cleanup_fns.append(cleanup_fn)
 
         # call once when instantiating with a saved project to make the live update button available
         # if there are annotations loaded from file.
-        enable_live_update_on_edges_available()
+        self.enable_live_update_on_edges_available()
 
         # Layout
         label_layout = QHBoxLayout()
@@ -182,6 +171,18 @@ class EdgeTrainingGui(LayerViewerGui):
         )
 
         return drawer
+
+    def enable_live_update_on_edges_available(self, *args, **kwargs):
+        any_have_edges = False
+        op = self.topLevelOperatorView
+        top_level_edge_labels_dict = op.EdgeLabelsDict.top_level_slot
+        assert top_level_edge_labels_dict.level == 1
+        for subslot in op.EdgeLabelsDict.top_level_slot:
+            any_have_edges = subslot.ready() and bool(subslot.value)
+            if any_have_edges:
+                break
+
+        self.live_update_button.setEnabled(any_have_edges)
 
     def initAppletDrawerUi(self):
         """

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -1,19 +1,18 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGroupBox, QSpacerItem, QSizePolicy, QCheckBox
 
-from ilastik.applets.edgeTraining.edgeTrainingGui import EdgeTrainingGui
+from ilastik.applets.edgeTraining.edgeTrainingGui import EdgeTrainingMixin
 from ilastik.applets.multicut.multicutGui import MulticutGuiMixin
+from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 import ilastik.utility.gui as guiutil
 
 
-class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingGui):
+class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerViewerGui):
     def __init__(self, parentApplet, topLevelOperatorView):
         self.__cleanup_fns = []
-        MulticutGuiMixin.__init__(self, parentApplet, topLevelOperatorView)
-        EdgeTrainingGui.__init__(self, parentApplet, topLevelOperatorView)
+        super().__init__(parentApplet, topLevelOperatorView, crosshair=False)
 
     def _after_init(self):
-        EdgeTrainingGui._after_init(self)
-        MulticutGuiMixin._after_init(self)
+        super()._after_init()
 
     def initAppletDrawerUi(self):
 
@@ -23,7 +22,7 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingGui):
             checked=False,
         )
 
-        training_controls = EdgeTrainingGui.createDrawerControls(self)
+        training_controls = EdgeTrainingMixin.createDrawerControls(self)
         training_controls.layout().setContentsMargins(5, 0, 5, 0)
         training_layout = QVBoxLayout()
         training_layout.addWidget(training_controls)
@@ -76,12 +75,11 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingGui):
             fn()
 
         # Base classes
-        EdgeTrainingGui.stopAndCleanUp(self)
-        MulticutGuiMixin.stopAndCleanUp(self)
+        super().stopAndCleanUp()
 
     def setupLayers(self):
         layers = []
-        edgeTrainingLayers = EdgeTrainingGui.setupLayers(self)
+        edgeTrainingLayers = EdgeTrainingMixin.setupLayers(self)
 
         mc_disagreement_layer = MulticutGuiMixin.create_multicut_disagreement_layer(self)
         if mc_disagreement_layer:
@@ -99,12 +97,12 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingGui):
         return layers
 
     def configure_gui_from_operator(self, *args):
-        EdgeTrainingGui.configure_gui_from_operator(self)
+        EdgeTrainingMixin.configure_gui_from_operator(self)
         MulticutGuiMixin.configure_gui_from_operator(self)
         self.train_edge_clf_box.setChecked(self.topLevelOperatorView.TrainRandomForest.value)
 
     def configure_operator_from_gui(self):
-        EdgeTrainingGui.configure_operator_from_gui(self)
+        EdgeTrainingMixin.configure_operator_from_gui(self)
         MulticutGuiMixin.configure_operator_from_gui(self)
 
     # TODO More elegant way to make multicut compute upon pressing Update button.

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -11,9 +11,6 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         self.__cleanup_fns = []
         super().__init__(parentApplet, topLevelOperatorView, crosshair=False)
 
-    def _after_init(self):
-        super()._after_init()
-
     def initAppletDrawerUi(self):
 
         self.train_edge_clf_box = QCheckBox(

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 
 # This is a mixin that can be added to any LayerViewerGui subclass
 # See MulticutGui (bottom of this file) for the standalone version.
-class MulticutGuiMixin(object):
+class MulticutGuiMixin:
 
     ###########################################
     ### AppletGuiInterface Concrete Methods ###
@@ -72,12 +72,12 @@ class MulticutGuiMixin(object):
     ###########################################
     ###########################################
 
-    def __init__(self, parentApplet, topLevelOperatorView):
+    def __init__(self, parentApplet, topLevelOperatorView, **kwargs):
         self.__cleanup_fns = []
         self.__topLevelOperatorView = topLevelOperatorView
         self.superpixel_edge_layer = None
         self.disagreement_layer = None
-        super(MulticutGuiMixin, self).__init__(parentApplet, topLevelOperatorView)
+        super(MulticutGuiMixin, self).__init__(parentApplet, topLevelOperatorView, **kwargs)
         self.__init_probability_colortable()
         self.__init_disagreement_label_colortable()
 

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -45,7 +45,7 @@ from volumina.utility import ShortcutManager
 
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
-from ilastik.applets.multicut.opMulticut import OpMulticutAgglomerator, AVAILABLE_SOLVER_NAMES, DEFAULT_SOLVER_NAME
+from ilastik.applets.multicut.opMulticut import AVAILABLE_SOLVER_NAMES, DEFAULT_SOLVER_NAME
 from ilastik.config import cfg as ilastik_config
 
 from lazyflow.request import Request
@@ -71,6 +71,11 @@ class MulticutGuiMixin:
 
     ###########################################
     ###########################################
+
+    def __init_subclass__(cls, **kwargs):
+        """Make sure Mixin can only be used with LayerViewerGui"""
+        assert issubclass(cls, LayerViewerGui), "Mixin should only be used with LayerViewerGui"
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, parentApplet, topLevelOperatorView, **kwargs):
         self.__cleanup_fns = []

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -81,9 +81,6 @@ class MulticutGuiMixin:
         self.__init_probability_colortable()
         self.__init_disagreement_label_colortable()
 
-    def _after_init(self):
-        pass
-
     def createDrawerControls(self):
         """
         This is a separate function from initAppletDrawer() so that it can be


### PR DESCRIPTION
Reorganized the code a bit after finding a good old `RuntimeError: wrapped C/C++ object of type QPushButton has been deleted` error when _closing_ the multicut workflow at the training stage.

Made inheritance from `LabelViewerGui` explicit by converting `EdgeTrainingGui` to a Mixin. Also removed some of the explicit `ParentClass.method` calls and let this be handled with `super`.