### PR TITLE
Multicut - simple Edge Feature Selection

### DIFF
--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -95,6 +95,10 @@ class EdgeTrainingMixin:
         self._init_edge_label_colortable()
         self._init_probability_colortable()
 
+        # init features
+        if not self.topLevelOperatorView.FeatureNames.ready():
+            self.topLevelOperatorView.FeatureNames.setValue(self._get_default_feature_selection())
+
     def _after_init(self):
         super()._after_init()
         self.update_probability_edges()

--- a/ilastik/applets/edgeTraining/edgeTrainingGui.py
+++ b/ilastik/applets/edgeTraining/edgeTrainingGui.py
@@ -37,7 +37,7 @@ from PyQt5.QtWidgets import (
     QMenu,
 )
 
-from ilastikrag.gui import FeatureSelectionDialog
+from .simpleEdgeFeatSelection import SimpleEdgeFeatureSelection
 from lazyflow.utility.orderedSignal import OrderedSignal
 
 from ilastik.utility.gui import threadRouted, silent_qobject
@@ -213,11 +213,16 @@ class EdgeTrainingMixin:
         cleanup_fn = op.GroundtruthSegmentation.notifyReady(self.configure_gui_from_operator, defer=True)
         self.__cleanup_fns.append(cleanup_fn)
 
+    def _get_default_feature_selection(self):
+        raw_channels = self.topLevelOperatorView.RawData.meta.channel_names
+        raw_is_3d = self.topLevelOperatorView.RawData.meta.getTaggedShape().get("z", 1) > 1
+        selected_input_channels = self.topLevelOperatorView.WatershedSelectedInput.meta.channel_names
+        return SimpleEdgeFeatureSelection.default_features(raw_channels, selected_input_channels, raw_is_3d)
+
     def _open_feature_selection_dlg(self):
-        rag = self.topLevelOperatorView.Rag.value
-        feature_names = rag.supported_features()
-        channel_names = self.topLevelOperatorView.VoxelData.meta.channel_names
-        default_selections = self.topLevelOperatorView.FeatureNames.value
+        if not self.topLevelOperatorView.FeatureNames.ready():
+            self.topLevelOperatorView.FeatureNames.setValue(self._get_default_feature_selection())
+        current_selection = self.topLevelOperatorView.FeatureNames.value
 
         def decodeToStringIfBytes(s):
             if isinstance(s, bytes):
@@ -225,21 +230,35 @@ class EdgeTrainingMixin:
             else:
                 return s
 
+        rag = self.topLevelOperatorView.Rag.value
+        feature_names = rag.supported_features()
+        channel_names = self.topLevelOperatorView.VoxelData.meta.channel_names
         channel_names = [decodeToStringIfBytes(s) for s in channel_names]
         feature_names = [decodeToStringIfBytes(s) for s in feature_names]
-        # default_selections
-        #    *dict, str: list - of - str *
-        default_selections_strings = {}
-        for key, value in default_selections.items():
-            default_selections_strings[decodeToStringIfBytes(key)] = [decodeToStringIfBytes(s) for s in value]
 
-        dlg = FeatureSelectionDialog(channel_names, feature_names, default_selections_strings, parent=self)
-        dlg_result = dlg.exec_()
-        if dlg_result != dlg.Accepted:
+        initial_selections = {}
+        for key, value in current_selection.items():
+            initial_selections[decodeToStringIfBytes(key)] = [decodeToStringIfBytes(s) for s in value]
+
+        raw_channels = self.topLevelOperatorView.RawData.meta.channel_names
+        selected_input_channels = self.topLevelOperatorView.WatershedSelectedInput.meta.channel_names
+        probability_channels = [x for x in channel_names if x not in raw_channels + selected_input_channels]
+        raw_is_3d = self.topLevelOperatorView.RawData.meta.getTaggedShape().get("z", 1) > 1
+
+        dlg = SimpleEdgeFeatureSelection(
+            raw_channels,
+            selected_input_channels,
+            probability_channels,
+            initial_selections,
+            supported_features=feature_names,
+            data_is_3d=raw_is_3d,
+            parent=self,
+        )
+        res = dlg.exec_()
+        if res != dlg.Accepted:
             return
 
