### PR TITLE
Add release recipe

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -1,4 +1,4 @@
-name: test
+name: conda-package
 
 on:
   push:
@@ -7,11 +7,10 @@ on:
     branches: [ main ]
 
 jobs:
-  test-w-conda-recipe:
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  conda-noarch-build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,23 +20,100 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
+          channel-priority: strict
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - name: install xvfb/deps
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -yy libgl1-mesa-dev xvfb curl
       - name: install common conda dependencies
-        run: conda install -n base -c conda-forge mamba boa setuptools_scm -y
+        run: mamba install -n base -c conda-forge mamba boa setuptools_scm -y
+      - uses: actions/cache@v2
+        with:
+          path: |
+            pkgs/noarch
+            pkgs/channeldata.json
+          key: ${{ github.sha }}-packages
+      - id: version
+        shell: bash -l {0}
+        run: |
+          vers=$( python setup.py --version )
+          echo "::set-output name=version::${vers}"
       - name: linux conda build test
+        shell: bash -l {0}
+        run: |
+          mkdir -p ./pkgs/noarch
+          conda mambabuild -c conda-forge conda-recipe --no-test --output-folder ./pkgs
+
+  test-conda-packages:
+    needs: [conda-noarch-build]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        ilastik_variant: ["ilastik-core", "ilastik", "ilastik-gpu"]
+        exclude:
+          - os: macos-latest
+            ilastik_variant: "ilastik-gpu"
+          - os: windows-latest
+            ilastik_variant: "ilastik-gpu"
+        include:
+          - ilastik_variant: "ilastik-core"
+            build_prefix: "py_"
+    runs-on: ${{ matrix.os }}
+    env:
+      ILASTIK_PACKAGE_NAME: ${{ matrix.ilastik_variant }}-${{ needs.conda-noarch-build.outputs.version }}-${{ matrix.build_prefix }}0.tar.bz2
+    steps:
+      # necessary on windows: https://github.com/actions/cache/issues/591#issuecomment-845132253
+      - name: "Use GNU tar instead BSD tar"
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: ""
+          channel-priority: strict
+          miniforge-variant: Mambaforge
+          use-mamba: true
+      - name: install xvfb/deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yy mesa-utils libgl1-mesa-dev xvfb curl
+      - name: install common conda dependencies
+        run: mamba install -n base -c conda-forge boa setuptools_scm -y
+      - uses: actions/cache@v2
+        with:
+          path: |
+            pkgs/noarch
+            pkgs/channeldata.json
+          key: ${{ github.sha }}-packages
+      - name: linux test
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l {0}
-        run: xvfb-run mamba build -c ilastik-forge -c conda-forge conda-recipe
-      - name: osx conda build test
+        run: |
+          xvfb-run --server-args="-screen 0 1024x768x24" conda mambabuild --test --override-channels \
+            -c ./pkgs -c pytorch -c ilastik-forge -c conda-forge \
+            ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
+      - name: osx test
         if: matrix.os == 'macos-latest'
         shell: bash -l {0}
-        run: mamba build -c ilastik-forge -c conda-forge conda-recipe
-      - name: windows conda-build test
+        run: |
+          VOLUMINA_SHOW_3D_WIDGET=0 conda mambabuild --test --override-channels \
+            -c ./pkgs -c pytorch -c ilastik-forge -c conda-forge \
+            ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
+      - name: windows test
         if: matrix.os == 'windows-latest'
         shell: cmd /C CALL {0}
-        # auto activation of env does not seem to work on win
-        run: mamba build -c ilastik-forge -c conda-forge conda-recipe
+        run: |
+          set VOLUMINA_SHOW_3D_WIDGET=0
+          conda mambabuild --test --override-channels ^
+            -c .\pkgs -c pytorch -c ilastik-forge -c conda-forge ^
+            .\pkgs\noarch\%ILASTIK_PACKAGE_NAME%
+

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,9 +14,10 @@ outputs:
     build:
       number: 0
       noarch: python
+      script_env:
+        - SETUPTOOLS_SCM_PRETEND_VERSION={{ setup_py_data.version }}
       script:
-        - export SETUPTOOLS_SCM_PRETEND_VERSION={{ setup_py_data.version }}
-        - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+        - python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
     requirements:
       host:
         - python >=3.7
@@ -80,3 +81,111 @@ outputs:
 
       commands:
         - pytest -v .
