### PR TITLE
Make sure ilastik errors when trying to access missing data in headless

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -48,7 +48,7 @@ from ilastik.workflow import Workflow
 from lazyflow.utility.pathHelpers import splitPath, globH5N5, globNpz, PathComponents
 from lazyflow.utility.helpers import get_default_axisordering
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-from lazyflow.operators import OpRaisingSource
+from lazyflow.operators import OpMissingDataSource
 from lazyflow.operators.ioOperators import OpH5N5WriterBigDataset
 from lazyflow.graph import Graph, Operator
 
@@ -459,7 +459,7 @@ class DummyDatasetInfo(DatasetInfo):
     def get_non_transposed_provider_slot(
         self, parent: Optional[Operator] = None, graph: Optional[Graph] = None
     ) -> OutputSlot:
-        opZero = OpRaisingSource(
+        opZero = OpMissingDataSource(
             shape=self.laneShape, dtype=self.laneDtype, axistags=self.axistags, parent=parent, graph=graph
         )
         return opZero.Output

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -48,7 +48,7 @@ from ilastik.workflow import Workflow
 from lazyflow.utility.pathHelpers import splitPath, globH5N5, globNpz, PathComponents
 from lazyflow.utility.helpers import get_default_axisordering
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-from lazyflow.operators import OpZeroSource
+from lazyflow.operators import OpRaisingSource
 from lazyflow.operators.ioOperators import OpH5N5WriterBigDataset
 from lazyflow.graph import Graph, Operator
 
@@ -459,7 +459,7 @@ class DummyDatasetInfo(DatasetInfo):
     def get_non_transposed_provider_slot(
         self, parent: Optional[Operator] = None, graph: Optional[Graph] = None
     ) -> OutputSlot:
-        opZero = OpZeroSource(
+        opZero = OpRaisingSource(
             shape=self.laneShape, dtype=self.laneDtype, axistags=self.axistags, parent=parent, graph=graph
         )
         return opZero.Output

--- a/lazyflow/operators/__init__.py
+++ b/lazyflow/operators/__init__.py
@@ -88,5 +88,5 @@ from .valueProviders import (
     OpPrecomputedInput,
     OpValueCache,
     OpZeroDefault,
-    OpZeroSource,
+    OpRaisingSource,
 )

--- a/lazyflow/operators/__init__.py
+++ b/lazyflow/operators/__init__.py
@@ -88,5 +88,5 @@ from .valueProviders import (
     OpPrecomputedInput,
     OpValueCache,
     OpZeroDefault,
-    OpRaisingSource,
+    OpMissingDataSource,
 )

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -500,8 +500,15 @@ class OpZeroDefault(Operator):
             self.Output.setDirty(roi)
 
 
-class OpZeroSource(Operator):
-    """Operator that serves zeros on it's Output
+class MissingDataAccessError(Exception):
+    pass
+
+
+class OpRaisingSource(Operator):
+    """Operator that raises when data is accessed
+
+    Provides valid metadata, but does not allow to get any data.
+    Needed to provide metadata for "missing" datasets in trained projects.
 
     This operator will never set anything dirty as it cannot be changed.
     """
@@ -522,8 +529,10 @@ class OpZeroSource(Operator):
         pass
 
     def execute(self, slot, subindex, roi, result):
-        result[...] = 0
-        return result
+        raise MissingDataAccessError(
+            "Tried to access placeholder dataset. You might not have saved the project with a trained classifier. "
+            "Without access to training data, the classifier cannot be retrained."
+        )
 
     def propagateDirty(self, *args, **kwargs):
         raise ValueError("Will never go here, no inputs...")

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -501,10 +501,15 @@ class OpZeroDefault(Operator):
 
 
 class MissingDataAccessError(Exception):
-    pass
+    def __init__(self):
+        message = (
+            "Tried to access placeholder dataset. You might not have saved the project with a trained classifier. "
+            "Without access to training data, the classifier cannot be retrained."
+        )
+        super().__init__(message)
 
 
-class OpRaisingSource(Operator):
+class OpMissingDataSource(Operator):
     """Operator that raises when data is accessed
 
     Provides valid metadata, but does not allow to get any data.
@@ -529,10 +534,7 @@ class OpRaisingSource(Operator):
         pass
 
     def execute(self, slot, subindex, roi, result):
-        raise MissingDataAccessError(
-            "Tried to access placeholder dataset. You might not have saved the project with a trained classifier. "
-            "Without access to training data, the classifier cannot be retrained."
-        )
+        raise MissingDataAccessError
 
     def propagateDirty(self, *args, **kwargs):
         raise ValueError("Will never go here, no inputs...")

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -306,7 +306,7 @@ class TestOpZeroDefault:
         {"shape": (10, 20, 30, 1, 2), "dtype": numpy.float32, "something_else": "blah", "one_more": 42},
     ],
 )
-def test_OpRaisingSource(graph, metadata):
+def test_OpMissingDataSource(graph, metadata):
     shape = metadata.pop("shape")
     dtype = metadata.pop("dtype")
 

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -33,7 +33,7 @@ from lazyflow.operators.valueProviders import (
     OpValueCache,
     OpMetadataMerge,
     OpZeroDefault,
-    OpRaisingSource,
+    OpMissingDataSource,
     MissingDataAccessError,
 )
 import pytest
@@ -310,7 +310,7 @@ def test_OpRaisingSource(graph, metadata):
     shape = metadata.pop("shape")
     dtype = metadata.pop("dtype")
 
-    op = OpRaisingSource(shape=shape, dtype=dtype, graph=graph, **metadata)
+    op = OpMissingDataSource(shape=shape, dtype=dtype, graph=graph, **metadata)
     assert op.Output.ready()
     assert op.Output.meta.dtype == dtype
     assert op.Output.meta.shape == shape


### PR DESCRIPTION
When running ilastik in headless, we do not require training data to be present. However, ilastik will try to train its classifier, if it has not been saved to the project file. This can lead to training from all zeros when data is inaccessible.
This is of course not acceptable.

fixes https://github.com/ilastik/ilastik/issues/2299