-        selections = dlg.selections()
-        self.topLevelOperatorView.FeatureNames.setValue(selections)
+        self.topLevelOperatorView.FeatureNames.setValue(dlg.selections())
 
     # Configure the handler for updated edge label maps
     def _init_edge_label_colortable(self):

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 
 class OpEdgeTraining(Operator):
     # Shared across lanes
-    DEFAULT_FEATURES = {"Grayscale": ["standard_edge_mean"]}
-    FeatureNames = InputSlot(value=DEFAULT_FEATURES)
+    FeatureNames = InputSlot()
     FreezeClassifier = InputSlot(value=True)
     TrainRandomForest = InputSlot(value=True)
 

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -27,7 +27,7 @@ class OpEdgeTraining(Operator):
     DEFAULT_FEATURES = {"Grayscale": ["standard_edge_mean"]}
     FeatureNames = InputSlot(value=DEFAULT_FEATURES)
     FreezeClassifier = InputSlot(value=True)
-    TrainRandomForest = InputSlot(value=False)
+    TrainRandomForest = InputSlot(value=True)
 
     # Lane-wise
     WatershedSelectedInput = InputSlot(level=1)

--- a/ilastik/applets/edgeTraining/simpleEdgeFeatSelection.py
+++ b/ilastik/applets/edgeTraining/simpleEdgeFeatSelection.py
@@ -1,0 +1,427 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2022, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#           http://ilastik.org/license.html
+###############################################################################
+import enum
+from functools import partial
+from typing import Dict, List, Set
+
+from ilastikrag.gui import FeatureSelectionDialog
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGroupBox,
+    QLabel,
+    QLayout,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ilastik.utility.gui.widgets import silent_qobject
+from ilastik.widgets.collapsibleWidget import CollapsibleWidget
+
+
+class SimpleEdgeFeatureSelection(QDialog):
+    """Simplified Edge feature selection dialog
+
+    The feature set behind the simplified feature groups are hard-coded in
+    `_defaultFeaturesStateDict`. These must be a subset of `supported_features`,
+    otherwise the dialog errors out.
+
+    `self._current_selection` is kept up to date via updateState callback from
+    checkmarks of this dialog. After accepting the advanced dialog, it is updated
+    via `_setFeatures`.
+
+    Args:
+      raw_channels: names of the raw channels that should be included in the selection
+      boundary_channels: names of the channels that were considered when calculating the superpixels
+      probability_channels names of the probability channels
+      selection: dictionary of (initially) selected features per channel.
+        {"channel_name": ["selected_feature1", "selected_feature2", ...]}
+      supported_feaures: list of feature names -> passed to ilastikrag.gui.FeatureSelectionDialog
+      data_is_3d: default feature set depends on dimensionality (2d vs 3d data)
+      parent: parent widget - dialog is modal and will block the parent
+    """
+
+    @enum.unique
+    class FeatureGroup(enum.Enum):
+        shape = "shape"
+        boundary_edge = "boundary channel along edges"
+        boundary_sp = "boundary channel on superpixels"
+        raw_edge = "raw data along edges"
+        raw_sp = "raw data on superpixels"
+
+    def __init__(
+        self,
+        raw_channels: List[str],
+        boundary_channels: List[str],
+        probability_channels: List[str],
+        selection: Dict[str, List[str]],
+        supported_features: List[str],
+        data_is_3d: bool = False,
+        parent: QWidget = None,
+    ):
+        super().__init__(parent)
+        layout = QVBoxLayout()
+
+        self.setWindowTitle("Edge Feature Selection")
+        self.raw_channels = raw_channels
+        self.boundary_channels = boundary_channels
+        self.probability_channels = probability_channels
+        self.data_is_3d = data_is_3d
+        self.channel_names = raw_channels + boundary_channels + probability_channels
+        # for the "big" feature selection dialog (ilastikrag)
+        self.supported_features = supported_features
+
+        self._internal_state = self._defaultFeaturesStateDict(raw_channels, boundary_channels, data_is_3d)
+
+        def make_checkbox(name):
+            checkbox = QCheckBox(name.value)
+            details = self._internal_state[name]
+            checkbox.stateChanged.connect(partial(self._updateState, name))
+            checkbox.setToolTip(details["description"])
+            return checkbox
+
+        self.checkboxes = {}
+
+        shapeGroupBox = QGroupBox("Shape")
+        shapeLayout = QVBoxLayout()
+        self.checkboxes[self.FeatureGroup.shape] = make_checkbox(self.FeatureGroup.shape)
+        shapeLabel = QLabel(
+            "Shape features take into account the shape of the superpixels. "
+            "These include the length/area, as well as an estimate of radii of an "
+            "ellipse/ellipsoid fitted to each edge."
+        )
+        shapeLabel.setWordWrap(True)
+
+        shapeLayout.addWidget(self.checkboxes[self.FeatureGroup.shape])
+        shapeLayout.addWidget(CollapsibleWidget(shapeLabel))
+        shapeGroupBox.setLayout(shapeLayout)
+        self.shapeGroupBox = shapeGroupBox
+
+        layout.addWidget(shapeGroupBox)
+
+        intensityGroupBox = QGroupBox("Intensity statistics")
+        intensityLayout = QVBoxLayout()
+        self.checkboxes[self.FeatureGroup.boundary_edge] = make_checkbox(self.FeatureGroup.boundary_edge)
+        self.checkboxes[self.FeatureGroup.boundary_sp] = make_checkbox(self.FeatureGroup.boundary_sp)
+        intensityLayout.addWidget(self.checkboxes[self.FeatureGroup.boundary_edge])
+        intensityLayout.addWidget(self.checkboxes[self.FeatureGroup.boundary_sp])
+
+        self.checkboxes[self.FeatureGroup.raw_edge] = make_checkbox(self.FeatureGroup.raw_edge)
+        self.checkboxes[self.FeatureGroup.raw_sp] = make_checkbox(self.FeatureGroup.raw_sp)
+        intensityLayout.addWidget(self.checkboxes[self.FeatureGroup.raw_edge])
+        intensityLayout.addWidget(self.checkboxes[self.FeatureGroup.raw_sp])
+        intensityLabel = QLabel(
+            "Intensity statistics are computed along either edges or superpixel area/volume. "
+            "Quantities computed include 10th and 90th quantile, and mean intensity. "
+            "For raw data these quantities are computed per channel."
+        )
+        intensityLabel.setWordWrap(True)
+        intensityLayout.addWidget(CollapsibleWidget(intensityLabel))
+        intensityGroupBox.setLayout(intensityLayout)
+        self.intensityGroupBox = intensityGroupBox
+        layout.addWidget(intensityGroupBox)
+
+        buttonbox = QDialogButtonBox(Qt.Horizontal)
+        buttonbox.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttonbox.accepted.connect(self.accept)
+        buttonbox.rejected.connect(self.reject)
+
+        advButton = QPushButton("Advanced")
+        advButton.clicked.connect(self._openAdvancedDlg)
+        self._advButton = advButton
+        buttonbox.addButton(advButton, QDialogButtonBox.ActionRole)
+
+        resetButton = QPushButton("Reset")
+        resetButton.setToolTip("Reset selection to default.")
+        resetButton.clicked.connect(self._resetToDefault)
+        buttonbox.addButton(resetButton, QDialogButtonBox.ResetRole)
+        layout.addWidget(buttonbox)
+
+        self.setLayout(layout)
+        layout.setSizeConstraint(QLayout.SetFixedSize)
+        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+
+        self._setFeatures(selection)
+
+    def _setFeatures(self, features: Dict[str, List[str]]):
+        """update current feature set and synchronize GUI
+
+        internal state is synchronized via callbacks on checkboxes.stateChanged
+
+        Args:
+          features: dictionary in the same format as used to set value in slots:
+            {"channel_name": ["selected_feature1", "selected_feature2", ...]}
+        """
+        self._current_selection = features
+        if not self._checkSelectionCompatible(self._current_selection):
+            self._setEnabledState(False)
+            for group, checkbox in self.checkboxes.items():
+                with silent_qobject(checkbox) as w:
+                    w.setChecked(Qt.Unchecked)
+                    self._internal_state[group]["state"] = False
+            return
+
+        self._setEnabledState(True)
+
+        # synchronize checkboxes
+        if self._current_selection:
+            checks = self._checkmarks(self._current_selection)
+            for group, val in checks.items():
+                with silent_qobject(self.checkboxes[group]) as w:
+                    w.setCheckState(Qt.Checked if val else Qt.Unchecked)
+                    self._internal_state[group]["state"] = val
+
+    def _setEnabledState(self, state: bool):
+        """User has selected something in the advanced dialog, disable all checkboxes."""
+        self.intensityGroupBox.setEnabled(state)
+        self.shapeGroupBox.setEnabled(state)
+
+        if state:
+            self._advButton.setText("Advanced")
+            self._advButton.setToolTip("Open advanced Feature Selection Dialog for more fine-grained control.")
+        else:
+            self._advButton.setText("Advanced*")
+            self._advButton.setToolTip(
+                "Non-standard feature selection - reset or open advanced Feature Selection Dialog for more fine-grained control."
+            )
+
+    def _updateState(self, group, state):
+        """update after checkbox change - always valid feature set"""
+        self._internal_state[group]["state"] = bool(state)
+        self._current_selection = SimpleEdgeFeatureSelection._to_feature_dict(self._internal_state)
+
+    def _checkSelectionCompatible(self, selection) -> bool:
+        for group, group_features in self._internal_state.items():
+            # make sure that groups are not _partly_ selected
+            for chan, features in group_features["features"].items():
+                overlap_sum = sum(x in features for x in selection.get(chan, []))
+                if overlap_sum not in [0, len(features)]:
+                    return False
+            # now check that there are no features not in the default_feauture_set
+            feats_flat = SimpleEdgeFeatureSelection.default_features(
+                self.raw_channels, self.boundary_channels, self.data_is_3d
+            )
+            for chan, feats in selection.items():
+                if feats and (chan not in feats_flat):
+                    return False
+                if any(x not in feats_flat[chan] for x in feats):
+                    return False
+        return True
+
+    def _resetToDefault(self):
+        self._internal_state = self._defaultFeaturesStateDict(self.raw_channels, self.boundary_channels)
+        self._setFeatures(SimpleEdgeFeatureSelection._to_feature_dict(self._internal_state))
+
+    def _checkmarks(self, selection: Dict[str, List[str]]) -> Dict[str, bool]:
+        if not self._checkSelectionCompatible(selection):
+            # don't bother
+            return {}
+
+        checks = {}
+        for group, group_features in self._internal_state.items():
+            # make sure that groups are not _partly_ selected
+            for chan, features in group_features["features"].items():
+                overlap_sum = sum(x in features for x in selection.get(chan, []))
+                if overlap_sum == len(features):
+                    checks[group] = True
+                else:
+                    checks[group] = False
+
+        return checks
+
+    def _openAdvancedDlg(self):
+        default_features = SimpleEdgeFeatureSelection._to_feature_dict(
+            self._defaultFeaturesStateDict(self.raw_channels, self.boundary_channels)
+        )
+
+        dlg = FeatureSelectionDialog(
+            self.channel_names, self.supported_features, self.selections(), default_features, parent=self
+        )
+        dlg_result = dlg.exec_()
+        if dlg_result != dlg.Accepted:
+            return
+
+        selections = dlg.selections()
+        self._setFeatures(selections)
+
+    def selections(self) -> Dict[str, List[str]]:
+        """
+        feature selection compatible with operator/ilastikrag.gui.feature_selection_dialog
+
+        returns:
+          dict of currently selected features (values) per channel name (keys)
+        """
+        return self._current_selection
+
+    @classmethod
+    def _defaultFeaturesStateDict(cls, raw_channels, edge_channels, data_is_3d=False):
+        default_sp_features = [
+            "standard_sp_mean",
+            "standard_sp_quantiles_10",
+            "standard_sp_quantiles_90",
+        ]
+        default_boundary_features = [
+            "standard_edge_mean",
+            "standard_edge_quantiles_10",
+            "standard_edge_quantiles_90",
+        ]
+        default_shape_feautures = [
+            "edgeregion_edge_regionradii_0",
+            "edgeregion_edge_regionradii_1",
+        ]
+
+        if data_is_3d:
+            default_shape_feautures += ["edgeregion_edge_regionradii_2"]
+
+        selected_features = {}
+
+        for channel in raw_channels:
+            selected_features[channel] = default_sp_features
+
+        for channel in edge_channels:
+            selected_features[channel] = default_boundary_features
+
+        default_dialog_features = {
+            cls.FeatureGroup.shape: {
+                "features": {edge_channels[0]: default_shape_feautures},
+                "state": True,
+                "description": "Radii of the superpixel edges as estimated by eigenvalues of the PCA.",
+            },
+            cls.FeatureGroup.boundary_edge: {
+                "description": "Intensity statistics (mean, Q10, Q90) computed on the boundary channel along the edges.",
+                "features": {channel: default_boundary_features for channel in edge_channels},
+                "state": True,
+            },
+            cls.FeatureGroup.raw_edge: {
+                "description": "Intensity statistics (mean, Q10, Q90) computed on the raw data along the edges.",
+                "features": {channel: default_boundary_features for channel in raw_channels},
+                "state": False,
+            },
+            cls.FeatureGroup.boundary_sp: {
+                "description": "Intensity statistics (mean, Q10, Q90) computed on the boundary channel on superpixels.",
+                "features": {channel: default_sp_features for channel in edge_channels},
+                "state": False,
+            },
+            cls.FeatureGroup.raw_sp: {
+                "description": "Intensity statistics (mean, Q10, Q90) computed on the raw data on superpixels.",
+                "features": {channel: default_sp_features for channel in raw_channels},
+                "state": True,
+            },
+        }
+
+        return default_dialog_features
+
+    @staticmethod
+    def _to_feature_dict(state_dict) -> Dict[str, List[str]]:
+        selected_features: Dict[str, Set[str]] = {}
+
+        for group_features in state_dict.values():
+            if group_features["state"]:
+                for channel, features in group_features["features"].items():
+                    if channel not in selected_features:
+                        selected_features[channel] = set()
+                    selected_features[channel] |= set(features)
+
+        return {k: list(v) for k, v in selected_features.items() if v}
+
+    @classmethod
+    def default_features(cls, raw_channels, boundary_channels, data_is_3d):
+        return cls._to_feature_dict(cls._defaultFeaturesStateDict(raw_channels, boundary_channels, data_is_3d))
+
+
+if __name__ == "__main__":
+    import os
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.environ["QT_MAC_WANTS_LAYER"] = "1"
+    os.environ["VOLUMINA_SHOW_3D_WIDGET"] = "0"
+
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication([])
+
+    supported_features = [
+        "edgeregion_edge_area",
+        "edgeregion_edge_regionradii_0",
+        "edgeregion_edge_regionradii_1",
+        "standard_sp_mean",
+        "standard_sp_quantiles_10",
+        "standard_sp_quantiles_100",
+        "standard_sp_quantiles_20",
+        "standard_sp_quantiles_30",
+        "standard_sp_quantiles_40",
+        "standard_sp_quantiles_50",
+        "standard_sp_quantiles_60",
+        "standard_sp_quantiles_70",
+        "standard_sp_quantiles_80",
+        "standard_sp_quantiles_90",
+        "standard_edge_mean",
+        "standard_edge_quantiles_10",
+        "standard_edge_quantiles_100",
+        "standard_edge_quantiles_20",
+        "standard_edge_quantiles_30",
+        "standard_edge_quantiles_40",
+        "standard_edge_quantiles_50",
+        "standard_edge_quantiles_60",
+        "standard_edge_quantiles_70",
+        "standard_edge_quantiles_80",
+        "standard_edge_quantiles_90",
+    ]
+
+    dlg = SimpleEdgeFeatureSelection(
+        [
+            "raw 0",
+            "raw 1",
+            "raw 2",
+        ],
+        ["boundary"],
+        ["probs 1", "probs 2"],
+        {
+            "boundary": ["standard_sp_mean", "standard_sp_quantiles_10", "standard_sp_quantiles_90"],
+            "raw 0": [
+                "standard_edge_mean",
+                "standard_edge_quantiles_10",
+                "standard_edge_quantiles_90",
+            ],
+            "raw 51": [
+                "standard_edge_mean",
+                "standard_edge_quantiles_10",
+                "standard_edge_quantiles_90",
+            ],
+            "raw 16": [
+                "standard_edge_mean",
+                "standard_edge_quantiles_10",
+                "standard_edge_quantiles_90",
+            ],
+        },
+        supported_features=supported_features,
+    )
+    dlg.exec_()
+
+    if dlg.Accepted:
+        from pprint import pprint
+
+        pprint(dlg.selections())

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -10,7 +10,7 @@ class OpEdgeTrainingWithMulticut(Operator):
     # Edge Training parameters
     FeatureNames = InputSlot(value=OpEdgeTraining.DEFAULT_FEATURES)
     FreezeClassifier = InputSlot(value=True)
