### PR TITLE
Fix notebook ex

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,16 @@ The following text equips you with knowledge that makes contributing to ilastik 
    gh repo clone ilastik
    ```
 
+1. Configure conda to use [strict channel priority](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority):
+
+   ```
+   conda config --set channel_priority strict
+   ```
+
 1. Install [conda-build][conda-build] in order to access the [conda develop][conda-develop] command:
 
    ```
-   conda install --name base conda-build
+   conda install --name base -c conda-forge conda-build
    ```
 
 1. Create a new environment and install dependencies:

--- a/notebooks/Readme.md
+++ b/notebooks/Readme.md
@@ -12,7 +12,7 @@ notebooks/
 ├── ...
 ```
 
-We use _conda_ to develop Python and recommend it for scientific Python development.
+We use _conda_ for Python-based projects and recommend it for scientific Python development.
 It is assumed that you have already installed _conda_ and are familiar with using a Terminal.
 
 In order to run the notebook type the following in a Terminal/Command Line:

--- a/notebooks/Readme.md
+++ b/notebooks/Readme.md
@@ -13,11 +13,17 @@ notebooks/
 ```
 
 We use _conda_ to develop Python and recommend it for scientific Python development.
-It is assumed that you have already installed it and are familiar with using a Terminal.
+It is assumed that you have already installed _conda_ and are familiar with using a Terminal.
 
 In order to run the notebook type the following in a Terminal/Command Line:
 
+Note: conda has to be configured with [_strict channel priority_](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority) in order to produce consistent environments.
+
+
 ```bash
+# make sure to use strict channel priority - this setting is global but in general a good idea
+conda config --set channel_priority strict
+
 $ conda env create -f environment.yml
 # this will produce a lot of output
 

--- a/notebooks/pixel_classification_api/Readme.md
+++ b/notebooks/pixel_classification_api/Readme.md
@@ -1,9 +1,4 @@
-### Prerequisites:
+Short notebook to demonstrate the ilastik pixel classification api with with a pre-trained project.
 
-In addition to creating the conda environment, you have to add the ilastik folder in development mode.
-This requires `conda-build` installed in your base environment (`conda install -n base -c conda-forge conda-build`).
+See [our notebook README](../Readme.md) for setup instructions.
 
-```bash
-# in .../ilastik-meta/ilastik
-conda develop .
-``` 

--- a/notebooks/pixel_classification_api/environment.yml
+++ b/notebooks/pixel_classification_api/environment.yml
@@ -4,5 +4,6 @@ channels:
   - conda-forge
 dependencies:
   - ilastik-dependencies-no-solvers
+  - ilastik-meta >=1.4.0b14
   - notebook
 # add additional packages to read/pre-process files here

--- a/notebooks/pixel_classification_api/pixel-classification-api.ipynb
+++ b/notebooks/pixel_classification_api/pixel-classification-api.ipynb
@@ -47,7 +47,7 @@
     "# load the image you would like to process and wrap it in an xarray.DataArray,\n",
     "# providing the appropriate dimension names\n",
     "image = DataArray(skimage.io.imread(\"2d_cells_apoptotic_1channel.png\"), dims=(\"y\", \"x\"))\n",
-    "prediction = pipeline.predict(data)\n",
+    "prediction = pipeline.predict(image)\n",
     "# show the foreground channel:\n",
     "skimage.io.imshow(prediction[..., 0])"
    ]


### PR DESCRIPTION
This (hopefully) fixes the notebook example by adding missing package and a note about strict channel priority.

Also added setting up conda with strict channel priority as a first setup step. It's not default yet, but I think we've been using it for so long, not realizing that this is something worth mentioning.
