### PR TITLE
Fixes globbing issues

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -571,13 +571,15 @@ class DataSelectionGui(QWidget):
         return previous_info.axistags
 
     def instantiate_dataset_info(self, url: str, role: Union[str, int], *info_args, **info_kwargs) -> DatasetInfo:
-        info = self.parentApplet.create_dataset_info(url=url, *info_args, **info_kwargs)
+        info = self.parentApplet.create_dataset_info(url=url, skip_deglobbing=True, *info_args, **info_kwargs)
         if info_kwargs.get("axistags") is not None:
             return info
         axistags = self.guess_axistags_for(role=role, info=info)
         if axistags in (info.axistags, None):
             return info
-        return self.parentApplet.create_dataset_info(url=url, *info_args, **info_kwargs, axistags=axistags)
+        return self.parentApplet.create_dataset_info(
+            url=url, skip_deglobbing=True, *info_args, **info_kwargs, axistags=axistags
+        )
 
     def _checkDataFormatWarnings(self, roleIndex, startingLaneNum, endingLane):
         warn_needed = False

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -395,6 +395,8 @@ class StackFileSelectionWidget(QDialog):
         for f in self.selectedFiles:
             self.fileListWidget.addItem(f)
 
+        self.okButton.setEnabled(bool(files))
+
     def eventFilter(self, watched, event):
         if watched == self.patternEdit:
             return self._filterPatternEditEvent(event)

--- a/ilastik/widgets/stackFileSelectionWidget.py
+++ b/ilastik/widgets/stackFileSelectionWidget.py
@@ -139,11 +139,10 @@ class StackFileSelectionWidget(QDialog):
         self.directoryEdit.setText(directory)
         try:
             globstring = self._getGlobString(directory)
-        except StackFileSelectionWidget.DetermineStackError as e:
-            QMessageBox.warning(self, "Invalid selection", str(e))
-        if globstring:
             self.patternEdit.setText(globstring)
             self._applyPattern()
+        except StackFileSelectionWidget.DetermineStackError as e:
+            QMessageBox.warning(self, "Invalid selection", str(e))
 
     def _getGlobString(self, directory):
         all_filenames = []

--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -136,6 +136,7 @@ class OpStackLoader(Operator):
     category = "Input"
 
     globstring = InputSlot()
+    SkipDeglobbing = InputSlot(value=False)
     SequenceAxis = InputSlot(optional=True)
     stack = OutputSlot()
 
@@ -146,7 +147,7 @@ class OpStackLoader(Operator):
             super().__init__(self.msg)
 
     def setupOutputs(self):
-        self.fileNameList = self.expandGlobStrings(self.globstring.value)
+        self.fileNameList = self.expandGlobStrings(self.globstring.value, skip_deglobbing=self.SkipDeglobbing.value)
 
         num_files = len(self.fileNameList)
         if len(self.fileNameList) == 0:
@@ -286,12 +287,12 @@ class OpStackLoader(Operator):
         return result
 
     @staticmethod
-    def expandGlobStrings(globStrings):
+    def expandGlobStrings(globStrings, skip_deglobbing: bool = False):
         ret = []
         # Parse list into separate globstrings and combine them
         for globString in globStrings.split(os.path.pathsep):
             s = globString.strip()
-            ret += sorted(glob.glob(s))
+            ret += [globString] if skip_deglobbing else sorted(glob.glob(s))
         return ret
 
 


### PR DESCRIPTION
Currently ilastik will not allow using files whose names can be interpreted as globs. This  PR makes it so that every file added via the GUI is interpreted as-is, and adds the `--skip-deglobbing` command line flag to to the same in headless mode (since our documentation already instructs users to use globbing in headless mode).

TODO:
Add tests