### PR TITLE
update dependencies

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -100,7 +100,7 @@ outputs:
       run:
         - python 3.7.*
         - ilastik-core {{ setup_py_data.version }}
-        - volumina
+        - volumina >=1.3.3
         - pytorch >=1.6,<1.10
         - tensorflow 1.14.*
         - tiktorch 22.2.0*
@@ -116,8 +116,7 @@ outputs:
         - pytest >=3,<4
         - pytest-qt
         # need to help mamba here a bit
-        - pytorch 1.9.* *cpu*  # [not osx]
-        - pytorch 1.9.*  # [osx]
+        - ilastik-pytorch-version-helper-cpu
 
       imports:
         - ilastik
@@ -150,7 +149,7 @@ outputs:
       run:
         - python 3.7.*
         - ilastik-core {{ setup_py_data.version }}
-        - volumina
+        - volumina >=1.3.3
         - pytorch >=1.6,<1.10
         - tensorflow 1.14.*
         - tiktorch 22.2.0*

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 dependencies:
   - python 3.7.*
-  - numpy 1.19.*
+  - numpy 1.21.*
   - appdirs
   - cachetools
   - dpct
@@ -42,10 +42,10 @@ dependencies:
   # Neural Network Workflow dependencies
   # can be changed to request gpu versions
   - cpuonly
-  - pytorch 1.10.*
+  - ilastik-pytorch-version-helper-cpu
+  - pytorch 1.9.*
   - tensorflow 1.14.*
   - tiktorch
-  - torchvision=*=*cpu
 
   # dev-only dependencies
   - conda-build


### PR DESCRIPTION
* go to `numpy` 1.21 for devenv
* use `ilastik-pytorch-version-helper-cpu` for consistent cpu environments on
  all osses using conda or mamba
* don't pin pytorch to exact version in `ilastik-gpu`
* allow more flexibility wrt `numpy` in `ilastik` recipes
* require minimum `volumina` version `1.3.3`

fixes #2543 