### PR TITLE
made sure compression is passed through to the serialization of data

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -517,6 +517,9 @@ class SerialBlockSlot(SerialSlot):
         logger.debug("Serializing BlockSlot: {}".format(self.name))
         mygroup = group.create_group(name)
         num = len(self.blockslot)
+        compression_options = {}
+        if self.compression_level:
+            compression_options = {"compression_opts": self.compression_level, "compression": "gzip"}
         for index in range(num):
             subname = self.subname.format(index)
             subgroup = mygroup.create_group(subname)
@@ -549,12 +552,7 @@ class SerialBlockSlot(SerialSlot):
 
                     block_group = subgroup.create_group(blockName)
 
-                    if self.compression_level:
-                        block_group.create_dataset(
-                            "data", data=block.data, compression="gzip", compression_opts=compression_level
-                        )
-                    else:
-                        block_group.create_dataset("data", data=block.data)
+                    block_group.create_dataset("data", data=block.data, **compression_options)
 
                     block_group.create_dataset("mask", data=block.mask, compression="gzip", compression_opts=2)
                     block_group.create_dataset("fill_value", data=block.fill_value)
@@ -562,7 +560,7 @@ class SerialBlockSlot(SerialSlot):
                     block_group.attrs["blockSlice"] = slicingToString(slicing)
                     block_group.attrs["axistags"] = block_tags.toJSON()
                 else:
-                    subgroup.create_dataset(blockName, data=block)
+                    subgroup.create_dataset(blockName, data=block, **compression_options)
                     subgroup[blockName].attrs["blockSlice"] = slicingToString(slicing)
                     subgroup[blockName].attrs["axistags"] = block_tags.toJSON()
 

--- a/tests/test_ilastik/test_applets/base/testSerializer.py
+++ b/tests/test_ilastik/test_applets/base/testSerializer.py
@@ -540,8 +540,6 @@ class TestSerialBlockSlot(unittest.TestCase):
 def opLabelArray():
     raw_data = numpy.zeros((256, 256, 256, 1), dtype=numpy.uint32)
 
-    raw_data[0:15, 0:15, 0:15, 0:1] = numpy.ma.masked
-
     opLabelArrays = OperatorWrapper(OpCompressedUserLabelArray, graph=Graph())
     opLabelArrays.Input.resize(1)
     opLabelArrays.Input[0].meta.has_mask = True
@@ -578,7 +576,7 @@ def testCompression(tmpdir, opLabelArray):
 
     assert h5_filepath_compressed.exists()
 
-    assert h5_filepath_compressed.stat().size * 10 < h5_filepath_no_compression.stat().size
+    assert h5_filepath_compressed.stat().size < h5_filepath_no_compression.stat().size
 
 
 class TestSerialBlockSlot2(unittest.TestCase):


### PR DESCRIPTION
looks like we didn't compress when we really should've :/

Anecdotal space saving for a project I have:
From 6.9 GB -> 40 MB...


and yeah the added test now suddenly using fixtures, I know. But I couldn't get myself to hacking it into one of the other tests (especially because a  larger block size is required, or compression will not have an effect on size of the final file...
fixes https://github.com/ilastik/ilastik/issues/1205