### PR TITLE
Fix OpMultiArraySlicer2 dirty to early

### DIFF
--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -113,12 +113,6 @@ class OpMultiArraySlicer2(Operator):
             if self.Input.meta.drange is not None:
                 oslot.meta.drange = self.Input.meta.drange
 
-        inputShape = self.Input.meta.shape
-        if self.inputShape != inputShape:
-            self.inputShape = inputShape
-            for oslot in self.Slices:
-                oslot.setDirty(slice(None))
-
     def getSliceIndexes(self):
         if self.SliceIndexes.ready():
             return self.SliceIndexes.value


### PR DESCRIPTION
Removed calls to `setDirty` for outputslots in `setupOutputs` of `OpMultiArraySlicer2`. I can not think of a reason why this was there in the first place. `Operator._setupOutputs` has the necessary logic in place.

~~while I couldn't exactly reproduce the reported issue~~, I could create a similar one when enabling users to add singleton axis in export (see https://github.com/ilastik/volumina/pull/263).
Update: I managed to reproduce the original issue - with a bit of trickery. I also made sure this does not happen anymore with this branch/pr:
1. In pixel classification, use 5d dataset with singletons in `t` and `z`.
2. train a classifier
3. In export: remove axes `t` and `z` (or just one of them), when closing the dialog, you'll get an error. Reopen the dialog and change some other setting (e.g. normalization), accept again, save the project.

this produces a project that results in #2239 ...

Fixes #2239 

I'm not sure this causes any side effects. Touching code that was in place for so long... So far I have not encountered any side effects that I could reproduce with this branch.