### PR TITLE
configure logging only once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,11 @@ jobs:
         name: restoring dependency cache
         keys:
         # This branch if available
-        - v1.4.11-dep-{{ .Branch }}-{{ epoch }}
+        - v1.4.12-dep-{{ .Branch }}-{{ epoch }}
         # Default branch if not
-        - v1.4.11-dep-main-
+        - v1.4.12-dep-main-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.4.11-dep-
+        - v1.4.12-dep-
     - restore_cache:
         name: restore ilastik-repo cache
         key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
@@ -54,8 +54,8 @@ jobs:
         name: update conda
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
-            conda update -q conda -c conda-forge -c defaults &&
-            conda install -n base -c conda-forge -c defaults conda-build
+            conda update -q conda -c conda-forge &&
+            conda install -n base -c conda-forge conda-build
     - run:
         name: install apt dependencies
         command: >
@@ -81,7 +81,7 @@ jobs:
         path: test-results
     - save_cache:
         name: store dependency cache
-        key: v1.4.11-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.4.12-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /opt/conda/pkgs
 
@@ -98,18 +98,18 @@ jobs:
     - restore_cache:
         name: restore dependency cache
         keys:
-        - v1.4.11-dep-{{ .Branch }}-{{ epoch }}
-        - v1.4.11-dep-main-
-        - v1.4.11-dep-
+        - v1.4.12-dep-{{ .Branch }}-{{ epoch }}
+        - v1.4.12-dep-main-
+        - v1.4.12-dep-
     - run:
         name: update conda
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
-            conda update -q conda -c conda-forge -c defaults
+            conda update -q conda -c conda-forge
     - run:
         name: create conda environment
         command: >
-            conda create -y -n black -c conda-forge -c base black
+            conda create -y -n black -c conda-forge black
     - run:
         name: black check
         command: >

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -218,7 +216,15 @@ def get_default_config(
     return default_log_config
 
 
+_LOGGING_CONFIGURED = False
+
+
 def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, logfile_path=DEFAULT_LOGFILE_PATH):
+    global _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        warnings.warn("logging has been already initialized; skipping further initialization calls", RuntimeWarning)
+        return
+
     if logfile_path == "/dev/null":
         assert output_mode != OutputMode.LOGFILE, "Must enable a logging mode."
         output_mode = OutputMode.CONSOLE
@@ -262,3 +268,5 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
         return filename + "(" + str(lineno) + "): " + category.__name__ + ": " + message.args[0]
 
     warnings.formatwarning = simple_warning_format
+
+    _LOGGING_CONFIGURED = True


### PR DESCRIPTION
logging is configure whenever the main ilastik main function is executed
(`ilastik.app.main`). In tests this happens multiple times.

This change prevents multiple initialization of logging. For me this
reduced the log size per test run from 2.7MB to 270kB

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.

