### PR TITLE
removed deprecated Iterable from collections

### DIFF
--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -23,6 +23,7 @@ from __future__ import division
 from builtins import range
 from copy import copy, deepcopy
 import collections
+from collections.abc import Iterable
 from functools import partial
 
 # SciPy
@@ -76,7 +77,7 @@ def max_margin(d, default=(0, 0, 0)):
         for params in features.values():
             try:
                 pmargin = params["margin"]
-                if not isinstance(pmargin, collections.Iterable):
+                if not isinstance(pmargin, Iterable):
                     pmargin = len(default) * [pmargin]
                 margin = [max(x) for x in zip(margin, pmargin)]
             except (ValueError, KeyError):

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Iterable
 import numpy as np
 import numpy.lib.recfunctions as nlr
 import h5py
@@ -208,7 +208,7 @@ def prepare_list(list_, names, dtypes=None):
         return np.array(())
     # make sure inner items are iterables
     first_row = list_[0]
-    if isinstance(first_row, str) or not isinstance(first_row, collections.Iterable):
+    if isinstance(first_row, str) or not isinstance(first_row, Iterable):
         list_ = [(x,) for x in list_]
         first_row = list_[0]
 
@@ -223,7 +223,7 @@ def prepare_list(list_, names, dtypes=None):
                 col_dtype = (col_name, item_dtype, maxlen)
             dtypes.append(col_dtype)
 
-    assert isinstance(dtypes, collections.Iterable)
+    assert isinstance(dtypes, Iterable)
     assert len(first_row) == len(dtypes)
     array = np.zeros((n_items,), dtype=dtypes)
     array[:] = list_

--- a/lazyflow/roi.py
+++ b/lazyflow/roi.py
@@ -20,7 +20,7 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 
-import collections
+from collections.abc import Iterable
 import numbers
 from functools import partial
 from itertools import combinations
@@ -55,7 +55,7 @@ class TinyVector(list):
         return TinyVector(self)
 
     def __add__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x + y for x, y in zip(self, other))
         else:
             return TinyVector(x + other for x in self)
@@ -65,7 +65,7 @@ class TinyVector(list):
     def __iadd__(self, other):
         # Must explicitly override list.__iadd__
         # Others (e.g. isub, imul) can use default implementation.
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             self = TinyVector(x + y for x, y in zip(self, other))
             return self
         else:
@@ -73,19 +73,19 @@ class TinyVector(list):
             return self
 
     def __sub__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x - y for x, y in zip(self, other))
         else:
             return TinyVector(x - other for x in self)
 
     def __rsub__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(y - x for x, y in zip(self, other))
         else:
             return TinyVector(other - x for x in self)
 
     def __mul__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x * y for x, y in zip(self, other))
         else:
             return TinyVector(x * other for x in self)
@@ -93,91 +93,91 @@ class TinyVector(list):
     __rmul__ = __mul__
 
     def __div__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x / y for x, y in zip(self, other))
         else:
             return TinyVector(x / other for x in self)
 
     def __rdiv__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector((y / x) for x, y in zip(self, other))
         else:
             return TinyVector((other / x) for x in self)
 
     def __truediv__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x / y for x, y in zip(self, other))
         else:
             return TinyVector(x / other for x in self)
 
     def __rtruediv__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(y / x for x, y in zip(self, other))
         else:
             return TinyVector(other / x for x in self)
 
     def __mod__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x % y for x, y in zip(self, other))
         else:
             return TinyVector(x % other for x in self)
 
     def __rmod__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(y % x for x, y in zip(self, other))
         else:
             return TinyVector(other % x for x in self)
 
     def __floordiv__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x // y for x, y in zip(self, other))
         else:
             return TinyVector(x // other for x in self)
 
     def __rfloordiv__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(y // x for x, y in zip(self, other))
         else:
             return TinyVector(other // x for x in self)
 
     def __eq__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x == y for x, y in zip(self, other))
         else:
             return TinyVector(x == other for x in self)
 
     def __ne__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x != y for x, y in zip(self, other))
         else:
             return TinyVector(x != other for x in self)
 
     def __ge__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x >= y for x, y in zip(self, other))
         else:
             return TinyVector(x >= other for x in self)
 
     def __le__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x <= y for x, y in zip(self, other))
         else:
             return TinyVector(x <= other for x in self)
 
     def __gt__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x > y for x, y in zip(self, other))
         else:
             return TinyVector(x > other for x in self)
 
     def __lt__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x < y for x, y in zip(self, other))
         else:
             return TinyVector(x < other for x in self)
 
     def __and__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x & y for x, y in zip(self, other))
         else:
             return TinyVector(x & other for x in self)
@@ -185,7 +185,7 @@ class TinyVector(list):
     __rand__ = __and__
 
     def __or__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x | y for x, y in zip(self, other))
         else:
             return TinyVector(x | other for x in self)
@@ -193,7 +193,7 @@ class TinyVector(list):
     __ror__ = __or__
 
     def __xor__(self, other):
-        if isinstance(other, collections.Iterable):
+        if isinstance(other, Iterable):
             return TinyVector(x ^ y for x, y in zip(self, other))
         else:
             return TinyVector(x ^ other for x in self)
@@ -532,9 +532,9 @@ def enlargeRoiForHalo(start, stop, shape, sigma, window=3.5, enlarge_axes=None, 
     spatial_start = enlarge_axes * start
     spatial_stop = enlarge_axes * stop
 
-    if isinstance(sigma, collections.Iterable):
+    if isinstance(sigma, Iterable):
         sigma = TinyVector(sigma)
-    if isinstance(start, collections.Iterable):
+    if isinstance(start, Iterable):
         ret_type = type(start[0])
     else:
         ret_type = type(start)

--- a/lazyflow/rtype.py
+++ b/lazyflow/rtype.py
@@ -30,7 +30,7 @@ from builtins import object
 ###############################################################################
 import numpy, copy
 import pickle as pickle
-import collections
+from collections.abc import Iterable
 import sys
 
 from lazyflow.roi import TinyVector, sliceToRoi, roiToSlice, roiFromShape
@@ -235,7 +235,7 @@ class SubRegion(Roi):
         if tIndex is not None:
             tStart = self.start[tIndex]
             tStop = self.stop[tIndex]
-        if isinstance(shape, collections.Iterable):
+        if isinstance(shape, Iterable):
             # add a dummy number for the channel dimension
             shape = shape + (1,)
         else:


### PR DESCRIPTION
collections.Iterable -> collections.abc.Iterable (since Python 3.3, deprecated in 3.9)

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
