### PR TITLE
Added pin for click in black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: 21.7b0
     hooks:
       - id: black
+        additional_dependencies: ['click==8.0.4']


### PR DESCRIPTION
https://github.com/psf/black/issues/2964

Hi,
I'm working with @k-dominik on the #2590 issue and we realized pre-commit was crashing on my machine unless I fixed the click version.
This PR modifies the .pre-commit-config.yaml file to fix _click_ at version 8.0.4 that solves the pre-commit problem.