### PR TITLE
fix doing "live" multicut without trained classifier

### DIFF
--- a/ilastik/applets/multicut/opMulticut.py
+++ b/ilastik/applets/multicut/opMulticut.py
@@ -222,6 +222,11 @@ if True:
             edge_ids = rag.edge_ids
             edge_probabilities = self.EdgeProbabilities.value
 
+            if edge_probabilities is None:
+                # This can happen when the cache doesn't have data yet.
+                result[0] = {}
+                return
+
             # 0: edge is "inactive", nodes belong to the same segment
             # 1: edge is "active", nodes belong to separate segments
             edge_labels_from_nodes = (node_labels[rag.edge_ids[:, 0]] != node_labels[rag.edge_ids[:, 1]]).view(np.uint8)

--- a/ilastik/applets/multicut/opMulticut.py
+++ b/ilastik/applets/multicut/opMulticut.py
@@ -218,14 +218,14 @@ if True:
                 result[0] = {}
                 return
 
-            rag = self.Rag.value
-            edge_ids = rag.edge_ids
             edge_probabilities = self.EdgeProbabilities.value
-
             if edge_probabilities is None:
                 # This can happen when the cache doesn't have data yet.
                 result[0] = {}
                 return
+
+            rag = self.Rag.value
+            edge_ids = rag.edge_ids
 
             # 0: edge is "inactive", nodes belong to the same segment
             # 1: edge is "active", nodes belong to separate segments


### PR DESCRIPTION
quick fix for a problem I found using multicut (didn't bother to open an issue).

clicking "live multicut" before training a classifier would result in an error.

We should probably be more user-friendly here, too, and not have that button enabled if RF is not trained (https://github.com/ilastik/ilastik/issues/2414).