-    TrainRandomForest = InputSlot(value=False)
+    TrainRandomForest = InputSlot(value=True)
 
     # Multicut parameters
     Beta = InputSlot(value=0.5)

--- a/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/opEdgeTrainingWithMulticut.py
@@ -8,7 +8,7 @@ from ilastik.utility import OpMultiLaneWrapper, OperatorSubView
 class OpEdgeTrainingWithMulticut(Operator):
 
     # Edge Training parameters
-    FeatureNames = InputSlot(value=OpEdgeTraining.DEFAULT_FEATURES)
+    FeatureNames = InputSlot()
     FreezeClassifier = InputSlot(value=True)
     TrainRandomForest = InputSlot(value=True)
 

--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -6,7 +6,7 @@ from elf.segmentation.watershed import distance_transform_watershed
 from lazyflow.utility import OrderedSignal
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.roi import roiToSlice, sliceToRoi
-from lazyflow.operators import OpBlockedArrayCache, OpValueCache
+from lazyflow.operators import OpBlockedArrayCache, OpValueCache, OpMetadataInjector
 from lazyflow.operators.generic import OpPixelOperator, OpSingleChannelSelector
 
 
@@ -148,7 +148,13 @@ class OpCachedWsdt(Operator):
         self._opSelectedInput.ChannelSelections.connect(self.ChannelSelections)
         self._opSelectedInput.Input.connect(self.Input)
         self._opSelectedInput.InvertPixelProbabilities.connect(self.InvertPixelProbabilities)
