### PR TITLE
Enable multicut with multiple lanes

### DIFF
--- a/ilastik/applets/counting/countingGuiBoxesInterface.py
+++ b/ilastik/applets/counting/countingGuiBoxesInterface.py
@@ -28,7 +28,7 @@ from typing import Iterable, TextIO, Tuple
 
 import numpy as np
 
-from ilastik.utility.gui import roi2rect, silent_widget
+from ilastik.utility.gui import roi2rect, silent_qobject
 from ilastik.widgets.boxListModel import BoxLabel
 from lazyflow.operators.generic import OpSubRegion
 from past.utils import old_div
@@ -816,7 +816,7 @@ class BoxController(QObject):
     def handleSelectionChange(self):
         for row, el in enumerate(self._currentBoxesList):
             if el._rectItem.isSelected():
-                with silent_widget(self.boxListModel) as w:
+                with silent_qobject(self.boxListModel) as w:
                     w.select(row)
                 break
 

--- a/ilastik/applets/counting/countingGuiBoxesInterface.py
+++ b/ilastik/applets/counting/countingGuiBoxesInterface.py
@@ -28,7 +28,7 @@ from typing import Iterable, TextIO, Tuple
 
 import numpy as np
 
-from ilastik.utility.gui import roi2rect
+from ilastik.utility.gui import roi2rect, silent_widget
 from ilastik.widgets.boxListModel import BoxLabel
 from lazyflow.operators.generic import OpSubRegion
 from past.utils import old_div
@@ -816,9 +816,8 @@ class BoxController(QObject):
     def handleSelectionChange(self):
         for row, el in enumerate(self._currentBoxesList):
             if el._rectItem.isSelected():
-                self.boxListModel.blockSignals(True)
-                self.boxListModel.select(row)
-                self.boxListModel.blockSignals(False)
+                with silent_widget(self.boxListModel) as w:
+                    w.select(row)
                 break
 
     def changeBoxesVisibility(self, bool):

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -176,6 +176,7 @@ class EdgeTrainingMixin:
 
         return drawer
 
+    @threadRouted
     def enable_live_update_on_edges_available(self, *args, **kwargs):
         any_have_edges = False
         op = self.topLevelOperatorView
@@ -391,8 +392,11 @@ class EdgeTrainingMixin:
         op = self.topLevelOperatorView
         ActionInfo = ShortcutManager.ActionInfo
 
+        superpixels_ready = op.Superpixels.ready()
+        with_training = op.TrainRandomForest.value
+
         # Superpixels -- Edge Labels
-        if op.Superpixels.ready() and op.EdgeLabelsDict.ready():
+        if superpixels_ready and op.EdgeLabelsDict.ready() and with_training:
             edge_labels = op.EdgeLabelsDict.value
             layer = LabelableSegmentationEdgesLayer(
                 createDataSource(op.Superpixels), self.edge_label_pen_table, edge_labels
@@ -421,7 +425,7 @@ class EdgeTrainingMixin:
             del layer
 
         # Superpixels -- Edge Probabilities
-        if op.Superpixels.ready() and op.EdgeProbabilitiesDict.ready():
+        if superpixels_ready and op.EdgeProbabilitiesDict.ready() and with_training:
             layer = SegmentationEdgesLayer(createDataSource(op.Superpixels))
             layer.name = "Edge Probabilities"  # Name is hard-coded in multiple places: grep before changing.
             layer.visible = False
@@ -446,7 +450,7 @@ class EdgeTrainingMixin:
             del layer
 
         # Superpixels -- Edges
-        if op.Superpixels.ready():
+        if superpixels_ready:
             default_pen = QPen(SegmentationEdgesLayer.DEFAULT_PEN)
             default_pen.setColor(Qt.yellow)
             layer = SegmentationEdgesLayer(createDataSource(op.Superpixels), default_pen)

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -130,9 +130,9 @@ class EdgeTrainingMixin:
             clicked=self._handle_live_update_clicked,
             enabled=False,
         )
-        configure_update_handlers(self.live_update_button.toggled, op.FreezeCache)
 
