### PR TITLE
Fix project deserialization in multicut

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingSerializer.py
@@ -197,8 +197,8 @@ class EdgeTrainingSerializer(AppletSerializer):
             SerialCachedDataFrameSlot(
                 operator.opEdgeFeaturesCache.Output, operator.opEdgeFeaturesCache, name="EdgeFeatures"
             ),
-            SerialClassifierSlot(operator.opClassifierCache.Output, operator.opClassifierCache),
             SerialSlot(operator.TrainRandomForest),
+            SerialClassifierSlot(operator.opClassifierCache.Output, operator.opClassifierCache),
         ]
         super().__init__(projectFileGroupName, slots=slots)
 

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -155,6 +155,8 @@ class OpEdgeTraining(Operator):
         Discards the labels for a given lane.
         NOTE: In addition to callers in this file, this function is also called from multicutWorkflow.py
         """
+        if self._cleaningUp:
+            return
         # Determine which lane triggered this and delete it's labels
         lane_index = self.Superpixels.index(subslot)
         old_labels = self.EdgeLabelsDict[lane_index].value

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -20,6 +20,7 @@
 ###############################################################################
 import argparse
 import numpy as np
+import sys
 
 from ilastik.workflow import Workflow
 


### PR DESCRIPTION
makes sure the classifier is properly deserialized last, so that it is not set dirty by accident (and then retrained)...

update: I looked into why the labels are removed at the end of headless batch processing (and also when closing the project) and it happens during cleanup, - in principle we don't care about the removal there, so it's now skipped during cleanup.

- [x] Format code and imports.
- [x] Reference relevant issues and other pull requests.


partly addresses #2561

this PR doesn't improve command line handling or error messages, that are also part of #2561