### PR TITLE
Prevent Ctrl+A shortcut toggling 2d/3d state in feature table

### DIFF
--- a/ilastik/widgets/featureTableWidget.py
+++ b/ilastik/widgets/featureTableWidget.py
@@ -19,8 +19,16 @@
 #          http://ilastik.org/license.html
 ###############################################################################
 from past.utils import old_div
-from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QImage, QPainter, QPen, QPixmap, QPolygon
-from PyQt5.QtWidgets import QAbstractItemView, QHeaderView, QItemDelegate, QStyle, QTableWidget, QTableWidgetItem
+from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QImage, QPainter, QPen, QPixmap, QPolygon, QKeyEvent
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QHeaderView,
+    QItemDelegate,
+    QStyle,
+    QTableWidget,
+    QTableWidgetItem,
+    QTableWidgetSelectionRange,
+)
 from PyQt5.QtCore import QPoint, QRect, QSize, Qt
 
 
@@ -541,6 +549,22 @@ class FeatureTableWidget(QTableWidget):
     def mouseReleaseEvent(self, e):
         super().mouseReleaseEvent(e)
         self._resetSelection()
+
+    def _selectAllFeatures(self):
+        """
+        Selects all features without modifying the 2d/3d switches
+        """
+        # top (1st row 2d/3d, 2nd row sigma value), left, bottom, right
+        selection_range = QTableWidgetSelectionRange(2, 0, self.rowCount() - 1, self.columnCount() - 2)
+        self.setRangeSelected(selection_range, True)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        # Overrides default select all shortcut to avoid toggling 2d/3d state
+        is_select_all_shortcut = event.modifiers() == Qt.ControlModifier and event.key() == Qt.Key_A
+        if is_select_all_shortcut:
+            self._selectAllFeatures()
+        else:
+            super().keyPressEvent(event)
 
     def keyReleaseEvent(self, e):
         super().keyReleaseEvent(e)

--- a/tests/test_ilastik/widgets/test_featureTableWidget.py
+++ b/tests/test_ilastik/widgets/test_featureTableWidget.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+import pytest
+from PyQt5.QtCore import Qt
+
+from ilastik.widgets.featureTableWidget import FeatureTableWidget, FeatureEntry
+
+
+@pytest.fixture
+def widget(qtbot):
+    w = FeatureTableWidget(
+        None,
+        (
+            ("Color", [FeatureEntry("Banana", minimum_scale=0.3)]),
+            ("Edge", [FeatureEntry("Mango"), FeatureEntry("Cherry")]),
+        ),
+        [0.3, 0.7, 1, 1.6, 3.5, 5.0, 10.0],
+        computeIn2d=[True, False, True, True, True, False, False],
+    )
+    qtbot.addWidget(w)
+    w.show()
+
+    qtbot.waitForWindowShown(w)
+
+    return w
+
+
+def test_ctrl_a_shortcut_should_select_everything(qtbot, widget: FeatureTableWidget):
+    assert widget.featureMatrix == [
+        [False, False, False, False, False, False, False],
+        [False, False, False, False, False, False, False],
+        [False, False, False, False, False, False, False],
+    ]
+    assert widget.computeIn2d == [True, False, True, True, True, False, False]
+
+    qtbot.keyPress(widget, Qt.Key_A, Qt.ControlModifier)
+
+    assert widget.computeIn2d == [True, False, True, True, True, False, False]
+    assert widget.featureMatrix == [
+        [True, True, True, True, True, True, True],
+        [False, True, True, True, True, True, True],
+        [False, True, True, True, True, True, True],
+    ]


### PR DESCRIPTION
![out](https://user-images.githubusercontent.com/5163640/126045702-73b6ef50-fdc1-4357-b979-1cf6c59af382.gif)
