### PR TITLE
enforce cuda build of pytorch for ilastik-gpu

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -151,10 +151,11 @@ outputs:
         - ilastik-core {{ setup_py_data.version }}
         - volumina >=1.3.3
         - pytorch >=1.6,<1.10
+        - pytorch * *cu*
         - tensorflow 1.14.*
         - tiktorch 22.3.2*
         - inferno
-        - torchvision
+        - torchvision * *cu*
         - cudatoolkit >=10.2
 
     test:
@@ -166,7 +167,7 @@ outputs:
         - pytest >=3,<4
         - pytest-qt
         - pytorch 1.9.*
-        - cudatoolkit 11.1.*
+        - cudatoolkit 11.0.*
 
       imports:
         - ilastik


### PR DESCRIPTION
pytorch <1.10 still uses track features -> not supported by mamba -> help it.
