### PR TITLE
fix tifffile incompatibility with py37

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,6 +51,9 @@ outputs:
         - pytiff
         - scikit-image
         - scikit-learn
+        # last py37 compatible version
+        # newer packages on CF currently don't reflect that
+        - tifffile <=2021.11.2
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra 1.11.1=*_1029

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -32,6 +32,8 @@ dependencies:
   - qimage2ndarray
   - scikit-image
   - scikit-learn
+  # see note in conda recipe about tifffile compatibility
+  - tifffile 2021.11.2
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
   - vigra 1.11.1=*_1029


### PR DESCRIPTION
`tifffile` versions `2022.x` on CF currently don't reflect this constraint