-        self.train_from_gt_button.clicked.connect(lambda: op.FreezeClassifier.setValue(False))
+        configure_update_handlers(self.live_update_button.toggled, op.FreezeClassifier)
+        configure_update_handlers(self.train_from_gt_button.toggled, op.TrainRandomForest)
 
         cleanup_fn = op.EdgeLabelsDict.notifyDirty(self.enable_live_update_on_edges_available)
         self.__cleanup_fns.append(cleanup_fn)

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -39,7 +39,7 @@ from PyQt5.QtWidgets import (
 
 from ilastikrag.gui import FeatureSelectionDialog
 
-from ilastik.utility.gui import threadRouted, silent_widget
+from ilastik.utility.gui import threadRouted, silent_qobject
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
@@ -355,17 +355,19 @@ class EdgeTrainingMixin:
     def set_updating(self):
         assert not self._currently_updating
         self._currently_updating = True
-        yield
-        self._currently_updating = False
+        try:
+            yield
+        finally:
+            self._currently_updating = False
 
     def configure_gui_from_operator(self, *args):
         if self._currently_updating:
             return False
         with self.set_updating():
             op = self.topLevelOperatorView
-            with silent_widget(self.train_from_gt_button) as w:
+            with silent_qobject(self.train_from_gt_button) as w:
                 w.setEnabled(op.GroundtruthSegmentation.ready())
-            with silent_widget(self.live_update_button) as w:
+            with silent_qobject(self.live_update_button) as w:
                 w.setChecked(not op.FreezeClassifier.value)
             if op.FreezeClassifier.value:
                 self.live_update_button.setIcon(QIcon(ilastikIcons.Play))

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -46,6 +46,7 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         def _handle_train_edge_clf_box_clicked():
             training_box.setEnabled(self.train_edge_clf_box.isChecked())
             op.TrainRandomForest.setValue(self.train_edge_clf_box.isChecked())
+            self.updateAllLayers()
 
         self.train_edge_clf_box.toggled.connect(_handle_train_edge_clf_box_clicked)
 

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -44,8 +44,11 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         self.__cleanup_fns.append(guiutil.enable_when_ready(multicut_box, multicut_required_slots))
 
         def _handle_train_edge_clf_box_clicked():
-            training_box.setEnabled(self.train_edge_clf_box.isChecked())
-            op.TrainRandomForest.setValue(self.train_edge_clf_box.isChecked())
+            checked = self.train_edge_clf_box.isChecked()
+            training_box.setEnabled(checked)
+            op.TrainRandomForest.setValue(checked)
+            if not checked:
+                op.FreezeClassifier.setValue(True)
             self.updateAllLayers()
 
         self.train_edge_clf_box.toggled.connect(_handle_train_edge_clf_box_clicked)

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -60,7 +60,9 @@ class OpEdgeTrainingWithMulticut(Operator):
         self.EdgeProbabilitiesDict.connect(opEdgeTraining.EdgeProbabilitiesDict)
         self.NaiveSegmentation.connect(opEdgeTraining.NaiveSegmentation)
 
-        opMulticut = OpMultiLaneWrapper(OpMulticut, parent=self)
+        opMulticut = OpMultiLaneWrapper(
+            OpMulticut, broadcastingSlotNames=["Beta", "SolverName", "FreezeCache"], parent=self
+        )
         opMulticut.Beta.connect(self.Beta)
         opMulticut.SolverName.connect(self.SolverName)
         opMulticut.FreezeCache.connect(self.FreezeCache)

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
 )
 
-from ilastik.utility.gui import threadRouted
+from ilastik.utility.gui import threadRouted, silent_widget
 from volumina.api import createDataSource
 from volumina.layer import SegmentationEdgesLayer
 from volumina.utility import ShortcutManager
@@ -298,7 +298,8 @@ class MulticutGuiMixin:
         with self.set_updating():
             op = self.__topLevelOperatorView
             self.update_button.setEnabled(op.FreezeCache.value)
-            self.live_multicut_button.setChecked(not op.FreezeCache.value)
+            with silent_widget(self.live_multicut_button) as w:
+                w.setChecked(not op.FreezeCache.value)
             self.probability_threshold_box.setValue(op.ProbabilityThreshold.value)
             if op.FreezeCache.value:
                 self.live_multicut_button.setIcon(QIcon(ilastikIcons.Play))

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -289,8 +289,12 @@ class MulticutGuiMixin:
     def set_updating(self):
         assert not self._currently_updating
         self._currently_updating = True
