### PR TITLE
fix version str

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             cd ${ILASTIK_ROOT}/ilastik-meta &&
             mamba env create --name ${TEST_ENV_NAME} --file ilastik/dev/environment-dev.yml &&
             mamba install --name ${TEST_ENV_NAME} --freeze-installed -c ilastik-forge -c conda-forge mpi4py pytest-cov volumina &&
-            mamba develop --name ${TEST_ENV_NAME} ilastik
+            conda run -n ${TEST_ENV_NAME} pip install -e ilastik
 
     - run:
         name: run ilastik tests

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ tests/images
 
 build/
 dist/
-ilastik.egg-info/
+ilastik_core.egg-info/
 lazyflow.egg-info/
 
 .settings
@@ -80,3 +80,6 @@ docs/**/_build
 *.jpg
 *.swp
 coverage.xml
+
+# setuptools_scm version
+ilastik/_version.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,6 @@ The following text equips you with knowledge that makes contributing to ilastik 
    conda install --name base -c conda-forge mamba
    ```
 
-1. Install [conda-build][conda-build] in order to access the [conda develop][conda-develop] command:
-
-   ```
-   mamba install --name base -c conda-forge conda-build
-   ```
-
-
 1. Create a new environment and install dependencies:
 
    ```
@@ -55,8 +48,10 @@ The following text equips you with knowledge that makes contributing to ilastik 
 1. Install repositories as packages in development mode:
 
    ```
-   conda develop --name ilastik volumina
-   conda develop --name ilastik ilastik
+   conda activate ilastik
+   # from the folder containing ilastik and volumina
+   pip install -e ilastik
+   pip install -e volumina
    ```
 
 1. Install pre-commit hooks:
@@ -78,7 +73,7 @@ The following text equips you with knowledge that makes contributing to ilastik 
    ```
    mamba activate ilastik
    cd ilastik
-   python ilastik.py
+   python ilastik_scripts/ilastik_startup.py
    ```
 
 ## Workflow

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - |
     mamba env create --name %ENV_NAME% --file %IlASTIK_ROOT%\ilastik-meta\ilastik\dev\environment-dev.yml
     mamba install --name %ENV_NAME% -c ilastik-forge -c conda-forge volumina
-    mamba develop --name %ENV_NAME% %IlASTIK_ROOT%\ilastik-meta\ilastik
+    conda run -n %ENV_NAME% pip install -e %IlASTIK_ROOT%\ilastik-meta\ilastik
   - mamba clean -p
 
 build: off

--- a/ilastik/__init__.py
+++ b/ilastik/__init__.py
@@ -25,29 +25,29 @@ import re
 ################################
 # # Add Submodules to sys.path ##
 ################################
-import os
 import h5py
-import time
-from typing import Optional, Iterable, List
+from typing import Optional, List
 from pkg_resources import parse_version
 
 try:
-    from ._version import version_tuple
-except ImportError:
-    version_tuple = (1, 4, "0b20")
+    from ._version import version
+except ModuleNotFoundError:
+    raise RuntimeError(
+        "Couldn't determine ilastik version - if you are developing ilastik please "
+        "make sure to use an editable install (`pip install -e .`). "
+        "Otherwise, please report this issue to the ilastik development team: team@ilastik.org"
+    )
+
 ##################
 # # Version info ##
 ##################
+
+__version__ = version
 
 
 def _format_version(t):
     """converts a tuple to a string"""
     return ".".join(str(i) for i in t)
-
-
-__version_info__ = version_tuple
-
-__version__ = _format_version(__version_info__)
 
 
 class Project:
@@ -134,8 +134,7 @@ def isVersionCompatible(version):
 
     # Only consider major and minor rev
     v1 = convertVersion(version)[0:2]
-    v2 = __version_info__[0:2]
-
+    v2 = convertVersion(__version__)[0:2]
     # Version 1.0 is compatible in all respects with version 0.6
     compatible_set = [(0, 6), (1, 0), (1, 1), (1, 2), (1, 3), (1, 4)]
     if v1 in compatible_set and v2 in compatible_set:

--- a/ilastik/__init__.py
+++ b/ilastik/__init__.py
@@ -27,7 +27,7 @@ import re
 ################################
 import h5py
 from typing import Optional, List
-from pkg_resources import parse_version
+from packaging.version import parse
 
 try:
     from ._version import version
@@ -95,7 +95,7 @@ class Project:
     @property
     def ilastikVersion(self) -> Optional["Version"]:
         version_string = self._getString(self.ILASTIK_VERSION)
-        return version_string if version_string is None else parse_version(version_string)
+        return version_string if version_string is None else parse(version_string)
 
     @property
     def workflowName(self) -> Optional[str]:

--- a/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationSerializer.py
@@ -19,7 +19,7 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 from builtins import range
-from pkg_resources import parse_version
+from packaging.version import parse
 import numpy
 import vigra
 from ilastik import Project
@@ -59,16 +59,16 @@ class BackwardsCompatibleLabelSerialBlockSlot(SerialBlockSlot):
 
     def labels_were_saved_in_forced_canonical_order(self, project: Project) -> bool:
         pixel_plus_object_workflow_name = "Object Classification (from pixel classification)"
-        v1_3_3 = parse_version("1.3.3")
-        v1_3_3post2 = parse_version("1.3.3post2")
+        v1_3_3 = parse("1.3.3")
+        v1_3_3post2 = parse("1.3.3post2")
 
         return (
             v1_3_3 <= project.ilastikVersion < v1_3_3post2 and project.workflowName == pixel_plus_object_workflow_name
         )
 
     def labels_were_saved_in_slot_original_order(self, project: Project):
-        v1_3_3post2 = parse_version("1.3.3post2")
-        v1_4_0b7 = parse_version("1.4.0b7")
+        v1_3_3post2 = parse("1.3.3post2")
+        v1_4_0b7 = parse("1.4.0b7")
 
         return v1_3_3post2 <= project.ilastikVersion <= v1_4_0b7
 


### PR DESCRIPTION
previously build str was not included, so version would currently be `1.4.0` as opposed to `1.4.0b27`.

Also added setuptools_scm to dev dependencies and made sure there is a proper version set in dev mode, too.

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.