-        self.SelectedInput.connect(self._opSelectedInput.Output)
+
+        # rename output channel name
+        self._opMetaInjector = OpMetadataInjector(parent=self)
+        self._opMetaInjector.Input.connect(self._opSelectedInput.Output)
+        self._opMetaInjector.Metadata.setValue({"channel_names": ["wsdt boundary channel"]})
+
+        self.SelectedInput.connect(self._opMetaInjector.Output)
 
         self._opThreshold = OpPixelOperator(parent=self)
         self._opThreshold.Input.connect(self._opSelectedInput.Output)

--- a/ilastik/widgets/collapsibleWidget.py
+++ b/ilastik/widgets/collapsibleWidget.py
@@ -1,0 +1,103 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2022, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from PyQt5.QtCore import QAbstractAnimation, QParallelAnimationGroup, QPropertyAnimation, Qt
+from PyQt5.QtWidgets import QToolButton, QVBoxLayout, QWidget
+
+
+# derived from https://stackoverflow.com/a/37119983
+class CollapsibleWidget(QWidget):
+    """Wraps a widget to expand/collapse on button press"""
+
+    def __init__(
+        self,
+        widget: QWidget,
+        header: str = "Details",
+        animation_duration: int = 100,
+        parent=None,
+    ):
+        """
+        Args:
+          widget: QWidget to be wrapped in a collapsible container. Multiple widgets
+            can be given as content by e.g. wrapping them in a QScrollArea. Widget
+            should be configured fully when passing it (to ensure correct sizing).
+            No resizing is taken into account.
+          header: Text displayed next to the arrow toolbutton
+          start_collapsed: Control initial state. Set to False to have widget expanded
+            visible upon construction.
+        """
+
+        super().__init__(parent)
+
+        toggleButton = QToolButton()
+        toggleButton.setStyleSheet("QToolButton {border: none;}")
+        toggleButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        toggleButton.setArrowType(Qt.ArrowType.RightArrow)
+        toggleButton.setText(header)
+        toggleButton.setCheckable(True)
+        toggleButton.setChecked(False)
+
+        # for testing:
+        self._toggleButton = toggleButton
+
+        # initial state: minimized
+        widget.setMaximumHeight(0)
+        widget.setMinimumHeight(0)
+
+        animation = QParallelAnimationGroup()
+        animation.addAnimation(QPropertyAnimation(self, b"minimumHeight"))
+        animation.addAnimation(QPropertyAnimation(self, b"maximumHeight"))
+        animation.addAnimation(QPropertyAnimation(widget, b"maximumHeight"))
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(toggleButton)
+
+        contentLayout = QVBoxLayout()
+        contentLayout.addWidget(widget)
+        layout.addLayout(contentLayout)
+
+        self.setLayout(layout)
+
+        def updateState(checked: bool):
+            if checked:
+                toggleButton.setArrowType(Qt.ArrowType.DownArrow)
+                animation.setDirection(QAbstractAnimation.Forward)
+            else:
+                toggleButton.setArrowType(Qt.ArrowType.RightArrow)
+                animation.setDirection(QAbstractAnimation.Backward)
+
+            animation.start()
+
+        toggleButton.clicked.connect(updateState)
+
+        collapsedHeight = self.sizeHint().height() - widget.maximumHeight()
+        contentHeight = widget.sizeHint().height()
+
+        for i in range(animation.animationCount() - 1):
+            anim = animation.animationAt(i)
+            anim.setDuration(animation_duration)
+            anim.setStartValue(collapsedHeight)
+            anim.setEndValue(collapsedHeight + contentHeight)
+
+        anim = animation.animationAt(animation.animationCount() - 1)
+        anim.setDuration(animation_duration)
+        anim.setStartValue(0)
+        anim.setEndValue(contentHeight)

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -225,11 +225,17 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
         opWsdt.RawData.connect(opDataSelection.ImageGroup[self.DATA_ROLE_RAW])
         opWsdt.Input.connect(opNormalizeProbabilities.Output)
 
