### PR TITLE
expoerimental/API added roi parameter to pixel classification pipeline

### DIFF
--- a/ilastik/experimental/api/__init__.py
+++ b/ilastik/experimental/api/__init__.py
@@ -1,2 +1,2 @@
-from ._base import from_project_file
+from ._base import from_project_file, xarray_roi_to_slicing
 from .types import Pipeline


### PR DESCRIPTION
In order to be more useful for larger data, this PR adds a `roi` parameter to the `predict` method of the pixel classification api.
Right now I went for `xarray` dict-like specification, which looks very sensible.

Example:

```python
import h5py
import xarray
from ilastik.experimental.api import from_project_file

pipeline = from_project_file("my_pretrained_project.ilp")
f = h5py.File("my-big-image.h5", "r")
ds = xarray(f["data"], dims="zyx")
block_prediction = pipeline.predict(ds, {"x": slice(0, 100), "y": slice(0, 200)}  # all "z"
```