### PR TITLE
Neural Network Workflow - start 'local' server from environment

### DIFF
--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -66,6 +66,9 @@ def _argparser() -> argparse.ArgumentParser:
     )
     ap.add_argument("--hbp", help="Enable HBP-specific functionality.", action="store_true")
     ap.add_argument("--tiktorch_executable", help="Specify path to tiktorch server executable", default=None)
+    ap.add_argument(
+        "--nn_device", help="Local device to run Neural Networks on. Examples: 'cpu', 'gpu:0'.", default=None
+    )
     return ap
 
 
@@ -136,6 +139,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     _update_debug_mode(parsed_args)
     _update_hbp_mode(parsed_args)
     _update_tiktorch_executable_location(parsed_args)
+    runtime_cfg.preferred_cuda_device_id = parsed_args.nn_device
 
     # If necessary, redirect stdout BEFORE logging is initialized
     _redirect_output(parsed_args)

--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -67,7 +67,7 @@ def _argparser() -> argparse.ArgumentParser:
     ap.add_argument("--hbp", help="Enable HBP-specific functionality.", action="store_true")
     ap.add_argument("--tiktorch_executable", help="Specify path to tiktorch server executable", default=None)
     ap.add_argument(
-        "--nn_device", help="Local device to run Neural Networks on. Examples: 'cpu', 'gpu:0'.", default=None
+        "--nn_device", help="Local device to run Neural Networks on. Examples: 'cpu', 'cuda:0'.", default=None
     )
     return ap
 

--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -20,8 +20,8 @@
 ###############################################################################
 import argparse
 import faulthandler
+import importlib
 import logging
-import platform
 import os
 import sys
 from typing import List, Optional, Sequence, Tuple
@@ -135,7 +135,7 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     _import_h5py_with_utf8_encoding()
     _update_debug_mode(parsed_args)
     _update_hbp_mode(parsed_args)
-    _update_tiktorch_executable_location(parsed_args, ilastik_dir)
+    _update_tiktorch_executable_location(parsed_args)
 
     # If necessary, redirect stdout BEFORE logging is initialized
     _redirect_output(parsed_args)
@@ -260,25 +260,21 @@ def _update_hbp_mode(parsed_args):
         ilastik_config.set("ilastik", "hbp", "true")
 
 
-def _update_tiktorch_executable_location(parsed_args, root_path: str):
+def _update_tiktorch_executable_location(parsed_args):
     """enable tiktorch local workflow"""
-    tiktorch_executable: Optional[Path] = None
-    if parsed_args.tiktorch_executable:
-        tiktorch_executable = Path(parsed_args.tiktorch_executable)
+    TIKTORCH_MODULES = ("tiktorch.server", "torch")
+
+    if parsed_args.tiktorch_executable and Path(parsed_args.tiktorch_executable).exists():
+        tiktorch_executable = [parsed_args.tiktorch_executable]
+    elif all(importlib.util.find_spec(mod) for mod in TIKTORCH_MODULES):
+        tiktorch_executable = [sys.executable, "-m", "tiktorch.server"]
     else:
-        # Maybe tiktorch is bundled
-        root_path = Path(root_path)
-        tiktorch_script = "run_tiktorch.sh" if platform.system() != "Windows" else "run_tiktorch.bat"
-        bundled_tiktorch_executable = root_path / "tiktorch" / tiktorch_script
+        tiktorch_executable = None
 
-        if bundled_tiktorch_executable.exists():
-            tiktorch_executable = bundled_tiktorch_executable
-
-    if tiktorch_executable and tiktorch_executable.exists():
+    if tiktorch_executable:
         tiktorch_msg = "Using tiktorch executable: %s" % tiktorch_executable
-        print(tiktorch_msg)
         logger.info(tiktorch_msg)
-        runtime_cfg.tiktorch_executable = str(tiktorch_executable)
+        runtime_cfg.tiktorch_executable = tiktorch_executable
 
 
 def _init_logging(parsed_args):

--- a/ilastik/config.py
+++ b/ilastik/config.py
@@ -83,6 +83,7 @@ filename: in
 @dataclass
 class RuntimeCfg:
     tiktorch_executable: Optional[str] = None
+    preferred_cuda_device_id: Optional[str] = None
 
 
 cfg: configparser.ConfigParser = configparser.ConfigParser()

--- a/ilastik/workflows/neuralNetwork/_localWorkflow.py
+++ b/ilastik/workflows/neuralNetwork/_localWorkflow.py
@@ -61,13 +61,13 @@ class LocalWorkflow(_NNWorkflowBase):
         devices = conn.get_devices()
         preferred_cuda_device_id = runtime_cfg.preferred_cuda_device_id
         device_ids = [dev[0] for dev in devices]
-        gpus = tuple(d for d in device_ids if d.startswith("gpu"))
+        cuda_devices = tuple(d for d in device_ids if d.startswith("cuda"))
 
         if preferred_cuda_device_id not in device_ids:
             if preferred_cuda_device_id:
                 logger.warning(f"Could nor find preferred cuda device {preferred_cuda_device_id}")
             try:
-                preferred_cuda_device_id = gpus[0]
+                preferred_cuda_device_id = cuda_devices[0]
             except IndexError:
                 preferred_cuda_device_id = "cpu"
 

--- a/ilastik/workflows/neuralNetwork/_localWorkflow.py
+++ b/ilastik/workflows/neuralNetwork/_localWorkflow.py
@@ -56,6 +56,29 @@ class LocalWorkflow(_NNWorkflowBase):
         conn_str = self._launcher.start()
         srv_config = ServerConfig(id="auto", address=conn_str, devices=[Device(id="cpu", name="cpu", enabled=True)])
         connFactory = tiktorch.TiktorchConnectionFactory()
+        conn = connFactory.ensure_connection(srv_config)
+
+        devices = conn.get_devices()
+        preferred_cuda_device_id = runtime_cfg.preferred_cuda_device_id
+        device_ids = [dev[0] for dev in devices]
+        gpus = tuple(d for d in device_ids if d.startswith("gpu"))
+
+        if preferred_cuda_device_id not in device_ids:
+            if preferred_cuda_device_id:
+                logger.warning(f"Could nor find preferred cuda device {preferred_cuda_device_id}")
+            try:
+                preferred_cuda_device_id = gpus[0]
+            except IndexError:
+                preferred_cuda_device_id = "cpu"
+
+            logger.info(f"Using default device for Neural Network Workflow {preferred_cuda_device_id}")
+        else:
+            logger.info(f"Using specified device for Neural Netowrk Workflow {preferred_cuda_device_id}")
+
+        device_name = devices[device_ids.index(preferred_cuda_device_id)][1]
+
+        srv_config = srv_config.evolve(devices=[Device(id=preferred_cuda_device_id, name=device_name, enabled=True)])
+
         self.nnClassificationApplet = NNClassApplet(self, "NNClassApplet", connectionFactory=connFactory)
         opClassify = self.nnClassificationApplet.topLevelOperator
         opClassify.ServerConfig.setValue(srv_config)


### PR DESCRIPTION
This starts the local server from a local environment (if `tiktorch.sever` and `pytorch` are in the environment).

Adds a command line flag to specify cpu/cuda device to use: `--nn_device` (calling it `nn` as it can also be `cpu`).

The local workflow can now be configured like

```bash
python ilastik.py 
    # if a different tiktorch server, not the one with the env should be run
    --tiktorch_executable ... \
    # defaults to 'last' cuda device in the list, fallback cpu
    --nn_device ...
```