### PR TITLE
test release recipe

### DIFF
--- a/.github/workflows/test-releases.yml
+++ b/.github/workflows/test-releases.yml
@@ -1,0 +1,51 @@
+name: test-releases
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-w-conda-recipe:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        ILASTIK_RELEASE_VARIANT: ["", "-gpu"]
+        exclude:
+          - os: macos-latest
+            ILASTIK_RELEASE_VARIANT: "-gpu"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: ""
+          miniforge-variant: Mambaforge
+          use-mamba: true
+      - name: install xvfb/deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yy libgl1-mesa-dev xvfb curl
+      - name: install common conda dependencies
+        run: mamba install -n base -c conda-forge mamba boa setuptools_scm -y
+      - name: linux conda build test
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash -l {0}
+        run: xvfb-run conda mambabuild -c pytorch -c ilastik-forge -c conda-forge conda-recipe
+      - name: osx conda build test
+        env:
+          VOLUMINA_SHOW_3D_WIDGET: 0
+        if: matrix.os == 'macos-latest'
+        shell: bash -l {0}
+        run: conda mambabuild -c pytorch -c ilastik-forge -c conda-forge conda-recipe
+      - name: windows conda-build test
+        if: matrix.os == 'windows-latest'
+        shell: cmd /C CALL {0}
+        # auto activation of env does not seem to work on win
+        run: conda mambabuild -c pytorch -c ilastik-forge -c conda-forge conda-recipe

--- a/conda-recipe-release/meta.yaml
+++ b/conda-recipe-release/meta.yaml
@@ -1,0 +1,61 @@
+{% set setup_py_data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
+{% set release_variant = environ.get('ILASTIK_RELEASE_VARIANT', '') %}
+
+package:
+  name: ilastik-release
+  version: {{ setup_py_data.version }}
+
+source:
+  path: ..
+
+name: ilastik{{ release_variant }}
+build:
+  noarch: python
+  entry_points:
+    - ilastik = ilastik.__main__:main
+requirements:
+  run:
+    - python 3.7.*
+    - ilastik-core {{ setup_py_data.version }}
+    - volumina
+
+    - pytorch 1.10.*
+    - tensorflow 1.14.*
+    - tiktorch 22.2.0*
+
+{% if release_variant == '' %}
+    - cpuonly
+    - torchvision=*=*cpu
+{% elif release_variant == "-gpu" %}
+    - cudatoolkit >=10.2
+{% endif %}
+
+test:
+  source_files:
+    - tests
+    - pytest.ini
+
+  requires:
+    - pytest >=3,<4
+    - pytest-qt
+
+  imports:
+    - ilastik
+    - ilastik.experimental
+    - ilastik.config
+    - ilastik.applets
+    - ilastik.workflows
+    - lazyflow
+    - tiktorch
+
+  commands:
+    - ilastik --help
+    - pytest -v --run-legacy-gui .
+
+
+about:
+  home: https://github.com/ilastik/ilastik
+  license: LGPL-2.1-or-later
+  summary: >
+    ilastik is a simple, user-friendly tool for interactive image classification,
+    segmentation and analysis.


### PR DESCRIPTION
This adds "release" recipes that enable conda as a distribution channel for ilastik.
As a side effect, gui tests are now run on all platforms.

In the conda recipe, I added "variants" for the cpu (`""`) and gpu (`"-gpu"`) builds via environment variables instead of having conda manage variants via `cbc.yaml`, mainly to enable parallel builds. I think in our case this is also simpler to read.

Once this is merged, we can probably get rid of appveyor and circleci builds

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.


