### PR TITLE
Write source data attributes to output files [h5]

### DIFF
--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -634,6 +634,10 @@ class OpH5N5WriterBigDataset(Operator):
         if self.Image.meta.display_mode is not None:
             self.d.attrs["display_mode"] = self.Image.meta.display_mode
 
+        source_metadata = self.Image.meta.dataset_attrs or {}
+        for k, v in source_metadata.items():
+            self.d.attrs[f"source_data_{k}"] = v
+
     def execute(self, slot, subindex, rroi, result):
         self.progressSignal(0)
 

--- a/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
@@ -119,6 +119,11 @@ class OpStreamingH5N5Reader(Operator):
         if chunks:
             self.OutputImage.meta.ideal_blockshape = chunks
 
+        dataset_attrs = dict(dataset.attrs)
+        dataset_attrs["file_name"] = self._h5N5File.filename
+        dataset_attrs["internal_path"] = internalPath
+        self.OutputImage.meta.dataset_attrs = dataset_attrs
+
     def execute(self, slot, subindex, roi, result):
         t = time.time()
         assert self._h5N5File is not None


### PR DESCRIPTION
I am sure I have previously done this already.

h5-reader will populate metadata.dataset_attrs from h5/n5 file attrs
h5-writer will add attrs by prepending attribute keys with "source_data_"
_edit_: now thinking about it, prepending to the key might look ugly at some point (say already working on a dataset that has already been processed before...)

Maybe I should add a base reader class to make it more obvious to add this property.