### PR TITLE
restore live update value after updating multicut

### DIFF
--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QGroupBox, QSpacerItem, QSizePolicy, QCheckBox
 
+from lazyflow.slot import valueContext
 from ilastik.applets.edgeTraining.edgeTrainingGui import EdgeTrainingMixin
 from ilastik.applets.multicut.multicutGui import MulticutGuiMixin
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
@@ -114,6 +115,6 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         slots than the ones available from OpMulticut. which
         FreezeClassifier is not).
         """
-        self.topLevelOperatorView.FreezeClassifier.setValue(False)
-        super()._update_multicut_views()
-        self.topLevelOperatorView.FreezeClassifier.setValue(True)
+
+        with valueContext(self.topLevelOperatorView.FreezeClassifier, False):
+            super()._update_multicut_views()

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1466,6 +1466,17 @@ class InputSlot(Slot):
         self.notifyResized(self._configureOperator)
 
 
+@contextmanager
+def valueContext(slot, value):
+    """Temporarily change value in the *with* statement context, yielding an old one."""
+    old = slot.value
+    slot.setValue(value)
+    try:
+        yield old
+    finally:
+        slot.setValue(old)
+
+
 class OutputSlot(Slot):
     """The base class for output slots, it provides methods to connect
     the OutputSlot to an InputSlot of another operator (i.e.


### PR DESCRIPTION
That's a brief one.

before, live update would be turned off silently leaving the button in an inconsistent state when "update multicut" was pressed.