### PR TITLE
Multicut fixes

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
@@ -24,6 +24,10 @@ from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot, 
 from ilastikrag import Rag
 from ilastikrag.util import dataframe_from_hdf5, dataframe_to_hdf5
 
+import logging
+
+logger = logging.getLogger(__file__)
+
 
 class SerialRagSlot(SerialSlot):
     def __init__(self, slot, cache, labels_slot):
@@ -158,6 +162,8 @@ class SerialCachedDataFrameSlot(SerialSlot):
 
 
 class EdgeTrainingSerializer(AppletSerializer):
+    version = "0.2"
+
     def __init__(self, operator, projectFileGroupName):
         slots = [
             SerialDictSlot(operator.FeatureNames),
@@ -169,4 +175,47 @@ class EdgeTrainingSerializer(AppletSerializer):
             SerialClassifierSlot(operator.opClassifierCache.Output, operator.opClassifierCache),
             SerialSlot(operator.TrainRandomForest),
         ]
-        super(EdgeTrainingSerializer, self).__init__(projectFileGroupName, slots=slots)
+        super().__init__(projectFileGroupName, slots=slots)
+
+    def _postprocess_0_1_import(self):
+        """
+        Due to a faulty slot connection from the watershed to the edgetraining applet
+        we have to set the edgeFeatureCache dirty so that it gets recomputed
+        if
+          * run in gui mode - in headless this is irrelevant, because:
+            * if a classifier was trained, the connections are correct,
+            * if there was no classifier involved (multicut on edge probabilties)
+              then previous lanes are not accessed
+          * serialized with version 0.1, and multiple lanes present
+        """
+        # Check if classifier was _not_ trained
+        try:
+            train_rf_serializer = self.serialSlots[
+                [isinstance(ss, SerialSlot) and ss.name == "TrainRandomForest" for ss in self.serialSlots].index(True)
+            ]
+            cached_dataframe_serializer = self.serialSlots[
+                [
+                    isinstance(ss, SerialCachedDataFrameSlot) and ss.name == "EdgeFeatures" for ss in self.serialSlots
+                ].index(True)
+            ]
+        except ValueError:
+            return
+
+        train_rf = train_rf_serializer.inslot.value
+
+        if train_rf:
+            return
+
+        if len(cached_dataframe_serializer.cache) < 2:
+            return
+
+        logger.info("Old project file detected. Clearing edge feature caches.")
+
+        for i in range(len(cached_dataframe_serializer.cache)):
+            cacheop = cached_dataframe_serializer.cache.getLane(i)
+            cacheop.resetValue()
+
+    def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
+        """Post-process slot deserialization"""
+        if groupVersion == "0.1" and not headless:
+            self._postprocess_0_1_import()

--- a/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
@@ -91,7 +91,7 @@ class SerialEdgeLabelsDictSlot(SerialSlot):
         for lane_index, (_dict_groupname, dict_group) in enumerate(sorted(multislot_group.items())):
             sp_ids = dict_group["sp_ids"][:, :]
             labels = dict_group["labels"][:]
-            edge_labels_dict = dict(list(zip(list(map(tuple, sp_ids)), labels)))
+            edge_labels_dict = dict(zip(map(tuple, sp_ids), labels))
             slot[lane_index].setValue(edge_labels_dict)
 
 

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -28,11 +28,11 @@ class OpEdgeTraining(Operator):
     FeatureNames = InputSlot(value=DEFAULT_FEATURES)
     FreezeClassifier = InputSlot(value=True)
     TrainRandomForest = InputSlot(value=False)
-    WatershedSelectedInput = InputSlot()
 
     # Lane-wise
+    WatershedSelectedInput = InputSlot(level=1)
     EdgeLabelsDict = InputSlot(level=1, value={})
-    VoxelData = InputSlot(level=1)
+    VoxelData = InputSlot(level=1)  # stacked input with edge probabilities
     Superpixels = InputSlot(level=1)
     GroundtruthSegmentation = InputSlot(level=1, optional=True)
     RawData = InputSlot(level=1, optional=True)  # Used by the GUI for display only

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -53,7 +53,7 @@ class OpEdgeTraining(Operator):
         self.opRagCache.name = "opRagCache"
 
         self.opComputeEdgeFeatures = OpMultiLaneWrapper(
-            OpComputeEdgeFeatures, parent=self, broadcastingSlotNames=["FeatureNames"]
+            OpComputeEdgeFeatures, parent=self, broadcastingSlotNames=["FeatureNames", "TrainRandomForest"]
         )
         self.opComputeEdgeFeatures.FeatureNames.connect(self.FeatureNames)
         self.opComputeEdgeFeatures.VoxelData.connect(self.VoxelData)
