### PR TITLE
Neural Network Classification workflow cleanup

### DIFF
--- a/ilastik/applets/neuralNetwork/nnClass.ui
+++ b/ilastik/applets/neuralNetwork/nnClass.ui
@@ -91,6 +91,12 @@
        <property name="textInteractionFlags">
         <set>Qt::TextBrowserInteraction</set>
        </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
       </widget>
      </item>
      <item>
@@ -306,6 +312,25 @@
      </item>
     </layout>
    </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </spacer>
+     </item>
   </layout>
  </widget>
  <customwidgets>

--- a/ilastik/applets/neuralNetwork/nnClassApplet.py
+++ b/ilastik/applets/neuralNetwork/nnClassApplet.py
@@ -44,9 +44,9 @@ class NNClassApplet(StandardApplet):
 
         self._topLevelOperator.classifier_cache.Output.notifyDirty(on_classifier_changed)
 
-        applet_name = ALLOW_TRAINING and "NN Training" or "NN Prediction"
+        applet_name = "NN Training" if ALLOW_TRAINING else "NN Prediction"
 
-        super(NNClassApplet, self).__init__(applet_name, workflow=workflow)
+        super().__init__(applet_name, workflow=workflow)
 
         self._serializableItems = [NNClassificationSerializer(self.topLevelOperator, projectFileGroupName)]
         self._gui = None

--- a/ilastik/applets/neuralNetwork/nnClassApplet.py
+++ b/ilastik/applets/neuralNetwork/nnClassApplet.py
@@ -21,7 +21,7 @@
 from ilastik.applets.base.standardApplet import StandardApplet
 from .opNNclass import OpNNClassification
 from .nnClassSerializer import NNClassificationSerializer
-from .tiktorchController import TiktorchController, TiktorchOperatorModel
+from .tiktorchController import TiktorchController, TiktorchOperatorModel, ALLOW_TRAINING
 
 
 class NNClassApplet(StandardApplet):
@@ -44,7 +44,9 @@ class NNClassApplet(StandardApplet):
 
         self._topLevelOperator.classifier_cache.Output.notifyDirty(on_classifier_changed)
 
-        super(NNClassApplet, self).__init__("NN Training", workflow=workflow)
+        applet_name = ALLOW_TRAINING and "NN Training" or "NN Prediction"
+
+        super(NNClassApplet, self).__init__(applet_name, workflow=workflow)
 
         self._serializableItems = [NNClassificationSerializer(self.topLevelOperator, projectFileGroupName)]
         self._gui = None

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -60,11 +60,11 @@ from PyQt5.QtWidgets import (
     QComboBox,
 )
 
-from ilastik.applets.labeling.labelingGui import LabelingGui
+from ilastik.applets.labeling.labelingGui import LabelingGui, Tool
 from ilastik.utility.gui import threadRouted
 from ilastik.utility import bind
 from ilastik.shell.gui.iconMgr import ilastikIcons
-from .tiktorchController import TiktorchController, TiktorchOperatorModel
+from .tiktorchController import TiktorchController, TiktorchOperatorModel, ALLOW_TRAINING
 
 from volumina.api import LazyflowSource, AlphaModulatedLayer, GrayscaleLayer
 from volumina.utility import preferences
@@ -413,6 +413,21 @@ class NNClassGui(LabelingGui):
 
         return menus
 
+    @threadRouted
+    def enableLabellingUI(self, enabled: bool = False):
+        self._changeInteractionMode(Tool.Navigation)
+        drawer = self.labelingDrawerUi
+        for widget in [
+            drawer.eraserToolButton,
+            drawer.AddLabelButton,
+            drawer.paintToolButton,
+            drawer.labelListView,
+            drawer.brushSizeCaption,
+            drawer.brushSizeComboBox,
+        ]:
+            widget.setEnabled(enabled)
+            widget.setVisible(enabled)
+
     def _get_model_state(self):
         factory = self.topLevelOperatorView.ClassifierFactory[:].wait()[0]
         return factory.get_model_state()
@@ -492,7 +507,7 @@ class NNClassGui(LabelingGui):
         )
         self.__cleanup_fns.append(self.topLevelOperatorView.cleanUp)
 
