### PR TITLE
Simplify logic in ArgMaxChannelIndicator; get rid of transparent pixels

### DIFF
--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -37,10 +37,8 @@ from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.operators import (
     OpValueCache,
     OpBlockedArrayCache,
-    OpMultiArraySlicer2,
     OpPrecomputedInput,
     OpPixelOperator,
-    OpMaxChannelIndicatorOperator,
     OpReorderAxes,
     OpCompressedUserLabelArray,
 )

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -39,7 +39,7 @@ import vigra
 # lazyflow
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow import roi
-from lazyflow.roi import roiToSlice, sliceToRoi, TinyVector, getIntersection
+from lazyflow.roi import roiToSlice, sliceToRoi, TinyVector, getIntersection, InvalidRoiException
 from lazyflow.request import RequestPool
 
 
@@ -533,6 +533,9 @@ class OpMaxChannelIndicatorOperator(Operator):
 
     def execute(self, slot, subindex, roi, result):
         key = roi.toSlice()
+        n_channels_requested = key[-1].stop - key[-1].start
+        if n_channels_requested != 1:
+            raise InvalidRoiException(f"This operator only accepts slices of size 1 for c! Got {n_channels_requested}.")
         data = self.inputs["Input"][key[:-1] + (slice(None),)].wait()
 
         # special case, when data is all zeros (e.g. directly from frozen cache w/o trained classifier)

--- a/lazyflow/roi.py
+++ b/lazyflow/roi.py
@@ -828,6 +828,10 @@ def slicing_to_string(slicing, max_shape=None):
     return "(" + ",  ".join(slice_strings) + ")"
 
 
+class InvalidRoiException(Exception):
+    pass
+
+
 if __name__ == "__main__":
     import doctest
 

--- a/tests/test_lazyflow/test_operators/testOpMaxChannelIndicator.py
+++ b/tests/test_lazyflow/test_operators/testOpMaxChannelIndicator.py
@@ -1,0 +1,67 @@
+import pytest
+import numpy
+import vigra
+
+from lazyflow.operators import OpArrayPiper, OpMaxChannelIndicatorOperator
+from lazyflow.roi import InvalidRoiException
+from lazyflow.utility import Pipeline
+
+
+def test_OpMaxChannelIndicatorOperator_all_zeros(graph):
+    """Special case for all zeros in probability maps"""
+    data = vigra.VigraArray(numpy.zeros((1, 3, 5, 7, 2)), axistags=vigra.defaultAxistags("tzyxc"))
+
+    # automatically connects op1.Output to op2.Input ...
+    with Pipeline(graph=graph) as pipe_line:
+        pipe_line.add(OpArrayPiper, Input=data)
+        pipe_line.add(OpMaxChannelIndicatorOperator)
+
+        for c in range(data.channels):
+            assert not numpy.any(pipe_line[-1].Output[..., c].wait())
+
+
+def test_OpMaxChannelIndicatorOperator(graph):
+    data = vigra.VigraArray(numpy.zeros((1, 3, 5, 7, 2)), axistags=vigra.defaultAxistags("tzyxc"))
+
+    data[:, :, :, ::2, 0] = 1
+    data[:, :, :, 1::2, 1] = 1
+
+    expected = data == 1
+
+    # automatically connects op1.Output to op2.Input ...
+    with Pipeline(graph=graph) as pipe_line:
+        pipe_line.add(OpArrayPiper, Input=data)
+        pipe_line.add(OpMaxChannelIndicatorOperator)
+
+        for c in range(data.channels):
+            numpy.testing.assert_array_equal(pipe_line[-1].Output[..., c].wait(), expected[..., c, None])
+
+
+def test_OpMaxChannelIndicatorOperator_tied_pixels(graph):
+    data = vigra.VigraArray(numpy.zeros((1, 3, 5, 7, 2)), axistags=vigra.defaultAxistags("tzyxc"))
+
+    data[..., 0] = 1
+    data[:, :, 0:2, 0:2, :] = 0.5
+
+    # for tied pixels we expect the first occurrence to "win"
+    expected = numpy.zeros_like(data)
+    expected[..., 0] = 1
+
+    # automatically connects op1.Output to op2.Input ...
+    with Pipeline(graph=graph) as pipe_line:
+        pipe_line.add(OpArrayPiper, Input=data)
+        pipe_line.add(OpMaxChannelIndicatorOperator)
+
+        for c in range(data.channels):
+            numpy.testing.assert_array_equal(pipe_line[-1].Output[..., c].wait(), expected[..., c, None])
+
+
+def test_OpMaxChannelIndicatorOperator_unexpected_roi_raises(graph):
+    data = vigra.VigraArray(numpy.zeros((1, 3, 5, 7, 2)), axistags=vigra.defaultAxistags("tzyxc"))
+
+    with pytest.raises(InvalidRoiException):
+        # automatically connects op1.Output to op2.Input ...
+        with Pipeline(graph=graph) as pipe_line:
+            pipe_line.add(OpArrayPiper, Input=data)
+            pipe_line.add(OpMaxChannelIndicatorOperator)
+            pipe_line[-1].Output[()].wait()


### PR DESCRIPTION
* removed logic that would return `0` pixels for tied predictions.
* unified behavior with the Simple Segmentation export slot (no `0` pixels there).
* made sure not to reintroduce #1033

fixes #2025