### PR TITLE
Make sure to use int datatype for potentially large volumes

### DIFF
--- a/bin/export_from_tiled_volume.py
+++ b/bin/export_from_tiled_volume.py
@@ -3,6 +3,7 @@ import numpy
 import h5py
 from lazyflow.utility import Timer
 from lazyflow.utility.io_util import TiledVolume
+from lazyflow.utility.helpers import bigintprod
 
 import logging
 
@@ -50,7 +51,7 @@ def export_from_tiled_volume(tiles_description_json_path, roi, output_hdf5_path,
                 output_axes = tiled_volume.description.output_axes
                 dset.attrs["axistags"] = vigra.defaultAxistags(output_axes).toJSON()
 
-        logger.info("Exported {:.1e} pixels in {:.1f} seconds.".format(numpy.prod(shape), timer.seconds()))
+        logger.info("Exported {:.1e} pixels in {:.1f} seconds.".format(bigintprod(shape), timer.seconds()))
 
 
 # EXAMPLE USAGE:

--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -48,6 +48,7 @@ from lazyflow.operators.opDenseLabelArray import OpDenseLabelArray
 
 from lazyflow.request import Request, RequestPool
 from lazyflow.roi import roiToSlice, sliceToRoi, determineBlockShape
+from lazyflow.utility.helpers import bigintprod
 
 from ilastik.applets.counting.countingOperators import OpTrainCounter, OpPredictCounter, OpLabelPreviewer
 
@@ -99,7 +100,7 @@ class OpVolumeOperator(Operator):
                 # split up requests into blocks
 
                 numBlocks = numpy.ceil(shape / fullBlockShape).astype("int")
-                blockCache = numpy.ndarray(shape=numpy.prod(numBlocks), dtype=self.Output.meta.dtype)
+                blockCache = numpy.ndarray(shape=bigintprod(numBlocks), dtype=self.Output.meta.dtype)
                 pool = RequestPool()
                 # blocks holds the different roi keys for each of the blocks
                 blocks = itertools.product(*[list(range(i)) for i in numBlocks])

--- a/ilastik/clusterOps.py
+++ b/ilastik/clusterOps.py
@@ -36,6 +36,8 @@ from lazyflow.utility import BigRequestStreamer
 from lazyflow.utility.io_util.blockwiseFileset import BlockwiseFileset
 from lazyflow.utility.timer import Timer
 from lazyflow.utility.pathHelpers import getPathVariants
+from lazyflow.utility.helpers import bigintprod
+
 
 from ilastik.clusterConfig import parseClusterConfigFile
 from ilastik.workflow import Workflow
@@ -162,7 +164,7 @@ class OpClusterize(Operator):
 
     def execute(self, slot, subindex, roi, result):
         dtypeBytes = self._getDtypeBytes()
-        totalBytes = dtypeBytes * numpy.prod(self.Input.meta.shape)
+        totalBytes = dtypeBytes * bigintprod(self.Input.meta.shape)
         totalMB = old_div(totalBytes, (1000 * 1000))
         logger.info(
             "Clusterizing computation of {} MB dataset, outputting according to {}".format(

--- a/ilastik/workflows/voxelSegmentation/classifierOperators.py
+++ b/ilastik/workflows/voxelSegmentation/classifierOperators.py
@@ -45,6 +45,7 @@ from lazyflow.classifiers import (
 
 
 from lazyflow.operators.opFeatureMatrixCache import OpFeatureMatrixCache
+from lazyflow.utility.helpers import bigintprod
 from .utils import slic_to_mask
 
 
@@ -409,7 +410,7 @@ class OpSupervoxelwiseClassifierPredict(Operator):
         input_data = numpy.asarray(input_data, numpy.float32)
 
         shape = input_data.shape
-        prod = numpy.prod(shape[:-1])
+        prod = bigintprod(shape[:-1])
         features = input_data.reshape((prod, shape[-1]))
         features = self.SupervoxelFeatures.value
         # print("features before prediction {}".format(features))

--- a/ilastik/workflows/voxelSegmentation/opSlic.py
+++ b/ilastik/workflows/voxelSegmentation/opSlic.py
@@ -15,6 +15,7 @@ import skimage.segmentation
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.operators import OpBlockedArrayCache, OpReorderAxes
 from lazyflow.roi import roiToSlice
+from lazyflow.utility.helpers import bigintprod
 
 
 import vigra
@@ -60,7 +61,7 @@ class OpSlic(Operator):
 
         if n_segments == 0:
             # If the number of supervoxels was not given, use a default proportional to the number of voxels
-            n_segments = numpy.int(numpy.prod(input_data.shape) / 2500)
+            n_segments = numpy.int(bigintprod(input_data.shape) / 2500)
 
         logger.debug(
             "calling skimage.segmentation.slic with {}".format(

--- a/lazyflow/classifiers/vigraRfAdaptiveMaskPixelwiseClassifier.py
+++ b/lazyflow/classifiers/vigraRfAdaptiveMaskPixelwiseClassifier.py
@@ -15,6 +15,7 @@ import h5py
 
 from .lazyflowClassifier import LazyflowPixelwiseClassifierABC, LazyflowPixelwiseClassifierFactoryABC
 from lazyflow.utility import Timer
+from lazyflow.utility.helpers import bigintprod
 
 import logging
 
@@ -111,18 +112,18 @@ class VigraRfAdaptiveMaskPixelwiseClassifier(LazyflowPixelwiseClassifierABC):
 
         # Allocate memory for probability volume and mask
         prob_vol = numpy.zeros((X.shape[:-1] + (len(self._known_labels),)), dtype=numpy.float32)
-        mask = numpy.ones(numpy.prod(X.shape[1:-1]), dtype=numpy.bool)
+        mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=numpy.bool)
 
         frm_cnt = 0
 
         for X_t in X:
             if frm_cnt % FRAME_SPAN == 0:
-                mask = numpy.ones(numpy.prod(X.shape[1:-1]), dtype=numpy.bool)
+                mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=numpy.bool)
 
-            prob_mat = numpy.zeros((numpy.prod(X.shape[1:-1]), len(self._known_labels)), dtype=numpy.float32)
+            prob_mat = numpy.zeros((bigintprod(X.shape[1:-1]), len(self._known_labels)), dtype=numpy.float32)
 
             # Reshape the image into a 2D feature matrix
-            mat_shape = (numpy.prod(X_t.shape[:-1]), X_t.shape[-1])
+            mat_shape = (bigintprod(X_t.shape[:-1]), X_t.shape[-1])
             feature_mat = numpy.reshape(X_t, mat_shape)
 
             # Mask the feature matrix
@@ -149,7 +150,7 @@ class VigraRfAdaptiveMaskPixelwiseClassifier(LazyflowPixelwiseClassifierABC):
 
                 logger.debug("[PROF] Morphology took {} ".format(morpho_timer.seconds()))
 
-                mask = prob_slice_dilated.reshape(numpy.prod(prob_slice_dilated.shape))
+                mask = prob_slice_dilated.reshape(bigintprod(prob_slice_dilated.shape))
 
                 # vigra.impex.writeHDF5(prob_slice_dilated, 'mask.h5', 'data')
 

--- a/lazyflow/classifiers/vigraRfPixelwiseClassifier.py
+++ b/lazyflow/classifiers/vigraRfPixelwiseClassifier.py
@@ -14,6 +14,7 @@ import vigra
 import h5py
 
 from .lazyflowClassifier import LazyflowPixelwiseClassifierABC, LazyflowPixelwiseClassifierFactoryABC
+from lazyflow.utility.helpers import bigintprod
 
 import logging
 
@@ -117,7 +118,7 @@ class VigraRfPixelwiseClassifier(LazyflowPixelwiseClassifierABC):
         X = X[roi_to_slice(*roi)]
 
         # reshape the image into a 2D feature matrix
-        matrix_shape = (numpy.prod(X.shape[:-1]), X.shape[-1])
+        matrix_shape = (bigintprod(X.shape[:-1]), X.shape[-1])
         feature_matrix = numpy.reshape(X, matrix_shape)
 
         # Run classifier

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -42,6 +42,8 @@ from lazyflow.classifiers import (
     LazyflowPixelwiseClassifierFactoryABC,
 )
 
+from lazyflow.utility.helpers import bigintprod
+
 from .opFeatureMatrixCache import OpFeatureMatrixCache
 from .opConcatenateFeatureMatrices import OpConcatenateFeatureMatrices
 
@@ -594,7 +596,7 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
 
         input_data = numpy.asarray(input_data, numpy.float32)
         shape = input_data.shape
-        prod = numpy.prod(shape[:-1])
+        prod = bigintprod(shape[:-1])
         features = input_data.reshape((prod, shape[-1]))
 
         with Timer() as prediction_timer:

--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -41,6 +41,7 @@ import vigra
 from lazyflow.graph import OrderedSignal, Operator, OutputSlot, InputSlot
 from lazyflow.roi import roiToSlice, roiFromShape, determineBlockShape
 from lazyflow.utility.bigRequestStreamer import BigRequestStreamer
+from lazyflow.utility.helpers import bigintprod
 
 
 class OpImageReader(Operator):
@@ -328,7 +329,7 @@ class OpStackWriter(Operator):
         # If ram usage info is available, make a better guess about how many requests we can launch in parallel
         ram_usage_per_requested_pixel = self.Input.meta.ram_usage_per_requested_pixel
         if ram_usage_per_requested_pixel is not None:
-            pixels_per_slice = numpy.prod(slice_shape)
+            pixels_per_slice = bigintprod(slice_shape)
             if "c" in tagged_sliceshape:
                 pixels_per_slice //= tagged_sliceshape["c"]
 

--- a/lazyflow/operators/ioOperators/opDvidVolume.py
+++ b/lazyflow/operators/ioOperators/opDvidVolume.py
@@ -35,6 +35,7 @@ import numpy
 import vigra
 from lazyflow.graph import Operator, OutputSlot
 from lazyflow.roi import determineBlockShape
+from lazyflow.utility.helpers import bigintprod
 
 from libdvid import DVIDException, ErrMsg
 from libdvid.voxels import VoxelsAccessor
@@ -129,7 +130,7 @@ class OpDvidVolume(Operator):
         self.Output.meta.ram_usage_per_requested_pixel = 2 * dtype.type().nbytes * num_channels
 
     def execute(self, slot, subindex, roi, result):
-        if numpy.prod(roi.stop - roi.start) > 1e9:
+        if bigintprod(roi.stop - roi.start) > 1e9:
             logger.error(
                 "Requesting a very large volume from DVID: {}\nIs that really what you meant to do?".format(roi)
             )
@@ -139,7 +140,7 @@ class OpDvidVolume(Operator):
         # FIXME: Disabled throttling for now.  Need a better heuristic or explicit setting.
         #         # For "heavy" requests, we'll use the throttled accessor
         #         HEAVY_REQ_SIZE = 256*256*10
-        #         if numpy.prod(result.shape) > HEAVY_REQ_SIZE:
+        #         if bigintprod(result.shape) > HEAVY_REQ_SIZE:
         #             accessor = self._throttled_accessor
         #         else:
         #             accessor = self._default_accessor

--- a/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
+++ b/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
@@ -28,6 +28,7 @@ from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
 from lazyflow.operators.opBlockedArrayCache import OpBlockedArrayCache
 import lazyflow.roi
+from lazyflow.utility.helpers import bigintprod
 import logging
 
 import numpy
@@ -103,7 +104,7 @@ class OpRESTfulPrecomputedChunkedVolumeReaderNoCache(Operator):
         """
         blocks = lazyflow.roi.getIntersectingBlocks(blockshape, roi, asarray=True)
 
-        num_indexes = numpy.prod(blocks.shape[0:-1])
+        num_indexes = bigintprod(blocks.shape[0:-1])
         axiscount = blocks.shape[-1]
         blocks_array = numpy.reshape(blocks, (num_indexes, axiscount))
 

--- a/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.utility import Timer
-from lazyflow.utility.helpers import get_default_axisordering
+from lazyflow.utility.helpers import get_default_axisordering, bigintprod
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class OpStreamingH5N5Reader(Operator):
         if "display_mode" in self._h5N5File[internalPath].attrs:
             self.OutputImage.meta.display_mode = str(self._h5N5File[internalPath].attrs["display_mode"])
 
-        total_volume = numpy.prod(numpy.array(self._h5N5File[internalPath].shape))
+        total_volume = bigintprod(self._h5N5File[internalPath].shape)
         chunks = self._h5N5File[internalPath].chunks
         if not chunks and total_volume > 1e8:
             self.OutputImage.meta.inefficient_format = True

--- a/lazyflow/operators/opCompressedCache.py
+++ b/lazyflow/operators/opCompressedCache.py
@@ -42,6 +42,7 @@ from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.roi import TinyVector, getIntersectingBlocks, getBlockBounds, roiToSlice, getIntersection
 from lazyflow.operators.opCache import ManagedBlockedCache
 from lazyflow.utility.chunkHelpers import chooseChunkShape
+from lazyflow.utility.helpers import bigintprod
 
 logger = logging.getLogger(__name__)
 
@@ -320,7 +321,7 @@ class OpUnmanagedCompressedCache(Operator):
 
         desiredSpace = 1024 ** 2 / float(dtypeBytes)
 
-        if numpy.prod(blockshape) <= desiredSpace:
+        if bigintprod(blockshape) <= desiredSpace:
             return blockshape
 
         # set t and c to 1
@@ -446,7 +447,7 @@ class OpUnmanagedCompressedCache(Operator):
                         block_file["fill_value"][...] = data.fill_value
 
                     if logger.isEnabledFor(logging.DEBUG):
-                        uncompressed_size = numpy.prod(data.shape) * self._getDtypeBytes(data.dtype)
+                        uncompressed_size = bigintprod(data.shape) * self._getDtypeBytes(data.dtype)
                         storage_size = block_file["data"].id.get_storage_size()
                         if "mask" in block_file:
                             storage_size += block_file["mask"].id.get_storage_size()

--- a/lazyflow/operators/opFilterLabels.py
+++ b/lazyflow/operators/opFilterLabels.py
@@ -24,6 +24,7 @@ from lazyflow.graph import Operator, InputSlot, OutputSlot
 import numpy
 import logging
 from lazyflow.utility import vigra_bincount
+from lazyflow.utility.helpers import bigintprod
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,7 @@ def remove_wrongly_sized_connected_components(a, min_size, max_size=None, in_pla
 
     if not in_place:
         a = a.copy()
-    if min_size == 0 and (max_size is None or max_size > numpy.prod(a.shape)):  # shortcut for efficiency
+    if min_size == 0 and (max_size is None or max_size > bigintprod(a.shape)):  # shortcut for efficiency
         if bin_out:
             numpy.place(a, a, 1)
         return a

--- a/lazyflow/roi.py
+++ b/lazyflow/roi.py
@@ -29,6 +29,8 @@ from typing import Sequence, Tuple, Union
 
 import numpy
 
+from lazyflow.utility.helpers import bigintprod
+
 import logging
 
 
@@ -638,7 +640,7 @@ def getIntersectingBlocks(blockshape, roi, asarray=False):
         return block_indices
     else:
         # Reshape into N*M matrix for easy iteration
-        num_indexes = numpy.prod(block_indices.shape[0:-1])
+        num_indexes = bigintprod(block_indices.shape[0:-1])
         axiscount = block_indices.shape[-1]
         return numpy.reshape(block_indices, (num_indexes, axiscount))
 
@@ -762,7 +764,7 @@ def determine_optimal_request_blockshape(
     atomic_blockshape = determineBlockShape(clipped_ideal_blockshape, target_block_volume_pixels)
     atomic_blockshape = numpy.asarray(atomic_blockshape)
 
-    if numpy.prod(clipped_ideal_blockshape) >= target_block_volume_pixels:
+    if bigintprod(clipped_ideal_blockshape) >= target_block_volume_pixels:
         # Target volume is too small for us to stack the atomic blockshape, anyway
         return tuple(atomic_blockshape)
 
@@ -780,7 +782,7 @@ def determine_optimal_request_blockshape(
             candidate_blockshape = blockshape.copy()
             candidate_blockshape[index] += clipped_ideal_blockshape[index]
             if (candidate_blockshape <= max_blockshape).all() and (
-                numpy.prod(candidate_blockshape) < target_block_volume_pixels
+                bigintprod(candidate_blockshape) < target_block_volume_pixels
             ):
                 candidate_blockshapes.append(candidate_blockshape)
 
@@ -790,7 +792,7 @@ def determine_optimal_request_blockshape(
         def normalized_surface_area(shape):
             pairs = numpy.array(list(combinations(shape, 2)))
             surface_area = 2 * (pairs[:, 0] * pairs[:, 1]).sum()
-            volume = numpy.prod(shape)
+            volume = bigintprod(shape)
             return surface_area / volume
 
         # Choose the best among the canidates

--- a/lazyflow/utility/bigRequestStreamer.py
+++ b/lazyflow/utility/bigRequestStreamer.py
@@ -27,6 +27,7 @@ from builtins import object
 import numpy
 from lazyflow.request import Request
 from lazyflow.utility import RoiRequestBatch
+from lazyflow.utility.helpers import bigintprod
 from lazyflow.roi import (
     getIntersectingBlocks,
     getBlockBounds,
@@ -111,7 +112,7 @@ class BigRequestStreamer(object):
         self._bigRoi = roi
         self._num_threads = max(1, Request.global_thread_pool.num_workers)
 
-        totalVolume = numpy.prod(numpy.subtract(roi[1], roi[0]))
+        totalVolume = bigintprod(numpy.subtract(roi[1], roi[0]))
 
         if batchSize is None:
             batchSize = self._num_threads
@@ -248,7 +249,7 @@ class BigRequestStreamer(object):
                 max_blockshape, ideal_blockshape, ram_usage_per_requested_pixel, self._num_threads, available_ram
             )
         # compute the RAM size of the block before adding back t anc c dimensions
-        fmt = Memory.format(ram_usage_per_requested_pixel * numpy.prod(blockshape))
+        fmt = Memory.format(ram_usage_per_requested_pixel * bigintprod(blockshape))
         # If we removed time and channel from consideration, add them back now before returning
         if "t" in outputSlot.meta.getAxisKeys():
             blockshape = blockshape[:time_index] + (blockshape_time_steps,) + blockshape[time_index:]

--- a/lazyflow/utility/helpers.py
+++ b/lazyflow/utility/helpers.py
@@ -20,7 +20,10 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 
-from typing import Tuple
+from functools import reduce
+from operator import mul
+from typing import Tuple, Iterable
+import numbers
 
 
 def itersubclasses(cls, _seen=None):
@@ -115,3 +118,12 @@ def get_default_axisordering(shape: Tuple[int, ...]) -> str:
         return axisorders[ndim]
     except KeyError:
         raise ValueError(f"cannot infer axis order for {ndim}-dimensional shape")
+
+
+def bigintprod(nums: Iterable[numbers.Integral]) -> int:
+    """Safe way to get the product of an iterable of integer numbers
+
+    avoids defaulting to C long (like numpy), which can result in overflows for
+    array shapes seen in practice on some operating systems (windows: long -> 32 bit).
+    """
+    return reduce(mul, map(int, nums))

--- a/lazyflow/utility/io_util/multiprocessHdf5File.py
+++ b/lazyflow/utility/io_util/multiprocessHdf5File.py
@@ -13,6 +13,8 @@ import warnings
 import multiprocessing
 import numpy
 
+from lazyflow.utility.helpers import bigintprod
+
 # This code uses multiprocessing to read hdf5 datasets faster
 # I'm still experimenting with implementation details,
 #  and switching between implementation variants via the METHOD setting below.
@@ -66,7 +68,7 @@ class ReaderProcess(multiprocessing.Process):
                         read_roi = slice_to_roi(slicing, h5_file[internal_path].shape)
                         read_roi = numpy.array(read_roi)
                         read_shape = read_roi[1] - read_roi[0]
-                        num_bytes = h5_file[internal_path].dtype.itemsize * numpy.prod(read_shape)
+                        num_bytes = h5_file[internal_path].dtype.itemsize * bigintprod(read_shape)
                         assert num_bytes <= self.available_bytes, "I don't yet support really big slicings"
                         read_array = numpy.frombuffer(self.transfer_buffer, dtype=numpy.uint8, count=num_bytes)
                         read_array.setflags(write=True)
@@ -107,7 +109,7 @@ class ReaderProcess(multiprocessing.Process):
             result.setflags(write=True)
 
         if METHOD == "shared-array":
-            result = numpy.frombuffer(self.transfer_buffer, dtype=dtype, count=numpy.prod(shape)).copy()
+            result = numpy.frombuffer(self.transfer_buffer, dtype=dtype, count=bigintprod(shape)).copy()
             result = result.reshape(shape)
         return result
 

--- a/lazyflow/utility/roiRequestBatch.py
+++ b/lazyflow/utility/roiRequestBatch.py
@@ -31,6 +31,7 @@ import numpy
 
 import lazyflow.stype
 from lazyflow.utility import OrderedSignal
+from lazyflow.utility.helpers import bigintprod
 from lazyflow.request import Request, SimpleRequestCondition, log_exception
 
 
@@ -246,7 +247,7 @@ class RoiRequestBatch(object):
 
                 # Report progress (if possible)
                 if self._totalVolume is not None:
-                    self._processedVolume += numpy.prod(numpy.subtract(roi[1], roi[0]))
+                    self._processedVolume += bigintprod(numpy.subtract(roi[1], roi[0]))
                     progress = 100 * self._processedVolume // self._totalVolume
                     self.progressSignal(progress)
 

--- a/lazyflow/utility/roiRequestBatch.py
+++ b/lazyflow/utility/roiRequestBatch.py
@@ -130,9 +130,6 @@ class RoiRequestBatch(object):
 
         # Progress bookkeeping
         self._totalVolume = totalVolume
-        if self._totalVolume is not None:
-            # Windows default long is int32; this can result in overflows in calculations
-            self._totalVolume = int(self._totalVolume)
         self._processedVolume = 0
 
     @property
@@ -250,7 +247,7 @@ class RoiRequestBatch(object):
                 # Report progress (if possible)
                 if self._totalVolume is not None:
                     self._processedVolume += numpy.prod(numpy.subtract(roi[1], roi[0]))
-                    progress = int(100 * (self._processedVolume / self._totalVolume))
+                    progress = 100 * self._processedVolume // self._totalVolume
                     self.progressSignal(progress)
 
                 logger.debug("Request completed for roi: {}".format(roi))

--- a/lazyflow/utility/roiRequestBatch.py
+++ b/lazyflow/utility/roiRequestBatch.py
@@ -130,6 +130,9 @@ class RoiRequestBatch(object):
 
         # Progress bookkeeping
         self._totalVolume = totalVolume
+        if self._totalVolume is not None:
+            # Windows default long is int32; this can result in overflows in calculations
+            self._totalVolume = int(self._totalVolume)
         self._processedVolume = 0
 
     @property
@@ -247,7 +250,7 @@ class RoiRequestBatch(object):
                 # Report progress (if possible)
                 if self._totalVolume is not None:
                     self._processedVolume += numpy.prod(numpy.subtract(roi[1], roi[0]))
-                    progress = 100 * self._processedVolume // self._totalVolume
+                    progress = int(100 * (self._processedVolume / self._totalVolume))
                     self.progressSignal(progress)
 
                 logger.debug("Request completed for roi: {}".format(roi))

--- a/lazyflow/utility/roiRequestBuffer.py
+++ b/lazyflow/utility/roiRequestBuffer.py
@@ -5,6 +5,7 @@ import numpy
 
 from lazyflow.graph import Slot
 from lazyflow.utility.roiRequestBatch import RoiRequestBatch
+from lazyflow.utility.helpers import bigintprod
 
 
 ROI = Tuple[int, int, int, int, int]
@@ -33,7 +34,7 @@ class _RoiIter:
         return numpy.ravel_multi_index(relevant_indices, self._iterate_shape)
 
     def __len__(self) -> int:
-        return numpy.prod(self._iterate_shape)
+        return bigintprod(self._iterate_shape)
 
     def __iter__(self) -> Iterator[ROI_TUPLE]:
         """iterate in ascending order, according to to_index"""
@@ -71,7 +72,7 @@ class RoiRequestBufferIter:
         self._roi_request_batch = RoiRequestBatch(
             outputSlot=self._slot,
             roiIterator=iter(self._roi_iter),
-            totalVolume=numpy.prod(self._slot.meta.shape),
+            totalVolume=bigintprod(self._slot.meta.shape),
             batchSize=self._batchsize,
             allowParallelResults=False,
         )

--- a/tests/test_lazyflow/test_utility/test_helpers.py
+++ b/tests/test_lazyflow/test_utility/test_helpers.py
@@ -1,0 +1,16 @@
+import pytest
+
+import numpy
+
+from lazyflow.utility.helpers import bigintprod
+
+
+@pytest.mark.parametrize(
+    "nums,result",
+    [
+        ((10, 10, 10), 1000),
+        ((numpy.power(2, 16), numpy.power(2, 16), 2), 2 ** 33),  # would fail with numpy.prod already on windows
+    ],
+)
+def test_bigintprod(nums, result):
+    assert bigintprod(nums) == result


### PR DESCRIPTION
In `numpy` default `int` type is `long`. [On windows, default `long` is 32 bits](https://numpy.org/devdocs/reference/arrays.scalars.html#integer-types).

added a tiny helper function that should be used when reducing shapes to their volume in order not to fall into this issue

ref: [user report on image.sc](https://forum.image.sc/t/overflow-warning-in-ilastik/48790?u=k-dominik)