@@ -76,7 +76,7 @@ class OpEdgeTraining(Operator):
         self.opClassifierCache.name = "opClassifierCache"
 
         self.opPredictEdgeProbabilities = OpMultiLaneWrapper(
-            OpPredictEdgeProbabilities, parent=self, broadcastingSlotNames=["EdgeClassifier"]
+            OpPredictEdgeProbabilities, parent=self, broadcastingSlotNames=["EdgeClassifier", "TrainRandomForest"]
         )
         self.opPredictEdgeProbabilities.EdgeClassifier.connect(self.opClassifierCache.Output)
         self.opPredictEdgeProbabilities.EdgeFeaturesDataFrame.connect(self.opEdgeFeaturesCache.Output)

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -61,7 +61,7 @@ class OpEdgeTrainingWithMulticut(Operator):
         self.NaiveSegmentation.connect(opEdgeTraining.NaiveSegmentation)
 
         opMulticut = OpMultiLaneWrapper(
-            OpMulticut, broadcastingSlotNames=["Beta", "SolverName", "FreezeCache"], parent=self
+            OpMulticut, broadcastingSlotNames=["Beta", "SolverName", "FreezeCache", "ProbabilityThreshold"], parent=self
         )
         opMulticut.Beta.connect(self.Beta)
         opMulticut.SolverName.connect(self.SolverName)

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -17,7 +17,7 @@ class OpEdgeTrainingWithMulticut(Operator):
     Beta = InputSlot(value=0.5)
     SolverName = InputSlot(value=DEFAULT_SOLVER_NAME)  # See opMulticut.py for list of solvers
     FreezeCache = InputSlot(value=True)
-    WatershedSelectedInput = InputSlot()
+    WatershedSelectedInput = InputSlot(level=1)
 
     # Lane-wise input slots
     RawData = InputSlot(level=1, optional=True)  # Used by the GUI for display only

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -186,6 +186,9 @@ class Operator(metaclass=OperatorMetaClass):
     description = ""
     category = "lazyflow"
 
