### PR TITLE
fix ilastik startup on mac/windows

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -53,7 +53,7 @@ outputs:
         - scikit-learn
         # last py37 compatible version
         # newer packages on CF currently don't reflect that
-        - tifffile <=2021.11.2
+        - tifffile >2020.9.22,<=2021.11.2
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra 1.11.1=*_1032

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -52,7 +52,7 @@ try:
 
     _supports_dvid = True
 except ImportError as ex:
-    if "OpDvidVolume" not in ex.args[0] and "OpExportDvidVolume" not in ex.args[0]:
+    if not any(x in ex.args[0] for x in ["OpDvidVolume", "OpExportDvidVolume", "libdvid"]):
         raise
     _supports_dvid = False
 

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -55,7 +55,7 @@ try:
 
     _supports_dvid = True
 except ImportError as ex:
-    if "OpDvidVolume" not in ex.args[0] and "OpDvidRoi" not in ex.args[0]:
+    if not any(x in ex.args[0] for x in ["OpDvidVolume", "OpDvidRoi", "libdvid"]):
         raise
     _supports_dvid = False
 


### PR DESCRIPTION
absolutely not sure why this bubbles up now, but when creating dev environments on mac and windows, calling the ilastik startup script will result in`ModuleNotFoundError`, with `libdvid` as root cause.
On linux `ImportError` is raised (and ignored, as expected) with `OpDvidVolume` as root cause.

for reference, the error on osx (also tested it on a _fresh_ windows machine):

<details>

```pytb
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/shell/gui/startShellGui.py", line 100, in launchShell
    from ilastik.shell.gui.ilastikShell import IlastikShell
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/shell/gui/ilastikShell.py", line 97, in <module>
    import ilastik.workflows
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/workflows/__init__.py", line 31, in <module>
    from .pixelClassification import PixelClassificationWorkflow
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/workflows/pixelClassification/__init__.py", line 23, in <module>
    from .pixelClassificationWorkflow import PixelClassificationWorkflow
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py", line 36, in <module>
    from ilastik.applets.dataSelection import DataSelectionApplet
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/applets/dataSelection/__init__.py", line 23, in <module>
    from .dataSelectionApplet import OpMultiLaneDataSelectionGroup, DataSelectionApplet
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/applets/dataSelection/dataSelectionApplet.py", line 42, in <module>
    from .opDataSelection import (
  File "/Users/kutra/sources/ilastik-meta/ilastik/ilastik/applets/dataSelection/opDataSelection.py", line 39, in <module>
    from lazyflow.operators.ioOperators import OpStreamingH5N5Reader
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operators/ioOperators/__init__.py", line 54, in <module>
    from .opInputDataReader import *
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operators/ioOperators/opInputDataReader.py", line 54, in <module>
    from lazyflow.operators.ioOperators import OpDvidVolume, OpDvidRoi
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operators/ioOperators/OpDvidVolume.py", line 40, in <module>
    from libdvid import DVIDException, ErrMsg
ModuleNotFoundError: No module named 'libdvid'
```

</details>

whereas on linux the stack-trace would be

<details>

```pytb
Traceback (most recent call last):
  File "/home/kutra/scratch/t2/ilastik/lazyflow/operators/ioOperators/opInputDataReader.py", line 54, in <module>
    from lazyflow.operators.ioOperators import OpDvidVolume, OpDvidRoi
ImportError: cannot import name 'OpDvidVolume' from 'lazyflow.operators.ioOperators' (/home/kutra/scratch/t2/ilastik/lazyflow/operators/ioOperators/__init__.py)
```

</details>