### PR TITLE
bump vigra, default to cf pytorch-cpu, remove pytorch channel

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -97,14 +97,14 @@ jobs:
         shell: bash -l {0}
         run: |
           xvfb-run --server-args="-screen 0 1024x768x24" conda mambabuild --test --override-channels \
-            -c ./pkgs -c pytorch -c ilastik-forge -c conda-forge \
+            -c ./pkgs -c ilastik-forge -c conda-forge \
             ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
       - name: osx test
         if: matrix.os == 'macos-latest'
         shell: bash -l {0}
         run: |
           VOLUMINA_SHOW_3D_WIDGET=0 conda mambabuild --test --override-channels \
-            -c ./pkgs -c pytorch -c ilastik-forge -c conda-forge \
+            -c ./pkgs -c ilastik-forge -c conda-forge \
             ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
       - name: windows test
         if: matrix.os == 'windows-latest'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -56,7 +56,7 @@ outputs:
         - tifffile <=2021.11.2
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
-        - vigra 1.11.1=*_1029
+        - vigra 1.11.1=*_1032
         - wsdt
         - xarray
         - z5py
@@ -105,10 +105,9 @@ outputs:
         - python 3.7.*
         - ilastik-core {{ setup_py_data.version }}
         - volumina >=1.3.3
-        - pytorch >=1.6,<1.10
+        - pytorch-cpu >=1.6,<1.10
         - tensorflow 1.14.*
         - tiktorch 22.3.2*
-        - cpuonly
         - inferno
         - torchvision
     test:
@@ -155,6 +154,7 @@ outputs:
         - ilastik-core {{ setup_py_data.version }}
         - volumina >=1.3.3
         - pytorch >=1.6,<1.10
+        - pytorch =*=*cu*
         - tensorflow 1.14.*
         - tiktorch 22.3.2*
         - inferno

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -1,6 +1,5 @@
 channels:
   - ilastik-forge
-  - pytorch
   - conda-forge
   - nodefaults
 dependencies:
@@ -36,16 +35,18 @@ dependencies:
   - tifffile 2021.11.2
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
-  - vigra 1.11.1=*_1029
+  - vigra 1.11.1=*_1032
   - wsdt
   - xarray
   - z5py
 
   # Neural Network Workflow dependencies
   # can be changed to request gpu versions
-  - cpuonly
-  - ilastik-pytorch-version-helper-cpu
-  - pytorch 1.9.*
+  # Note that if you want packages from pytorch channel, it should be `pytorch` and `cpuonly`
+  # for the gpu build, on windows the pytorch channel is required
+  - pytorch-cpu 1.9.*
+  # - pytorch 1.9.*=*cu*
+  # - cudatoolkit 11.1.*
   - tensorflow 1.14.*
   - tiktorch
 


### PR DESCRIPTION
* vigra: use the latest build
* use pytorch-cpu from cf in favor of pytorch + cpuonly from pytorch channel
* remove pytorch channel from osx, linux ci
* only windows gpu build requires pytorch channel
