### PR TITLE
Fix ci: mamba/conda incompatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,20 +42,22 @@ jobs:
         name: restoring dependency cache
         keys:
         # This branch if available
-        - v1.4.12-dep-{{ .Branch }}-{{ epoch }}
+        - v1.4.13-dep-{{ .Branch }}-{{ epoch }}
         # Default branch if not
-        - v1.4.12-dep-main-
+        - v1.4.13-dep-main-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.4.12-dep-
+        - v1.4.13-dep-
     - restore_cache:
         name: restore ilastik-repo cache
         key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
     - run:
-        name: update conda
+        name: configure base environment
+        # due to an incompatibility of mamba with conda 4.13, one currently cannot update conda first
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
-            conda update -q conda -c conda-forge &&
-            conda install -n base -c conda-forge conda-build mamba
+            conda install -n base -c conda-forge mamba &&
+            mamba update -q conda -c conda-forge &&
+            mamba install -n base -c conda-forge conda-build boa
     - run:
         name: install apt dependencies
         command: >
@@ -67,7 +69,7 @@ jobs:
             cd ${ILASTIK_ROOT}/ilastik-meta &&
             mamba env create --name ${TEST_ENV_NAME} --file ilastik/dev/environment-dev.yml &&
             mamba install --name ${TEST_ENV_NAME} --freeze-installed -c ilastik-forge -c conda-forge mpi4py pytest-cov volumina &&
-            conda run -n ${TEST_ENV_NAME} pip install -e ilastik
+            mamba run -n ${TEST_ENV_NAME} pip install -e ilastik
 
     - run:
         name: run ilastik tests
@@ -81,7 +83,7 @@ jobs:
         path: test-results
     - save_cache:
         name: store dependency cache
-        key: v1.4.12-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.4.13-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /opt/conda/pkgs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 clone_folder: c:\projects\ilastik
 
 environment:
   ENV_NAME: test-env
   # set miniconda version explicitly
-  MINICONDA: C:\Miniconda37-x64
+  MINICONDA: C:\Miniconda38-x64
   IlASTIK_ROOT: C:\ilastik
   VOLUMINA_SHOW_3D_WIDGET: 0
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
@@ -17,8 +17,10 @@ install:
   - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
   - cmd: where conda
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority strict
-  - cmd: conda update -q conda
-  - cmd: conda install -c conda-forge conda-build mamba
+  # due to an incompatibility of mamba with conda 4.13, one currently cannot update conda first
+  - cmd: conda install -n base -c conda-forge mamba
+  - cmd: mamba update -n base -c conda-forge conda
+  - cmd: mamba install -n base -c conda-forge conda-build boa
   # Get the current main of all submodules
   - cmd: git clone https://github.com/ilastik/ilastik-meta %IlASTIK_ROOT%\ilastik-meta
   - cmd: cd %IlASTIK_ROOT%\ilastik-meta
@@ -31,7 +33,7 @@ install:
   - |
     mamba env create --name %ENV_NAME% --file %IlASTIK_ROOT%\ilastik-meta\ilastik\dev\environment-dev.yml
     mamba install --name %ENV_NAME% -c ilastik-forge -c conda-forge volumina
-    conda run -n %ENV_NAME% pip install -e %IlASTIK_ROOT%\ilastik-meta\ilastik
+    mamba run -n %ENV_NAME% pip install -e %IlASTIK_ROOT%\ilastik-meta\ilastik
   - mamba clean -p
 
 build: off


### PR DESCRIPTION
Currently the latest conda and mamba are not compatible anymore. Updating conda first, will not allow for mamba installation (I think they retroactively patched all packages to pin conda to `<4.13`. In any case, conda will not downgrade itself during the process and will produce the usual soup of incompatibility hints.

Here, we'll install mamba first, and let mamba do all solving (for updating conda, and other packages in the base env).

gitlab actions are fine, as they're using mambaforge.

xref: https://github.com/mamba-org/mamba/issues/1724