### PR TITLE
Use mamba to spin up development environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
             conda update -q conda -c conda-forge &&
-            conda install -n base -c conda-forge conda-build
+            conda install -n base -c conda-forge conda-build mamba
     - run:
         name: install apt dependencies
         command: >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The following text equips you with knowledge that makes contributing to ilastik 
 
 ## Development Environment
 
-1. Download and install [Git][git], [GitHub CLI][github-cli], and _the latest 64-bit_ [miniconda][miniconda].
+1. Download and install [Git][git], [GitHub CLI][github-cli], and _the latest 64-bit_ [Mambaforge][mambaforge].
    - Windows: all following commands should be executed in the _Anaconda Prompt_ from the Start Menu.
    - Linux: Git might be already preinstalled, GitHub CLI might be available in your system package manager.
    - macOS: Git is already preinstalled, GitHub CLI is available in [Homebrew][homebrew].
@@ -29,24 +29,26 @@ The following text equips you with knowledge that makes contributing to ilastik 
    gh repo clone ilastik
    ```
 
-1. Configure conda to use [strict channel priority](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority):
+1. If you have an existing [Miniconda][miniconda] installation, you can use it for ilastik development, but install [Mamba][mamba] and configure conda to use [strict channel priority][strict-channel-priority]:
 
    ```
    conda config --set channel_priority strict
+   conda install --name base -c conda-forge mamba
    ```
 
 1. Install [conda-build][conda-build] in order to access the [conda develop][conda-develop] command:
 
    ```
-   conda install --name base -c conda-forge conda-build
+   mamba install --name base -c conda-forge conda-build
    ```
+
 
 1. Create a new environment and install dependencies:
 
    ```
-   conda deactivate
-   conda env remove --name ilastik
-   conda create --name ilastik --channel ilastik-forge --channel conda-forge ilastik-dependencies-no-solvers pre-commit
+   mamba deactivate
+   mamba env remove --name ilastik
+   mamba create --name ilastik --channel pytorch --channel ilastik-forge --channel conda-forge ilastik-dependencies-no-solvers pre-commit
    ```
 
 1. Install repositories as packages in development mode:
@@ -73,7 +75,7 @@ The following text equips you with knowledge that makes contributing to ilastik 
 1. Launch ilastik:
 
    ```
-   conda activate ilastik
+   mamba activate ilastik
    cd ilastik
    python ilastik.py
    ```
@@ -159,14 +161,17 @@ But please run those tools on the code you are contributing :)
 [git]: https://git-scm.com/
 [github-cli]: https://cli.github.com/
 [miniconda]: https://docs.conda.io/en/latest/miniconda.html
+[mambaforge]: https://github.com/conda-forge/miniforge#mambaforge
 [homebrew]: https://brew.sh/
 [conda-build]: https://docs.conda.io/projects/conda-build/en/latest/
 [conda-develop]: https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html
+[mamba]: https://mamba.readthedocs.io/en/latest/
 [ilastik]: https://github.com/ilastik/ilastik
 [volumina]: https://github.com/ilastik/volumina
 [github-flow]: https://guides.github.com/introduction/flow/
 [google-style]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
 [black]: https://black.readthedocs.io/en/stable/
+[strict-channel-priority]: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority
 
 
 ## Further notes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - cmd: where conda
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority strict
   - cmd: conda update -q conda
-  - cmd: conda install -c conda-forge conda-build
+  - cmd: conda install -c conda-forge conda-build mamba
   # Get the current main of all submodules
   - cmd: git clone https://github.com/ilastik/ilastik-meta %IlASTIK_ROOT%\ilastik-meta
   - cmd: cd %IlASTIK_ROOT%\ilastik-meta

--- a/scripts/devenv.py
+++ b/scripts/devenv.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import time
 
-EXECUTABLES = ("conda", "git")
+EXECUTABLES = ("mamba", "git")
 REPOSITORIES = ("ilastik", "volumina")
 DEFAULT_CREATE_ARGS = [
     "--channel",
@@ -74,7 +74,7 @@ def main():
 
 def cmd_create(args, rest):
     chan_args = ["--override-channels", "--strict-channel-priority"]
-    run(["conda", "create", "--yes", "--name", args.name] + chan_args + (rest or DEFAULT_CREATE_ARGS) + ["conda-build"])
+    run(["mamba", "create", "--yes", "--name", args.name] + chan_args + (rest or DEFAULT_CREATE_ARGS) + ["boa"])
 
     for repo in REPOSITORIES:
         run(["conda", "develop", "--name", args.name, repo])
@@ -82,7 +82,7 @@ def cmd_create(args, rest):
 
 
 def cmd_remove(args, _rest):
-    run(["conda", "env", "remove", "--yes", "--name", args.name])
+    run(["mamba", "env", "remove", "--yes", "--name", args.name])
 
 
 def run(cmd, cwd=None):


### PR DESCRIPTION
This updates the contributing instructions with use of mamba instead of conda for envrionment creation. Also update `devenv.py` accordingly.

