### PR TITLE
[mnt, ci] remove defaults channel from envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             cd ${ILASTIK_ROOT}/ilastik-meta &&
             python ilastik/scripts/devenv.py create --name ${TEST_ENV_NAME}
             --channel pytorch
-            --channel ilastik-forge --channel conda-forge --channel defaults
+            --channel ilastik-forge --channel conda-forge
             ilastik-dependencies-no-solvers pytorch cpuonly pre-commit mpi4py pytest-cov
     - run:
         name: run ilastik tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   # Point to the current ilastik-meta
   - >
     python ilastik/scripts/devenv.py create --name %ENV_NAME%
-    --channel pytorch --channel ilastik-forge --channel conda-forge --channel defaults
+    --channel pytorch --channel ilastik-forge --channel conda-forge
     ilastik-dependencies-no-solvers pytorch cpuonly pre-commit
   - conda clean -p
 


### PR DESCRIPTION
removed default channels from test environment. This resets build cache on circleci.