### PR TITLE
fix multicut not updating from boundary evidence

### DIFF
--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -440,6 +440,10 @@ class OpPredictEdgeProbabilities(Operator):
         result[0] = edge_weights
 
     def propagateDirty(self, slot, subindex, roi):
+        if slot == self.EdgeClassifier and not self.TrainRandomForest.value:
+            # ignore classifier dirtiness if RF is not trained
+            return
+
         self.EdgeProbabilities.setDirty()
 
 


### PR DESCRIPTION
Symptom: multicut could be update with different thresholds when training a classifier just fine. Going directly from boundary evidence, however, would not result in updated multicut segmentations.

I traced this back to the classifier. The classifier will be set dirty by the change of edgeFeatures (triggered by the `TrainRandomForest` slot. While it's true that, changing the features should invalidate the classifier.


I see four possible ways to mitigate it:
1. separate paths for weights from RF predictions or from boundary evidence directly (#2595)
1. Disconnect the slot when classifier is not trained - the op becomes not ready and will not signal dirtiness. This would require quite some rework - but would probably be the cleanest solution.
2. Add the `TrainRandomForest` slot to `OpTrainEdgeClassifier` and don't propagate dirtiness while `TrainRandomForest` is `False` - hardly any rework, safe for multiple downstream connections (this PR)
4. Don't propagate dirtiness downstream in `OpPredictEdgeProbabilities`. Relies on this being the only operator that is connected to the classifier :/

I opted for ~~(2)~~ (4) after discussing this with @emilmelnikov and @Tomaz-Vieira  as a compromise between code changes and robustness of the fix.