+        self.live_multicut_button.setEnabled(False)
+        self.update_button.setEnabled(False)
         yield
         self._currently_updating = False
+        self.live_multicut_button.setEnabled(True)
+        self.update_button.setEnabled(True)
 
     def configure_gui_from_operator(self, *args):
         if self._currently_updating:

--- a/ilastik/applets/multicut/multicutGui.py
+++ b/ilastik/applets/multicut/multicutGui.py
@@ -38,7 +38,7 @@ from PyQt5.QtWidgets import (
     QPushButton,
 )
 
-from ilastik.utility.gui import threadRouted, silent_widget
+from ilastik.utility.gui import threadRouted, silent_qobject
 from volumina.api import createDataSource
 from volumina.layer import SegmentationEdgesLayer
 from volumina.utility import ShortcutManager
@@ -291,10 +291,12 @@ class MulticutGuiMixin:
         self._currently_updating = True
         self.live_multicut_button.setEnabled(False)
         self.update_button.setEnabled(False)
-        yield
-        self._currently_updating = False
-        self.live_multicut_button.setEnabled(True)
-        self.update_button.setEnabled(True)
+        try:
+            yield
+        finally:
+            self._currently_updating = False
+            self.live_multicut_button.setEnabled(True)
+            self.update_button.setEnabled(True)
 
     def configure_gui_from_operator(self, *args):
         if self._currently_updating:
@@ -302,7 +304,7 @@ class MulticutGuiMixin:
         with self.set_updating():
             op = self.__topLevelOperatorView
             self.update_button.setEnabled(op.FreezeCache.value)
-            with silent_widget(self.live_multicut_button) as w:
+            with silent_qobject(self.live_multicut_button) as w:
                 w.setChecked(not op.FreezeCache.value)
             self.probability_threshold_box.setValue(op.ProbabilityThreshold.value)
             if op.FreezeCache.value:

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -68,7 +68,7 @@ from lazyflow.operators import OpFeatureMatrixCache
 # ilastik
 from ilastik.config import cfg as ilastik_config
 from ilastik.utility import bind
-from ilastik.utility.gui import threadRouted, silent_widget
+from ilastik.utility.gui import threadRouted, silent_qobject
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui, SubvolumeSelectionDlg
@@ -774,7 +774,7 @@ class PixelClassificationGui(LabelingGui):
 
     def setLiveUpdateEnabled(self, checked: Optional[bool] = None):
         checked = checked if checked is not None else self.isLiveUpdateEnabled()
-        with silent_widget(self.labelingDrawerUi.liveUpdateButton) as w:
+        with silent_qobject(self.labelingDrawerUi.liveUpdateButton) as w:
             w.setChecked(checked)
         if checked:
             self._viewerControlUi.checkShowPredictions.setChecked(True)

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -68,7 +68,7 @@ from lazyflow.operators import OpFeatureMatrixCache
 # ilastik
 from ilastik.config import cfg as ilastik_config
 from ilastik.utility import bind
-from ilastik.utility.gui import threadRouted
+from ilastik.utility.gui import threadRouted, silent_widget
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.applets.dataSelection.dataSelectionGui import DataSelectionGui, SubvolumeSelectionDlg
@@ -774,9 +774,8 @@ class PixelClassificationGui(LabelingGui):
 
     def setLiveUpdateEnabled(self, checked: Optional[bool] = None):
         checked = checked if checked is not None else self.isLiveUpdateEnabled()
-        self.labelingDrawerUi.liveUpdateButton.blockSignals(True)
-        self.labelingDrawerUi.liveUpdateButton.setChecked(checked)
-        self.labelingDrawerUi.liveUpdateButton.blockSignals(False)
+        with silent_widget(self.labelingDrawerUi.liveUpdateButton) as w:
+            w.setChecked(checked)
         if checked:
             self._viewerControlUi.checkShowPredictions.setChecked(True)
             self.handleShowPredictionsClicked()

--- a/ilastik/utility/gui/__init__.py
+++ b/ilastik/utility/gui/__init__.py
@@ -22,4 +22,4 @@
 from .roi import roi2rect
 from .threadRouter import ThreadRouter, threadRouted, threadRoutedWithRouter
 from .thunkEvent import ThunkEvent, ThunkEventHandler
