### PR TITLE
Added overlay layer for NN workflow

### DIFF
--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -615,6 +615,16 @@ class NNClassGui(LabelingGui):
                 ref_label.nameChanged.connect(setPredLayerName)
                 layers.append(predictionLayer)
 
+        # Add the overlay second to last
+        overlaySlot = self.topLevelOperatorView.OverlayImages
+        if overlaySlot.ready():
+            overlayLayer = self.createStandardLayerFromSlot(overlaySlot)
+            overlayLayer.name = "Overlay"
+            overlayLayer.visible = True
+            overlayLayer.opacity = 1.0
+
+            layers.append(overlayLayer)
+
         # Add the raw data last (on the bottom)
         inputDataSlot = self.topLevelOperatorView.InputImages
         if inputDataSlot.ready():

--- a/ilastik/applets/neuralNetwork/opNNclass.py
+++ b/ilastik/applets/neuralNetwork/opNNclass.py
@@ -53,6 +53,7 @@ class OpNNClassification(Operator):
 
     # Graph inputs
     InputImages = InputSlot(level=1)
+    OverlayImages = InputSlot(level=1, optional=True)
     ServerConfig = InputSlot(stype=stype.Opaque, nonlane=True)
     Checkpoints = InputSlot()
 

--- a/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
+++ b/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
@@ -46,7 +46,8 @@ class _NNWorkflowBase(Workflow):
     workflowDescription = "Base class for NN Classification workflows"
 
     DATA_ROLE_RAW = 0
-    ROLE_NAMES = ["Raw Data"]
+    DATA_ROLE_OVERLAY = 1
+    ROLE_NAMES = ["Raw Data", "Overlay"]
     EXPORT_NAMES = ["Probabilities", "Labels"]
 
     @property
@@ -136,6 +137,7 @@ class _NNWorkflowBase(Workflow):
 
         # Input Image ->  Classification Op (for display)
         opNNclassify.InputImages.connect(opData.Image)
+        opNNclassify.OverlayImages.connect(opData.ImageGroup[self.DATA_ROLE_OVERLAY])
         # Data Export connections
         opDataExport.RawData.connect(opData.ImageGroup[self.DATA_ROLE_RAW])
         opDataExport.RawDatasetInfo.connect(opData.DatasetGroup[self.DATA_ROLE_RAW])


### PR DESCRIPTION
tiny PR that adds the possibility to load an _optional_ "overlay" image into the NN workflows. This can be useful, when a networks expects some other input than the raw data, but it's still interesting to see the result on top of the raw data. I think @akreshuk requested it :)