### PR TITLE
update pixel classification example to use ilastik-core

### DIFF
--- a/notebooks/Readme.md
+++ b/notebooks/Readme.md
@@ -12,22 +12,23 @@ notebooks/
 ├── ...
 ```
 
-We use _conda_ for Python-based projects and recommend it for scientific Python development.
-It is assumed that you have already installed _conda_ and are familiar with using a Terminal.
+We use _mamba/(conda)_ for Python-based projects and recommend it for scientific Python development.
+It is assumed that you have already installed _mamba_ and are familiar with using a Terminal.
 
 In order to run the notebook type the following in a Terminal/Command Line:
 
-Note: conda has to be configured with [_strict channel priority_](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority) in order to produce consistent environments.
+Note: mamba has to be configured with [_strict channel priority_](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority) in order to produce consistent environments.
 
 
 ```bash
 # make sure to use strict channel priority - this setting is global but in general a good idea
-conda config --set channel_priority strict
+mamba config --set channel_priority strict
 
-$ conda env create -f environment.yml
+# create n environment - make sure to choose an appropriate <environment_name>
+$ mamba env create -n <environment_name> -f environment.yml
 # this will produce a lot of output
 
-$ conda activate <created_environment_name>
+$ mamba activate <environment_name>
 
 # start the notebook server in the current folder
 $ jupyter notebook --notebook-dir .

--- a/notebooks/pixel_classification_api/environment.yml
+++ b/notebooks/pixel_classification_api/environment.yml
@@ -1,9 +1,7 @@
-name: ilastik-pc-api
 channels:
   - ilastik-forge
   - conda-forge
 dependencies:
-  - ilastik-dependencies-no-solvers
-  - ilastik-meta >=1.4.0b14
+  - ilastik-core
   - notebook
 # add additional packages to read/pre-process files here

--- a/notebooks/pixel_classification_api/pixel-classification-api.ipynb
+++ b/notebooks/pixel_classification_api/pixel-classification-api.ipynb
@@ -23,7 +23,8 @@
     "import numpy\n",
     "from xarray import DataArray\n",
     "# Add your imports here, e.g. for loading and preprocessing data\n",
-    "import skimage.io"
+    "import imageio\n",
+    "from matplotlib import pyplot as plt"
    ]
   },
   {
@@ -46,10 +47,10 @@
    "source": [
     "# load the image you would like to process and wrap it in an xarray.DataArray,\n",
     "# providing the appropriate dimension names\n",
-    "image = DataArray(skimage.io.imread(\"2d_cells_apoptotic_1channel.png\"), dims=(\"y\", \"x\"))\n",
+    "image = DataArray(imageio.imread(\"2d_cells_apoptotic_1channel.png\"), dims=(\"y\", \"x\"))\n",
     "prediction = pipeline.predict(image)\n",
     "# show the foreground channel:\n",
-    "skimage.io.imshow(prediction[..., 0])"
+    "plt.imshow(prediction[..., 0])"
    ]
   }
  ],


### PR DESCRIPTION
* adapted the Pixel Classification API example to use the `ilastik-core` package. Also using `imageio` instead of `skimage.io` now.
* updated installation instructions to use mamba