+    inputs: InputDict
+    outputs: OutputDict
+
     @property
     def transaction(self):
         """

--- a/lazyflow/utility/testing.py
+++ b/lazyflow/utility/testing.py
@@ -194,14 +194,14 @@ def build_multi_output_mock_op(slot_data: SLOT_DATA, graph: Graph, n_lanes: int 
             pass
 
         def execute(self, slot, subindex, roi, result):
-            raise NotImplementedError("Data access for this mock operator not implemented yet.")
             if self._data[slot.name].data is None:
                 raise RuntimeError(f"Slot {slot.name} should not be accessed")
             key = roi.toSlice()
             if slot.level == 0:
                 result[...] = self._data[slot.name].data[key]
             elif slot.level == 1:
-                result[...] = self._data[slot.name].data[subindex][key]
+                assert len(subindex) == 1
+                result[...] = self._data[slot.name].data[subindex[0]][key]
 
     assert all(slot_descr.level in [0, 1] for slot_descr in slot_data.values())
 

--- a/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
+++ b/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
@@ -1,0 +1,104 @@
+import h5py
+import numpy
+import pandas
+import pytest
+
+from ilastikrag import Rag
+from ilastik.applets.edgeTraining import OpEdgeTraining
+from lazyflow.utility.testing import build_multi_output_mock_op, SlotDescription
+from ilastik.applets.edgeTraining.edgeTrainingSerializer import EdgeTrainingSerializer
+import vigra
+
+
+@pytest.fixture
+def empty_project_file():
+    with h5py.File("test_project1", mode="a", driver="core", backing_store=False) as test_project:
+        test_project.create_dataset("ilastikVersion", data=b"1.0.0")
+        yield test_project
+
+
+@pytest.fixture
+def superpixels():
+    # superpixels needed for creation and deserialization of the rag
+    data = numpy.zeros((5, 6, 1), dtype="uint32")
+    data[0:2, ...] = 1
+    data[2:, ...] = 2
+    return data
+
+
+@pytest.fixture
+def rag(superpixels):
+    return Rag(vigra.taggedView(superpixels, axistags="yxc").withAxes("yx"))
+
+
+@pytest.fixture
+def inputs(graph, superpixels):
+    slot_data = {
+        "WatershedSelectedInput": SlotDescription(
+            level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags=vigra.defaultAxistags("yxc")
+        ),
+        "VoxelData": SlotDescription(
+            level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags=vigra.defaultAxistags("yxc")
+        ),
+        "Superpixels": SlotDescription(
+            level=1,
+            dtype=numpy.uint32,
+            shape=(5, 6, 1),
+            axistags=vigra.defaultAxistags("yxc"),
+            data=[superpixels, superpixels],
+        ),
+    }
+    return build_multi_output_mock_op(slot_data, graph, n_lanes=2)
+
+
+def test_serializer_roundtrip(graph, inputs, empty_project_file, superpixels, rag):
+    op = OpEdgeTraining(graph=graph)
+    op.VoxelData.connect(inputs.VoxelData)
+    op.Superpixels.connect(inputs.Superpixels)
+    op.WatershedSelectedInput.connect(inputs.WatershedSelectedInput)
+
+    # set level0 slots
+    op.TrainRandomForest.setValue(False)
+    op.FeatureNames.setValue({"test0": [b"test_feature_0", b"test_feature_1"]})
+
+    # set level1 slots
+    laneop = op.getLane(0)
+    edge_features_reference = pandas.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    laneop.opEdgeFeaturesCache.forceValue(edge_features_reference, set_dirty=False)
+
+    edge_labels_reference = {(0, 1): 0, (0, 2): 1, (1, 2): 0}
+    laneop.EdgeLabelsDict.setValue(edge_labels_reference)
+
+    laneop.opRagCache.forceValue(rag, set_dirty=False)
+
+    serializer = EdgeTrainingSerializer(op, "EdgeTraining")
+    serializer.serializeToHdf5(empty_project_file, empty_project_file.name)
+
+    # round trip
+    op_load = OpEdgeTraining(graph=graph)
+
+    op_load.VoxelData.connect(inputs.VoxelData)
+    op_load.Superpixels.connect(inputs.Superpixels)
+    op_load.WatershedSelectedInput.connect(inputs.WatershedSelectedInput)
+
+    deserializer = EdgeTrainingSerializer(op_load, "EdgeTraining")
+    deserializer.deserializeFromHdf5(empty_project_file, empty_project_file.name)
+
+    # check level0 slots
+    assert op_load.TrainRandomForest.value == False
+    assert all(a == b for a, b in zip(op_load.FeatureNames.value["test0"], [b"test_feature_0", b"test_feature_1"]))
+
+    # check level1 slots
+    # empty lane
+    op_load_lane1 = op_load.getLane(1)
+    assert op_load_lane1.EdgeLabelsDict.value == {}
+    assert op_load_lane1.opEdgeFeaturesCache._value is None
+
+    # lane w content
+    op_load_lane0 = op_load.getLane(0)
+    edge_features_loaded = op_load_lane0.opEdgeFeaturesCache.Output.value
+    assert edge_features_loaded.equals(edge_features_reference)
+
+    assert op_load_lane0.EdgeLabelsDict.value == edge_labels_reference
+
+    loaded_rag = op_load_lane0.opRagCache.Output.value

--- a/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
+++ b/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
@@ -2,17 +2,17 @@ import h5py
 import numpy
 import pandas
 import pytest
-
-from ilastikrag import Rag
-from ilastik.applets.edgeTraining import OpEdgeTraining
-from lazyflow.utility.testing import build_multi_output_mock_op, SlotDescription
-from ilastik.applets.edgeTraining.edgeTrainingSerializer import EdgeTrainingSerializer
 import vigra
+from ilastikrag import Rag
+
+from ilastik.applets.edgeTraining import OpEdgeTraining
+from ilastik.applets.edgeTraining.edgeTrainingSerializer import EdgeTrainingSerializer
+from lazyflow.utility.testing import SlotDesc, build_multi_output_mock_op
 
 
 @pytest.fixture
 def empty_project_file():
-    with h5py.File("test_project1", mode="a", driver="core", backing_store=False) as test_project:
+    with h5py.File("test_project1.ilp", mode="a", driver="core", backing_store=False) as test_project:
         test_project.create_dataset("ilastikVersion", data=b"1.0.0")
         yield test_project
 
@@ -34,17 +34,13 @@ def rag(superpixels):
 @pytest.fixture
 def inputs(graph, superpixels):
     slot_data = {
-        "WatershedSelectedInput": SlotDescription(
-            level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags=vigra.defaultAxistags("yxc")
-        ),
-        "VoxelData": SlotDescription(
-            level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags=vigra.defaultAxistags("yxc")
-        ),
-        "Superpixels": SlotDescription(
+        "WatershedSelectedInput": SlotDesc(level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags="yxc"),
+        "VoxelData": SlotDesc(level=1, dtype=numpy.float32, shape=(5, 6, 1), axistags="yxc"),
+        "Superpixels": SlotDesc(
             level=1,
             dtype=numpy.uint32,
             shape=(5, 6, 1),
-            axistags=vigra.defaultAxistags("yxc"),
+            axistags="yxc",
             data=[superpixels, superpixels],
         ),
     }

--- a/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
+++ b/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
@@ -1,0 +1,81 @@
+from lazyflow.utility.testing import build_multi_output_mock_op, SlotDescription
+from lazyflow.graph import Operator, OutputSlot
+import numpy
+import pytest
+import vigra
+
+
+def test_empty(graph):
+    op = build_multi_output_mock_op(dict(), graph)
+
+    assert isinstance(op, Operator)
+    assert len(op.inputs) == 0
+    assert len(op.outputs) == 0
+
+
+def test_single_default_slot(graph):
+    op = build_multi_output_mock_op({"Output": SlotDescription()}, graph)
+
+    assert len(op.inputs) == 0
+    assert len(op.outputs) == 1
+    assert isinstance(op.Output, OutputSlot)
+    assert op.Output.ready()
+    assert op.Output.level == 0
+
+
+def test_multiple_default_slots(graph):
+    op = build_multi_output_mock_op({"Output0": SlotDescription(), "Output1": SlotDescription()}, graph)
+
+    assert len(op.inputs) == 0
+    assert len(op.outputs) == 2
+    assert op.Output0.ready()
+    assert op.Output1.ready()
+    assert op.Output0.level == 0
+    assert op.Output1.level == 0
+    assert op.Output0 != op.Output1
+
+
+def test_multi_lane_slot(graph):
+    op = build_multi_output_mock_op({"Output": SlotDescription(level=1)}, graph)
+
+    assert op.Output.level == 1
+
+
+def test_multi_lane_slot_w_lanes(graph):
+    op = build_multi_output_mock_op({"Output": SlotDescription(level=1)}, graph, n_lanes=42)
+
+    assert op.Output.level == 1
+    assert len(op.Output) == 42
+    assert all(subslot.ready() for subslot in op.Output)
+
+
+def test_all_meta_w_lanes(graph):
+    op = build_multi_output_mock_op(
+        {
+            "Lvl0": SlotDescription(level=0, shape=(10, 42), axistags=vigra.defaultAxistags("xy"), dtype=numpy.uint8),
+            "Lvl1": SlotDescription(
+                level=1, shape=(10, 42, 100), axistags=vigra.defaultAxistags("xyz"), dtype=numpy.float32
+            ),
+        },
+        graph,
+        n_lanes=12,
+    )
+
+    assert op.Lvl0.level == 0
+    assert op.Lvl1.level == 1
+
+    assert op.Lvl0.ready()
+    assert all(subslot.ready() for subslot in op.Lvl1)
+
+    assert op.Lvl0.meta.shape == (10, 42)
+    assert all(subslot.meta.shape == (10, 42, 100) for subslot in op.Lvl1)
+
+    assert op.Lvl0.meta.getAxisKeys() == ["x", "y"]
+    assert all(subslot.meta.getAxisKeys() == ["x", "y", "z"] for subslot in op.Lvl1)
+
+
+@pytest.mark.xfail
+def test_data_access_lvl0(graph):
+    op = build_multi_output_mock_op({"Output": SlotDescription(data=numpy.array([42]))}, graph)
+
+    assert op.Output.value

--- a/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
+++ b/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
@@ -1,8 +1,6 @@
-from lazyflow.utility.testing import build_multi_output_mock_op, SlotDescription
+from lazyflow.utility.testing import build_multi_output_mock_op, SlotDesc
 from lazyflow.graph import Operator, OutputSlot
 import numpy
-import pytest
-import vigra
 
 
 def test_empty(graph):
@@ -14,7 +12,7 @@ def test_empty(graph):
 
 
 def test_single_default_slot(graph):
-    op = build_multi_output_mock_op({"Output": SlotDescription()}, graph)
+    op = build_multi_output_mock_op({"Output": SlotDesc()}, graph)
 
     assert len(op.inputs) == 0
     assert len(op.outputs) == 1
@@ -24,7 +22,7 @@ def test_single_default_slot(graph):
 
 
 def test_multiple_default_slots(graph):
-    op = build_multi_output_mock_op({"Output0": SlotDescription(), "Output1": SlotDescription()}, graph)
+    op = build_multi_output_mock_op({"Output0": SlotDesc(), "Output1": SlotDesc()}, graph)
 
     assert len(op.inputs) == 0
     assert len(op.outputs) == 2
@@ -36,13 +34,13 @@ def test_multiple_default_slots(graph):
 
 
 def test_multi_lane_slot(graph):
-    op = build_multi_output_mock_op({"Output": SlotDescription(level=1)}, graph)
+    op = build_multi_output_mock_op({"Output": SlotDesc(level=1)}, graph)
 
     assert op.Output.level == 1
 
 
 def test_multi_lane_slot_w_lanes(graph):
-    op = build_multi_output_mock_op({"Output": SlotDescription(level=1)}, graph, n_lanes=42)
+    op = build_multi_output_mock_op({"Output": SlotDesc(level=1)}, graph, n_lanes=42)
 
     assert op.Output.level == 1
     assert len(op.Output) == 42
@@ -52,10 +50,8 @@ def test_multi_lane_slot_w_lanes(graph):
 def test_all_meta_w_lanes(graph):
     op = build_multi_output_mock_op(
         {
-            "Lvl0": SlotDescription(level=0, shape=(10, 42), axistags=vigra.defaultAxistags("xy"), dtype=numpy.uint8),
-            "Lvl1": SlotDescription(
-                level=1, shape=(10, 42, 100), axistags=vigra.defaultAxistags("xyz"), dtype=numpy.float32
-            ),
+            "Lvl0": SlotDesc(level=0, shape=(10, 42), axistags="xy", dtype=numpy.uint8),
+            "Lvl1": SlotDesc(level=1, shape=(10, 42, 100), axistags="xyz", dtype=numpy.float32),
         },
         graph,
         n_lanes=12,
@@ -75,6 +71,6 @@ def test_all_meta_w_lanes(graph):
 
 
 def test_data_access_lvl0(graph):
-    op = build_multi_output_mock_op({"Output": SlotDescription(data=numpy.array([42]))}, graph)
+    op = build_multi_output_mock_op({"Output": SlotDesc(data=numpy.array([42]))}, graph)
 
     assert op.Output.value == 42

--- a/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
+++ b/tests/test_lazyflow/test_operators/testMultiOutputMockOperator.py
@@ -74,8 +74,7 @@ def test_all_meta_w_lanes(graph):
     assert all(subslot.meta.getAxisKeys() == ["x", "y", "z"] for subslot in op.Lvl1)
 
 
-@pytest.mark.xfail
 def test_data_access_lvl0(graph):
     op = build_multi_output_mock_op({"Output": SlotDescription(data=numpy.array([42]))}, graph)
 
-    assert op.Output.value
+    assert op.Output.value == 42


### PR DESCRIPTION
Summary:
* use correct data to compute features on when _not_ training a random forest. Due to a faulty connection it would always use the probability map from the last lane.
* fixed some more level0 slot to level1 slot connection by adding appropriate broadcasting slots to wrappers.
* added a utility method `build_multi_output_mock_op` to produce a "mock" predecessor for top level operators, such that all their inputs can be made ready
* added test for `EdgeTrainingSerializer`
* added a "migration" procedure for "old" multilane projects that use the predictions directly as weights in the multicut

Comments very welcome, @emilmelnikov @Tomaz-Vieira 