-from .widgets import enable_when_ready
+from .widgets import enable_when_ready, silent_widget

--- a/ilastik/utility/gui/__init__.py
+++ b/ilastik/utility/gui/__init__.py
@@ -22,4 +22,4 @@
 from .roi import roi2rect
 from .threadRouter import ThreadRouter, threadRouted, threadRoutedWithRouter
 from .thunkEvent import ThunkEvent, ThunkEventHandler
-from .widgets import enable_when_ready, silent_widget
+from .widgets import enable_when_ready, silent_qobject

--- a/ilastik/utility/gui/widgets.py
+++ b/ilastik/utility/gui/widgets.py
@@ -23,6 +23,7 @@ from typing import Callable, Iterable, Union
 from contextlib import contextmanager
 
 from PyQt5.QtWidgets import QWidget
+from PyQt5.QtCore import QObject
 
 from lazyflow.slot import Slot
 
@@ -64,10 +65,10 @@ def enable_when_ready(
 
 
 @contextmanager
-def silent_widget(widget: QWidget) -> QWidget:
+def silent_qobject(qobject: QObject) -> QObject:
     """Disable notifying connected callbacks/slots."""
-    blocked_status: bool = widget.blockSignals(True)
+    blocked_status: bool = qobject.blockSignals(True)
     try:
-        yield widget
+        yield qobject
     finally:
-        widget.blockSignals(blocked_status)
+        qobject.blockSignals(blocked_status)

--- a/ilastik/utility/gui/widgets.py
+++ b/ilastik/utility/gui/widgets.py
@@ -20,6 +20,7 @@
 ###############################################################################
 
 from typing import Callable, Iterable, Union
+from contextlib import contextmanager
 
 from PyQt5.QtWidgets import QWidget
 
@@ -60,3 +61,13 @@ def enable_when_ready(
             f()
 
     return cleanup
+
+
+@contextmanager
+def silent_widget(widget: QWidget) -> QWidget:
+    """Disable notifying connected callbacks/slots."""
+    blocked_status: bool = widget.blockSignals(True)
+    try:
+        yield widget
+    finally:
+        widget.blockSignals(blocked_status)

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -77,9 +77,7 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
 
         # -- DataSelection applet
         #
-        self.dataSelectionApplet = DataSelectionApplet(
-            self, "Input Data", "Input Data", forceAxisOrder=["zyxc", "yxc"], max_lanes=1
-        )
+        self.dataSelectionApplet = DataSelectionApplet(self, "Input Data", "Input Data", forceAxisOrder=["zyxc", "yxc"])
 
         # Dataset inputs
         opDataSelection = self.dataSelectionApplet.topLevelOperator

--- a/lazyflow/operators/opBlockedArrayCache.py
+++ b/lazyflow/operators/opBlockedArrayCache.py
@@ -73,7 +73,6 @@ class OpBlockedArrayCache(Operator, ManagedBlockedCache):
         self._opCacheFixer.fixAtCurrent.connect(self.fixAtCurrent)
 
         self._opSimpleBlockedArrayCache = OpSimpleBlockedArrayCache(parent=self)
-        self._opSimpleBlockedArrayCache.Input.connect(self._opCacheFixer.Output)
         self._opSimpleBlockedArrayCache.CompressionEnabled.connect(self.CompressionEnabled)
         self._opSimpleBlockedArrayCache.Input.connect(self._opCacheFixer.Output)
         self._opSimpleBlockedArrayCache.BlockShape.connect(self.BlockShape)


### PR DESCRIPTION
Multicut has been misbehaving with multiple lanes in the past - that's why it was single lane now for a while. This PR enables using multiple lanes again and dodges some of the previous pitfalls:

fixes #2061, live update is synced via a broadcasting slot

fixes https://github.com/ilastik/ilastik/issues/2189 , this was cause by circular updates in the multi-lane setting. Prevented this by not sending signals from widgets currently being updated in operator callbacks

fixes #1858, live update now inherently synced via callbacks

fixes #2139 by hiding prediction layer if no classifier is trained

commits can be reviewed in order.

superseeds #1910