### PR TITLE
initialize all object classification gui lanes once accessed the first time

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationApplet.py
+++ b/ilastik/applets/objectClassification/objectClassificationApplet.py
@@ -54,9 +54,10 @@ class ObjectClassificationApplet(StandardApplet):
 
         multi_lane_gui = super(ObjectClassificationApplet, self).getMultiLaneGui()
         guis = multi_lane_gui.getGuis()
-        if len(guis) > 0 and isinstance(guis[0], ObjectClassificationGui) and not guis[0].isInitialized:
-            guis[0].selectLabel(0)
-            guis[0].isInitialized = True
+        for gui in guis:
+            if isinstance(gui, ObjectClassificationGui) and not gui.isInitialized:
+                gui.selectLabel(0)
+                gui.isInitialized = True
         return multi_lane_gui
 
     @property


### PR DESCRIPTION
The gui would only be properly initialized for the first lane, now this is done for every lane. As a result, ilastik would be in brush mode, not in object annotation mode.

fixes https://github.com/ilastik/ilastik/issues/2470
fixes https://github.com/ilastik/ilastik/issues/1921