### PR TITLE
adding deploy job for core-package on merges to main

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -21,13 +21,15 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - name: install xvfb/deps
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -yy libgl1-mesa-dev xvfb curl
       - name: install common conda dependencies
-        run: conda install -n base -c conda-forge mamba boa setuptools_scm -y
+        run: mamba install -n base -c conda-forge boa setuptools_scm -y
       - name: linux conda build test
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l {0}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: deploy
+
+on:
+  # run only once all the tests have passed
+  workflow_run:
+    branches:
+      - main
+    workflows: test
+    types: completed
+
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    environment: conda-deploy
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: ""
+          miniforge-variant: Mambaforge
+          use-mamba: true
+      - name: linux conda build and upload
+        shell: bash -l {0}
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          mamba install -n base -c conda-forge boa setuptools_scm anaconda-client -y
+          mamba config --set anaconda_upload yes
+          xvfb-run conda mambabuild -c ilastik-forge -c conda-forge --user ilastik-forge conda-recipe


### PR DESCRIPTION
currently this also builds on every PR commit (in order to demonstrate that it works), which is of course not intended. Before merging, this has to be changed of course.

files are uploaded here: https://anaconda.org/ilastik-forge/ilastik-core/files

side note: will tackle the black thing separately, which is cause by empty changeset (python-wise)

Also, maybe it would be better still to do releases via tags, and not build _every_ push to main as a conda-recipe.

Todos:
- [x] remove build on PRs