### PR TITLE
PC + OC workflow: fix loading projects

### DIFF
--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -253,7 +253,7 @@ class ObjectClassificationWorkflow(Workflow):
         """
         if self.stored_object_classifier:
             opObjectClassification = self.objectClassificationApplet.topLevelOperator
-            opObjectClassification.classifier_cache.forceValue(self.stored_object_classifier)
+            opObjectClassification.classifier_cache.forceValue(self.stored_object_classifier, set_dirty=False)
             # Release reference
             self.stored_object_classifier = None
 
@@ -621,7 +621,7 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         # If we have stored classifiers, restore them into the workflow now.
         if self.stored_pixel_classifier:
             opPixelClassification = self.pcApplet.topLevelOperator
-            opPixelClassification.classifier_cache.forceValue(self.stored_pixel_classifier)
+            opPixelClassification.classifier_cache.forceValue(self.stored_pixel_classifier, set_dirty=False)
             # Release reference
             self.stored_pixel_classifier = None
         super().handleNewLanesAdded()


### PR DESCRIPTION
PixelClassification + Object Classification, while not recommended, should work properly. Right now projects are not loaded correctly (see #2244)

this prevents dirty notifications bubbling up. In the combined workflow, the pixel classification classifier is set after the object classifier is added.
Hence, it is marked as dirty and discarded. Even worse, it sets the segmentation dirty, which in turn discards the object annotations.

Setting classifiers "silently" is exactly what you want there. No dirty notifications bubbling ~~up~~ down on added lanes.

fixes #2244