+        # SELECTED WS INPUT: Convert to float32
+        opConvertSelectedWsInput = OpConvertDtype(parent=self)
+        opConvertSelectedWsInput.ConversionDtype.setValue(np.float32)
+        opConvertSelectedWsInput.Input.connect(opWsdt.SelectedInput)
+
         # Actual computation is done with both RawData and Probabilities
         opStackRawAndVoxels = OpSimpleStacker(parent=self)
-        opStackRawAndVoxels.Images.resize(2)
+        opStackRawAndVoxels.Images.resize(3)
         opStackRawAndVoxels.Images[0].connect(opConvertRaw.Output)
         opStackRawAndVoxels.Images[1].connect(opNormalizeProbabilities.Output)
+        opStackRawAndVoxels.Images[2].connect(opConvertSelectedWsInput.Output)
         opStackRawAndVoxels.AxisFlag.setValue("c")
 
         # If superpixels are available from a file, use it.

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -94,8 +94,6 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
             self, "Training and Multicut", "Training and Multicut"
         )
         opEdgeTrainingWithMulticut = self.edgeTrainingWithMulticutApplet.topLevelOperator
-        DEFAULT_FEATURES = {self.ROLE_NAMES[self.DATA_ROLE_RAW]: ["standard_edge_mean"]}
-        opEdgeTrainingWithMulticut.FeatureNames.setValue(DEFAULT_FEATURES)
 
         # -- DataExport applet
         #

