### PR TITLE
Handle outputshape returned by server

### DIFF
--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -21,11 +21,8 @@
 ###############################################################################
 import logging
 import socket
-import threading
 import numpy
 import warnings
-import numpy as np
-from concurrent.futures import CancelledError
 from typing import Iterable, List, Callable
 
 import vigra
@@ -90,6 +87,9 @@ class ModelSession:
         scale_by_name = {d.name: d.size for d in self.scale}
 
         result = []
+        # FIXME: currently we don't make use of having potentially multiple valid
+        # output shapes. It can make sense, to choose it dynamically, e.g.
+        # a smaller one for "live" prediction, a larger one for batch
         for shape in self.__session.validShapes:
             dim_size_by_name = {d.name: d.size for d in shape.dims}
             valid_shape = {}
@@ -124,7 +124,7 @@ class ModelSession:
 
     @property
     def training_shape(self):
-        logger.warning("HARDCODED training shape, this might not do what you want")
+        warnings.warn("HARDCODED training shape, this might not do what you want.")
         return [0, 0, 0, 128, 128]
 
     @property

--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -74,6 +74,44 @@ class ModelSession:
         return self.__session.outputAxes
 
     @property
+    def offset(self):
+        return self.__session.offset
+
+    @property
+    def scale(self):
+        return self.__session.scale
+
+    @property
+    def output_shapes(self):
+        return self.__session.validShapes
+
+    @property
+    def output_shape(self):
+        """
+        shape = shape(input_tensor) * scale + 2 * offset
+        """
+        offset_by_name = {d.name: d.size for d in self.offset}
+        scale_by_name = {d.name: d.size for d in self.scale}
+
+        result = []
+        for shape in self.__session.validShapes:
+            dim_size_by_name = {d.name: d.size for d in shape.dims}
+            valid_shape = {}
+            for dim in dim_size_by_name:
+                # HACK: Check if models are updated to make this unnecessary
+                if dim in "xyz":
+                    multiplier = 2
+                else:
+                    multiplier = 1
+                size = dim_size_by_name.get(dim, 1) * scale_by_name.get(dim, 1.0) + multiplier * offset_by_name.get(
+                    dim, 0
+                )
+                valid_shape[dim] = size
+
+            result.append(valid_shape)
+        return result[0]
+
+    @property
     def has_training(self):
         return self.__session.hasTraining
 
@@ -97,11 +135,13 @@ class ModelSession:
 
     @property
     def training_shape(self):
+        logger.warning("HARDCODED training shape, this might not do what you want")
         return [0, 0, 0, 128, 128]
 
     @property
     def known_classes(self):
-        return [1, 2]
+        output_shape = self.output_shape
+        return list(range(1, int(output_shape["c"]) + 1))
 
     @property
     def num_classes(self):

--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -79,8 +79,7 @@ class ModelSession:
     def scale(self):
         return self.__session.scale
 
-    @property
-    def output_shape(self):
+    def get_output_shape(self):
         """
         shape = shape(input_tensor) * scale + 2 * offset
         """
@@ -129,7 +128,7 @@ class ModelSession:
 
     @property
     def known_classes(self):
-        output_shape = self.output_shape
+        output_shape = self.get_output_shape()
         return list(range(1, int(output_shape["c"]) + 1))
 
     @property

--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -82,10 +82,6 @@ class ModelSession:
         return self.__session.scale
 
     @property
-    def output_shapes(self):
-        return self.__session.validShapes
-
-    @property
     def output_shape(self):
         """
         shape = shape(input_tensor) * scale + 2 * offset
@@ -98,14 +94,7 @@ class ModelSession:
             dim_size_by_name = {d.name: d.size for d in shape.dims}
             valid_shape = {}
             for dim in dim_size_by_name:
-                # HACK: Check if models are updated to make this unnecessary
-                if dim in "xyz":
-                    multiplier = 2
-                else:
-                    multiplier = 1
-                size = dim_size_by_name.get(dim, 1) * scale_by_name.get(dim, 1.0) + multiplier * offset_by_name.get(
-                    dim, 0
-                )
+                size = int(dim_size_by_name.get(dim, 1) * scale_by_name.get(dim, 1.0) + 2 * offset_by_name.get(dim, 0))
                 valid_shape[dim] = size
 
             result.append(valid_shape)

--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -23,6 +23,7 @@ import logging
 import socket
 import numpy
 import warnings
+from collections import defaultdict
 from typing import Iterable, List, Callable
 
 import vigra
@@ -83,8 +84,8 @@ class ModelSession:
         """
         shape = shape(input_tensor) * scale + 2 * offset
         """
-        offset_by_name = {d.name: d.size for d in self.offset}
-        scale_by_name = {d.name: d.size for d in self.scale}
+        offsets = defaultdict(lambda: 0, {d.name: d.size for d in self.offset})
+        scales = defaultdict(lambda: 1.0, {d.name: d.size for d in self.scale})
 
         result = []
         # FIXME: currently we don't make use of having potentially multiple valid
@@ -94,8 +95,7 @@ class ModelSession:
             dim_size_by_name = {d.name: d.size for d in shape.dims}
             valid_shape = {}
             for dim in dim_size_by_name:
-                size = int(dim_size_by_name.get(dim, 1) * scale_by_name.get(dim, 1.0) + 2 * offset_by_name.get(dim, 0))
-                valid_shape[dim] = size
+                valid_shape[dim] = int(dim_size_by_name[dim] * scales[dim] + 2 * offsets[dim])
 
             result.append(valid_shape)
         return result[0]

--- a/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
+++ b/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
@@ -13,7 +13,26 @@ def pb_session():
             inference_pb2.NamedInt(name="x", size=256),
             inference_pb2.NamedInt(name="y", size=128),
             inference_pb2.NamedInt(name="c", size=1),
-        ]
+        ],
+        validShapes=[
+            inference_pb2.Shape(
+                dims=[
+                    inference_pb2.NamedInt(name="x", size=1024),
+                    inference_pb2.NamedInt(name="y", size=512),
+                    inference_pb2.NamedInt(name="c", size=1),
+                ]
+            ),
+        ],
+        scale=[
+            inference_pb2.NamedFloat(name="x", size=1),
+            inference_pb2.NamedFloat(name="y", size=0.5),
+            inference_pb2.NamedFloat(name="c", size=2),
+        ],
+        offset=[
+            inference_pb2.NamedInt(name="x", size=16),
+            inference_pb2.NamedInt(name="y", size=32),
+            inference_pb2.NamedInt(name="c", size=3),
+        ],
     )
 
 
@@ -28,3 +47,16 @@ def test_get_halo_returns_0_if_value_is_unspecified(pb_session):
     model_session = ModelSession(session=pb_session, factory=mock.Mock())
     assert model_session.get_halo(axes="xyz") == [256, 128, 0]
     assert model_session.get_halo(axes="txyz") == [0, 256, 128, 0]
+
+
+def test_get_output_shape(pb_session):
+    """shape = shape(input_tensor) * scale + 2 * offset"""
+    model_session = ModelSession(session=pb_session, factory=mock.Mock())
+
+    output_shape = model_session.get_output_shape()
+    assert output_shape == {"x": 1056, "y": 320, "c": 8}
+
+
+def test_known_classes(pb_session):
+    model_session = ModelSession(session=pb_session, factory=mock.Mock())
+    assert model_session.known_classes == list(range(1, 9))


### PR DESCRIPTION
Previously, the output shape was hard-coded. This breaks many networks ;).

Derive output shape from model information  returned by server.