+
+    about:
+      home: https://github.com/ilastik/ilastik
+      license: LGPL-2.1-or-later
+      summary: >
+        ilastik-core package enables ilastik-api usage to mix into environments.
+        ilastik is a simple, user-friendly tool for interactive image classification,
+        segmentation and analysis.
+        
+
+  - name: ilastik
+    build:
+      noarch: python
+      entry_points:
+        - ilastik = ilastik.__main__:main
+    requirements:
+      run:
+        - python 3.7.*
+        - ilastik-core {{ setup_py_data.version }}
+        - volumina
+        - pytorch 1.10.*
+        - tensorflow 1.14.*
+        - tiktorch 22.2.0*
+        - cpuonly
+        - inferno
+        - torchvision=*=*cpu
+    test:
+      source_files:
+        - tests
+        - pytest.ini
+
+      requires:
+        - pytest >=3,<4
+        - pytest-qt
+
+      imports:
+        - ilastik
+        - ilastik.experimental
+        - ilastik.config
+        - ilastik.applets
+        - ilastik.workflows
+        - lazyflow
+        - tiktorch
+
+      commands:
+        - ilastik --help
+        - pytest -v .
+
+    about:
+      home: https://github.com/ilastik/ilastik
+      license: LGPL-2.1-or-later
+      summary: >
+        ilastik conda package to create ilastik gui environments.
+        ilastik is a simple, user-friendly tool for interactive image classification,
+        segmentation and analysis.
+
+
+  - name: ilastik-gpu
+    build:
+      noarch: python
+      entry_points:
+        - ilastik = ilastik.__main__:main
+    requirements:
+      run:
+        - python 3.7.*
+        - ilastik-core {{ setup_py_data.version }}
+        - volumina
+        - pytorch >=1.6
+        - tensorflow 1.14.*
+        - tiktorch 22.2.0*
+        - inferno
+        - torchvision
+        - cudatoolkit >=10.2
+
+    test:
+      source_files:
+        - tests
+        - pytest.ini
+
+      requires:
+        - pytest >=3,<4
+        - pytest-qt
+        - pytorch 1.10.*
+        - cudatoolkit 11.1.*
+
+      imports:
+        - ilastik
+        - ilastik.experimental
+        - ilastik.config
+        - ilastik.applets
+        - ilastik.workflows
+        - lazyflow
+        - tiktorch
+        - torch
+        - vigra
+        - tensorflow
+
+      commands:
+        - ilastik --help
+        - pytest -v .
+
+    about:
+      home: https://github.com/ilastik/ilastik
+      license: LGPL-2.1-or-later
+      summary: >
+        ilastik conda package to create ilastik gpu-enabled gui environments.
+        ilastik is a simple, user-friendly tool for interactive image classification,
+        segmentation and analysis.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,80 +1,82 @@
 {% set setup_py_data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
 
 package:
-  name: ilastik-core
+  name: ilastik-package-meta-recipe
   version: {{ setup_py_data.version }}
 
 source:
   path: ..
 
-requirements:
-  host:
-    - python >=3.7
-    - pip
-    - setuptools >=40.0
-    - setuptools_scm
-  run:
-    - python >=3.7
-    - numpy >1.12
-    - appdirs
-    - cachetools
-    - dpct
-    - fastfilters
-    - future
-    - greenlet
-    - grpcio
-    - h5py
-    - hytra
-    - ilastik-feature-selection
-    - ilastikrag
-    - ilastiktools
-    - jsonschema
-    - mamutexport
-    - marching_cubes
-    - ndstructs
-    - nifty
-    - psutil
-    - pyopengl
-    - pyqt >=5.12
-    - python-elf
-    - pytiff
-    - scikit-image
-    - scikit-learn
-    # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
-    # need to bump this manually until there is a true version bump in vigra
-    - vigra 1.11.1=*_1028
-    - wsdt
-    - xarray
-    - z5py
-  run_constrained:
-    - tiktorch >=22.2.0
 
-build:
-  number: 0
-  noarch: python
-  script:
-    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ setup_py_data.version }}
-    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+outputs:
+  - name: ilastik-core
 
+    build:
+      number: 0
+      noarch: python
+      script:
+        - export SETUPTOOLS_SCM_PRETEND_VERSION={{ setup_py_data.version }}
+        - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+    requirements:
+      host:
+        - python >=3.7
+        - pip
+        - setuptools >=40.0
+        - setuptools_scm
+      run:
+        - python >=3.7
+        - numpy >1.12
+        - appdirs
+        - cachetools
+        - dpct
+        - fastfilters
+        - future
+        - greenlet
+        - grpcio
+        - h5py
+        - hytra
+        - ilastik-feature-selection
+        - ilastikrag
+        - ilastiktools
+        - jsonschema
+        - mamutexport
+        - marching_cubes
+        - ndstructs
+        - nifty
+        - psutil
+        - pyopengl
+        - pyqt >=5.12
+        - python-elf
+        - pytiff
+        - scikit-image
+        - scikit-learn
+        # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
+        # need to bump this manually until there is a true version bump in vigra
+        - vigra 1.11.1=*_1028
+        - wsdt
+        - xarray
+        - z5py
+      run_constrained:
+        - tiktorch >=22.2.0
 
-test:
-  imports:
-    - ilastik
-    - ilastik.experimental
-    - ilastik.config
-    - ilastik.applets
-    - ilastik.workflows
-    - lazyflow
+    test:
+      imports:
+        - ilastik
+        - ilastik.experimental
+        - ilastik.config
+        - ilastik.applets
+        - ilastik.workflows
+        - lazyflow
 
-  source_files:
-    - tests
-    - pytest.ini
+      source_files:
+        - tests
+        - pytest.ini
 
-  requires:
-    - pytest >=3,<4
-    - pytest-qt
-    - volumina
-    - tiktorch
+      requires:
+        - pytest >=3,<4
+        - pytest-qt
+        - volumina
+        - tiktorch
 
-  commands:
-    - pytest -v .
+      commands:
+        - pytest -v .

--- a/tests/test_ilastik/widgets/test_ImageFileDialog.py
+++ b/tests/test_ilastik/widgets/test_ImageFileDialog.py
@@ -23,7 +23,7 @@ def tmp_preferences(tmp_path) -> pathlib.Path:
 def image(tmp_path) -> Path:
     image_path = Path(tmp_path) / "some_picture.png"
     image_path.touch()
-    return image_path
+    return image_path.resolve()
 
 
 def test_default_image_directory_is_home_with_blank_preferences_file():


### PR DESCRIPTION
Summary:

* added multi-output (meta) recipe, which ensures core and "release" packages are in sync
* added build/test to gh-actions
  * legacy-gui-tests currently not run there (would hang, need to investigate, will open issue after merge)
  * windows-gpu variant not tested - didn't manage to find a working combination of packages yet (issue after merge)
  * in order to speedup tests, avoid unnecessary builds, conda build is done in two stages, ones to only build noarch recipe on linux, and then runs the tests in a second stage on all osses.