### PR TITLE
Fix ram estimation, prepare numpy upgrade

### DIFF
--- a/lazyflow/metaDict.py
+++ b/lazyflow/metaDict.py
@@ -23,7 +23,8 @@ from builtins import zip
 ###############################################################################
 # Python
 import copy
-import numpy
+import warnings
+
 from collections import OrderedDict, defaultdict
 from ndstructs import Shape5D
 
@@ -190,12 +191,13 @@ class MetaDict(defaultdict):
         """
         For numpy dtypes only, return the size of the dtype in bytes.
         """
-        dtype = self.dtype
-        if isinstance(dtype, numpy.dtype):
-            # Make sure we're dealing with a type (e.g. numpy.float64),
-            #  not a numpy.dtype
-            dtype = dtype.type
-        return dtype().nbytes
+        warnings.warn(
+            "getDtypeBytes was deprecated, please use lazyflow.utility.helpers.get_ram_per_element instead",
+            DeprecationWarning,
+        )
+        from lazyflow.utility.helpers import get_ram_per_element
+
+        return get_ram_per_element(self.dtype)
 
     def __str__(self):
         """

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -227,11 +227,11 @@ class OpInputDataReader(Operator):
         self.opInjector.Input.connect(self.internalOutput)
 
         # Add metadata for estimated RAM usage if the internal operator didn't already provide it.
-        if self.internalOutput.meta.ram_per_pixelram_usage_per_requested_pixel is None:
+        if self.internalOutput.meta.ram_usage_per_requested_pixel is None:
             ram_per_pixel = self.internalOutput.meta.dtype().nbytes
             if "c" in self.internalOutput.meta.getTaggedShape():
                 ram_per_pixel *= self.internalOutput.meta.getTaggedShape()["c"]
-            self.opInjector.Metadata.setValue({"ram_per_pixelram_usage_per_requested_pixel": ram_per_pixel})
+            self.opInjector.Metadata.setValue({"ram_usage_per_requested_pixel": ram_per_pixel})
         else:
             # Nothing to add
             self.opInjector.Metadata.setValue({})

--- a/lazyflow/operators/opSimpleBlockedArrayCache.py
+++ b/lazyflow/operators/opSimpleBlockedArrayCache.py
@@ -8,6 +8,7 @@ from .opUnblockedArrayCache import OpUnblockedArrayCache
 from lazyflow.request import Request, RequestPool
 from lazyflow.roi import getIntersectingRois, roiToSlice
 from lazyflow.rtype import SubRegion
+from lazyflow.utility.helpers import get_ram_per_element
 
 
 class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
@@ -37,11 +38,7 @@ class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
         self.Output.meta.ideal_blockshape = tuple(numpy.minimum(self._blockshape, self.Input.meta.shape))
 
         # Estimate ram usage per requested pixel
-        ram_per_pixel = 0
-        if self.Input.meta.dtype == object or self.Input.meta.dtype == numpy.object_:
-            ram_per_pixel = sys.getsizeof(None)
-        elif numpy.issubdtype(self.Input.meta.dtype, numpy.dtype):
-            ram_per_pixel = self.Input.meta.dtype().nbytes
+        ram_per_pixel = get_ram_per_element(self.Input.meta.dtype)
 
         # One 'pixel' includes all channels
         tagged_shape = self.Input.meta.getTaggedShape()

--- a/lazyflow/operators/opSlicedBlockedArrayCache.py
+++ b/lazyflow/operators/opSlicedBlockedArrayCache.py
@@ -35,6 +35,7 @@ from lazyflow.operators.opBlockedArrayCache import OpBlockedArrayCache
 from lazyflow.roi import sliceToRoi
 from lazyflow.operators.opCache import MemInfoNode
 from lazyflow.operators.opCache import ObservableCache
+from lazyflow.utility.helpers import get_ram_per_element
 
 
 class OpSlicedBlockedArrayCache(Operator, ObservableCache):
@@ -135,11 +136,7 @@ class OpSlicedBlockedArrayCache(Operator, ObservableCache):
         self.Output.meta.assignFrom(self.Input.meta)
 
         # Estimate ram usage
-        ram_per_pixel = 0
-        if self.Output.meta.dtype == object or self.Output.meta.dtype == numpy.object_:
-            ram_per_pixel = sys.getsizeof(None)
-        elif numpy.issubdtype(self.Output.meta.dtype, numpy.dtype):
-            ram_per_pixel = self.Output.meta.dtype().nbytes
+        ram_per_pixel = get_ram_per_element(self.Output.meta.dtype)
 
         tagged_shape = self.Output.meta.getTaggedShape()
         if "c" in tagged_shape:

--- a/lazyflow/operators/opSplitRequestsBlockwise.py
+++ b/lazyflow/operators/opSplitRequestsBlockwise.py
@@ -1,5 +1,3 @@
-from builtins import zip
-
 ###############################################################################
 #   lazyflow: data flow based lazy parallel computation framework
 #
@@ -22,13 +20,13 @@ from builtins import zip
 #          http://ilastik.org/license/
 ###############################################################################
 
-import sys
 import numpy
 from functools import partial
 
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.roi import getIntersectingRois, roiToSlice
 from lazyflow.request import RequestPool
+from lazyflow.utility.helpers import get_ram_per_element
 
 
 class OpSplitRequestsBlockwise(Operator):
@@ -65,11 +63,7 @@ class OpSplitRequestsBlockwise(Operator):
         self.Output.meta.ideal_blockshape = tuple(numpy.minimum(self.BlockShape.value, self.Input.meta.shape))
 
         # Estimate ram usage per requested pixel
-        ram_per_pixel = 0
-        if self.Input.meta.dtype == object or self.Input.meta.dtype == numpy.object_:
-            ram_per_pixel = sys.getsizeof(None)
-        elif numpy.issubdtype(self.Input.meta.dtype, numpy.dtype):
-            ram_per_pixel = self.Input.meta.dtype().nbytes
+        ram_per_pixel = get_ram_per_element(self.Input.meta.dtype)
 
         # One 'pixel' includes all channels
         tagged_shape = self.Input.meta.getTaggedShape()

--- a/tests/test_lazyflow/test_operators/testCacheMemoryManager.py
+++ b/tests/test_lazyflow/test_operators/testCacheMemoryManager.py
@@ -248,7 +248,6 @@ class TestCacheMemoryManager:
         split = OpSplitRequestsBlockwise(True, graph=g)
         split.BlockShape.setValue(blockshape)
         split.Input.connect(op.Output)
-
         streamer = BigRequestStreamer(split.Output, [(0,) * len(shape), shape])
         streamer.execute()
 


### PR DESCRIPTION
numpy deprecated checking `numpy.issubdtype(whatever, numpy.dtype)` with `numpy.dtype` as second argument (which was coerced to `numpy.generic` in the past). The warning for this was there for quite some time. I took the opportunity and removed some code duplication in the process of fixing this.

Also fixed a typo that has been there from 2014 that prevented the metadata for ram_usage_per_requested_pixel to be set. To be fair, this wasn't an issue up until the numpy deprecation as most operators had some sort of safeguard around this.

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Rebase commits into a logical sequence.