-        self.forceAtLeastTwoLabels(True)
+        self.enableLabellingUI(ALLOW_TRAINING)
 
         self.invalidatePredictionsTimer = QTimer()
         self.invalidatePredictionsTimer.timeout.connect(self.updatePredictions)

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -414,7 +414,7 @@ class NNClassGui(LabelingGui):
         return menus
 
     @threadRouted
-    def enableLabellingUI(self, enabled: bool = False):
+    def setLabelingUIEnabled(self, enabled: bool = False):
         self._changeInteractionMode(Tool.Navigation)
         drawer = self.labelingDrawerUi
         for widget in [
@@ -507,7 +507,7 @@ class NNClassGui(LabelingGui):
         )
         self.__cleanup_fns.append(self.topLevelOperatorView.cleanUp)
 
-        self.enableLabellingUI(ALLOW_TRAINING)
+        self.setLabelingUIEnabled(ALLOW_TRAINING)
 
         self.invalidatePredictionsTimer = QTimer()
         self.invalidatePredictionsTimer.timeout.connect(self.updatePredictions)

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -592,7 +592,7 @@ class NNClassGui(LabelingGui):
                 predictsrc = LazyflowSource(predictionSlot)
                 predictionLayer = AlphaModulatedLayer(predictsrc, tintColor=ref_label.pmapColor(), normalize=(0.0, 1.0))
                 predictionLayer.visible = self.labelingDrawerUi.livePrediction.isChecked()
-                predictionLayer.opacity = 0.25
+                predictionLayer.opacity = 0.5
                 predictionLayer.visibleChanged.connect(self.updateShowPredictionCheckbox)
 
                 def setLayerColor(c, predictLayer_=predictionLayer, initializing=False):
@@ -784,7 +784,7 @@ class NNClassGui(LabelingGui):
 
     def _uploadModel(self, modelBytes):
         cancelSrc = CancellationTokenSource()
-        dialog = PercentProgressDialog(self, title="Uploading model")
+        dialog = PercentProgressDialog(self, title="Initializing model")
         dialog.rejected.connect(cancelSrc.cancel)
         dialog.open()
 

--- a/ilastik/applets/neuralNetwork/nnClassificationDataExportGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassificationDataExportGui.py
@@ -63,16 +63,10 @@ class NNClassificationResultsViewer(DataExportLayerViewerGui):
         if selection.startswith("Probabilities"):
             exportedLayers = self._initPredictionLayers(opLane.ImageToExport)
             for layer in exportedLayers:
-                layer.visible = True
+                layer.visible = False
                 layer.name = layer.name + "- Exported"
             layers += exportedLayers
         elif selection.startswith("Labels"):
-            exportedLayer = self._initColortablelayer(opLane.ImageOnDisk)
-            if exportedLayer:
-                exportedLayer.visible = True
-                exportedLayer.name = selection + " - Exported"
-                layers.append(exportedLayer)
-
             previewLayer = self._initColortablelayer(opLane.ImageToExport)
             if previewLayer:
                 previewLayer.visible = False

--- a/ilastik/applets/neuralNetwork/tiktorchController.py
+++ b/ilastik/applets/neuralNetwork/tiktorchController.py
@@ -29,6 +29,11 @@ from lazyflow.operators.tiktorch import IConnectionFactory
 logger = logging.getLogger(__name__)
 
 
+# When implementing training, check code that accesses this flag -
+# used to hide "unused" gui elements
+ALLOW_TRAINING = False
+
+
 @dataclasses.dataclass
 class ModelInfo:
     name: str


### PR DESCRIPTION
Summary:

* This sets the classification applet up as a "predict" only for now.
* initially hides prediction layers in export (would start predicting there right away otherwise)
* model "upload" rephrased to model "initialization"

NN Drawer:

before:
![before](https://user-images.githubusercontent.com/24434157/124950912-208c5400-e013-11eb-987b-c34fdc739278.png)


after:

![after](https://user-images.githubusercontent.com/24434157/124950929-25510800-e013-11eb-83be-7d281dd12be8.png)
