### PR TITLE
fix dnd behavior on secondary roles

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -66,7 +66,7 @@ from lazyflow.slot import Slot
 
 
 class LocationOptions(object):
-    """ Enum for location menu options """
+    """Enum for location menu options"""
 
     Project = 0
     AbsolutePath = 1
@@ -415,11 +415,17 @@ class DataSelectionGui(QWidget):
 
     def addFileNames(self, paths: List[Path], startingLaneNum: int, roleIndex: int):
         # If the user didn't cancel
-        for path in paths or []:
+        # we iterate through every path and add it. now bulk addition.
+        for index, path in enumerate(paths or []):
             try:
+                # startlingLaneNum = -1 if dragged onto the empty table
+                if startingLaneNum is not None and startingLaneNum >= 0:
+                    lane_index = startingLaneNum + index
+                else:
+                    lane_index = startingLaneNum
                 full_path = self._get_dataset_full_path(path, roleIndex=roleIndex)
                 info = self.instantiate_dataset_info(url=str(full_path), role=roleIndex)
-                self.addLanes([info], roleIndex=roleIndex, startingLaneNum=startingLaneNum)
+                self.addLanes([info], roleIndex=roleIndex, startingLaneNum=lane_index)
             except DataSelectionGui.UserCancelledError:
                 pass
             except Exception as ex:

--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -28,6 +28,7 @@ from vigra import AxisTags
 import threading
 import h5py
 from functools import partial
+import itertools
 import logging
 
 logger = logging.getLogger(__name__)
@@ -413,16 +414,18 @@ class DataSelectionGui(QWidget):
         paths = ImageFileDialog(self).getSelectedPaths()
         self.addFileNames(paths, startingLaneNum, roleIndex)
 
-    def addFileNames(self, paths: List[Path], startingLaneNum: int, roleIndex: int):
-        # If the user didn't cancel
-        # we iterate through every path and add it. now bulk addition.
-        for index, path in enumerate(paths or []):
+    def addFileNames(self, paths: Optional[List[Path]], startingLaneNum: Optional[int], roleIndex: int):
+        if paths is None:
+            paths = []
+
+        # startlingLaneNum == -1 if dragged onto the empty table.
+        if startingLaneNum is not None and startingLaneNum >= 0:
+            lane_indices = itertools.count(startingLaneNum)
+        else:
+            lane_indices = itertools.repeat(startingLaneNum)
+
+        for path, lane_index in zip(paths, lane_indices):
             try:
-                # startlingLaneNum = -1 if dragged onto the empty table
-                if startingLaneNum is not None and startingLaneNum >= 0:
-                    lane_index = startingLaneNum + index
-                else:
-                    lane_index = startingLaneNum
                 full_path = self._get_dataset_full_path(path, roleIndex=roleIndex)
                 info = self.instantiate_dataset_info(url=str(full_path), role=roleIndex)
                 self.addLanes([info], roleIndex=roleIndex, startingLaneNum=lane_index)


### PR DESCRIPTION
in the past it was possible to drag n drop files into all roles.

Reason for loss of this functionality was that the startingLaneNum would not be
would not be incremented.

Now we increment this with each file path.

fixes: https://github.com/ilastik/ilastik/issues/2472