### PR TITLE
clear caches when superpixel input changes

### DIFF
--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -211,6 +211,17 @@ class OpEdgeTraining(Operator):
     def getLane(self, laneIndex):
         return OperatorSubView(self, laneIndex)
 
+    def clear_caches(self, lane_index):
+        self.opClassifierCache.resetValue()
+        for cache in [
+            self.opRagCache,
+            self.opEdgeProbabilitiesCache,
+            self.opEdgeProbabilitiesDictCache,
+            self.opEdgeFeaturesCache,
+        ]:
+            c = cache.getLane(lane_index)
+            c.resetValue()
+
 
 class OpCreateRag(Operator):
     Superpixels = InputSlot()

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -95,6 +95,9 @@ class OpEdgeTrainingWithMulticut(Operator):
     def propagateDirty(self, slot, subindex, roi):
         pass
 
+    def clear_caches(self, lane_index):
+        self.opEdgeTraining.clear_caches(lane_index)
+
     ##
     ## MultiLaneOperatorABC
     ##

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -256,11 +256,9 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
 
         def _invalidate_cache_on_sp_change(*args, **kwargs):
             op = opEdgeTrainingWithMulticut
-            print("Setting the cache dirty!", args, kwargs)
             opEdgeTrainingWithMulticut.clear_caches(op.current_view_index())
 
         opSuperpixelsSelect.Output.notifyDirty(_invalidate_cache_on_sp_change)
-        opSuperpixelsSelect.Output.notifyDirty(lambda *x, **xx: print("dirty"))
 
         # DataExport inputs
         opDataExport.RawData.connect(opDataSelection.ImageGroup[self.DATA_ROLE_RAW])

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -254,6 +254,14 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
         opEdgeTrainingWithMulticut.GroundtruthSegmentation.connect(opGroundtruthCache.Output)
         opEdgeTrainingWithMulticut.WatershedSelectedInput.connect(opWsdt.SelectedInput)
 
+        def _invalidate_cache_on_sp_change(*args, **kwargs):
+            op = opEdgeTrainingWithMulticut
+            print("Setting the cache dirty!", args, kwargs)
+            opEdgeTrainingWithMulticut.clear_caches(op.current_view_index())
+
+        opSuperpixelsSelect.Output.notifyDirty(_invalidate_cache_on_sp_change)
+        opSuperpixelsSelect.Output.notifyDirty(lambda *x, **xx: print("dirty"))
+
         # DataExport inputs
         opDataExport.RawData.connect(opDataSelection.ImageGroup[self.DATA_ROLE_RAW])
         opDataExport.RawDatasetInfo.connect(opDataSelection.DatasetGroup[self.DATA_ROLE_RAW])


### PR DESCRIPTION
normally, we like to still see cache values, even if input changes to enable
"correct where it's wrong" type of labeling.
When superpixels change, the old predictions don't make any sense at all, so
caches are flushed.

fixes #1488 
fixes #2154 