### PR TITLE
Stack selection improvements

### DIFF
--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -395,6 +395,8 @@ class StackFileSelectionWidget(QDialog):
         for f in self.selectedFiles:
             self.fileListWidget.addItem(f)
 
+        self.okButton.setEnabled(bool(files))
+
     def eventFilter(self, watched, event):
         if watched == self.patternEdit:
             return self._filterPatternEditEvent(event)

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -139,11 +139,10 @@ class StackFileSelectionWidget(QDialog):
         self.directoryEdit.setText(directory)
         try:
             globstring = self._getGlobString(directory)
-        except StackFileSelectionWidget.DetermineStackError as e:
-            QMessageBox.warning(self, "Invalid selection", str(e))
-        if globstring:
             self.patternEdit.setText(globstring)
             self._applyPattern()
+        except StackFileSelectionWidget.DetermineStackError as e:
+            QMessageBox.warning(self, "Invalid selection", str(e))
 
     def _getGlobString(self, directory):
         all_filenames = []


### PR DESCRIPTION
Fixes error message of "variable used before assignment" when selecting a bad directory in the Add Stack dialogue. Also disables the Ok button when no files are selected.  