--- a/ilastik/workflows/multicut/multicutWorkflow.py
+++ b/ilastik/workflows/multicut/multicutWorkflow.py
@@ -89,9 +89,6 @@ class MulticutWorkflow(Workflow):
         # -- Edge training applet
         #
         self.edgeTrainingApplet = EdgeTrainingApplet(self, "Edge Training", "Edge Training")
-        opEdgeTraining = self.edgeTrainingApplet.topLevelOperator
-        DEFAULT_FEATURES = {self.ROLE_NAMES[self.DATA_ROLE_RAW]: ["standard_edge_mean"]}
-        opEdgeTraining.FeatureNames.setValue(DEFAULT_FEATURES)
 
         # -- Multicut applet
         #

--- a/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
+++ b/tests/test_ilastik/test_applets/edgeTraining/testEdgeTrainingSerializer.py
@@ -55,8 +55,8 @@ def test_serializer_roundtrip(graph, inputs, empty_project_file, superpixels, ra
     op.WatershedSelectedInput.connect(inputs.WatershedSelectedInput)
 
     # set level0 slots
-    op.TrainRandomForest.setValue(False)
     op.FeatureNames.setValue({"test0": [b"test_feature_0", b"test_feature_1"]})
+    op.TrainRandomForest.setValue(True)
 
     # set level1 slots
     laneop = op.getLane(content_lane)
@@ -82,7 +82,7 @@ def test_serializer_roundtrip(graph, inputs, empty_project_file, superpixels, ra
     deserializer.deserializeFromHdf5(empty_project_file, empty_project_file.name)
 
     # check level0 slots
-    assert not op_load.TrainRandomForest.value
+    assert op_load.TrainRandomForest.value
     assert all(a == b for a, b in zip(op_load.FeatureNames.value["test0"], [b"test_feature_0", b"test_feature_1"]))
 
     # check level1 slots
@@ -111,6 +111,9 @@ def test_serializer_01_02(graph, inputs, empty_project_file, serializer_version,
     op.VoxelData.connect(inputs.VoxelData)
     op.Superpixels.connect(inputs.Superpixels)
     op.WatershedSelectedInput.connect(inputs.WatershedSelectedInput)
+    # need to set _something_ to make operator "ready"
+    # this is necessary since the removal of the default value here
+    op.FeatureNames.setValue({"test0": [b"test_feature_0", b"test_feature_1"]})
     op.TrainRandomForest.setValue(train_rf)
 
     laneop = op.getLane(0)

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -239,6 +239,8 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             QApplication.processEvents()
             self.waitForViews(gui.editor.imageViews)
 
+            gui.train_edge_clf_box.setChecked(False)
+            QApplication.processEvents()
             assert not gui.train_edge_clf_box.isChecked()
 
             threshold = 0.5

--- a/tests/test_ilastik/widgets/test_collapsibleWidget.py
+++ b/tests/test_ilastik/widgets/test_collapsibleWidget.py
@@ -1,0 +1,34 @@
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel
+
+from ilastik.widgets.collapsibleWidget import CollapsibleWidget
+
+
+@pytest.fixture
+def widget(qtbot):
+    w = QLabel("Test 42")
+    qtbot.addWidget(w)
+    return w
+
+
+def test_state_change(qtbot, widget):
+    w = CollapsibleWidget(widget, animation_duration=0)
+
+    qtbot.addWidget(w)
+    w.show()
+    with qtbot.waitExposed(w):
+        # start off collapsed
+        assert widget.visibleRegion().isEmpty()
+
+        # expand
+        qtbot.mouseClick(w._toggleButton, Qt.MouseButton.LeftButton)
+        qtbot.wait(50)  # wait for change to settle, since we're querying gui state
+
+        assert not widget.visibleRegion().isEmpty()
+
+        # collapse again
+        qtbot.mouseClick(w._toggleButton, Qt.MouseButton.LeftButton)
+        qtbot.wait(50)  # wait for change to settle, since we're querying gui state
+
+        assert widget.visibleRegion().isEmpty()


### PR DESCRIPTION
Using input of the very useful discussion in #2546 @akreshuk and I came up with the simple dialog for selecting features.

Available features:
* shape: translates to a subset of edgeregion(edge): radii
* Intensity: mean, Q10, Q90. For raw data always computed on all channels (per channel). Per default it is not possible to select a probability channel here, only raw data, or "boundary channel".


Screenshots:

<details>


<img width="498" alt="default feature selection" src="https://user-images.githubusercontent.com/24434157/189346258-e08bd541-d990-45c1-816d-acc44a91cce9.png">
features selected per default


<img width="1298" alt="default features in the advanced dialog" src="https://user-images.githubusercontent.com/24434157/189346340-5387e90c-cbf8-4421-986a-461f5928cb14.png">
default features in the advanced dialog


<img width="498" alt="indication of non-default selection" src="https://user-images.githubusercontent.com/24434157/189346454-397394b0-91ec-45dc-acc0-5213641b934a.png">
indication of non-default selection


</details>

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests. --> no 😢
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io). --> no 😢
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.


Note: This will be merged if tests pass - in case of comments, pls open an issue.