### PR TITLE
enable batch processing applet in tracking with learning

### DIFF
--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -189,6 +189,7 @@ class StructuredTrackingWorkflowBase(Workflow):
         self._applets.append(self.annotationsApplet)
         self._applets.append(self.trackingApplet)
         self._applets.append(self.dataExportTrackingApplet)
+        self._applets.append(self.batchProcessingApplet)
 
         if self.divisionDetectionApplet:
             opDivDetection = self.divisionDetectionApplet.topLevelOperator


### PR DESCRIPTION
I guess the only person that can tell why it wasn't there would be @akreshuk. Is there a reason batch was hidden here? I rummaged a bit in history but couldn't find an explanation. Was this just an oversight?