### PR TITLE
Fix warnings

### DIFF
--- a/ilastik/applets/counting/countingOperators.py
+++ b/ilastik/applets/counting/countingOperators.py
@@ -380,7 +380,7 @@ class OpTrainCounter(Operator):
             constraintindices.append(offset)
 
             constraintvalues = np.array(constraintvalues, np.float64)
-            constraintindices = np.array(constraintindices, np.int)
+            constraintindices = np.array(constraintindices, np.int64)
 
             boxConstraints = {
                 "boxFeatures": constraintmatrix,

--- a/ilastik/applets/counting/opCounting.py
+++ b/ilastik/applets/counting/opCounting.py
@@ -286,7 +286,7 @@ class OpCounting(Operator):
         # Set background-labels (annotations) to zero...
         def conv(arr):
             numpy.place(arr, arr == 2, 0)
-            return arr.astype(numpy.float)
+            return arr.astype(numpy.float32)
 
         self.opExtractForegroundLabels.Function.setValue(conv)
         self.opExtractForegroundLabels.Input.connect(self.opLabelPipeline.Output)

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -86,7 +86,7 @@ class DatasetInfo(ABC):
         self.laneShape = laneShape
         self.laneDtype = laneDtype
         if isinstance(self.laneDtype, numpy.dtype):
-            self.laneDtype = numpy.typeDict[self.laneDtype.name]
+            self.laneDtype = numpy.sctypeDict[self.laneDtype.name]
         self.allowLabels = allowLabels
         self.subvolume_roi = subvolume_roi
         self.axistags = axistags

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -298,7 +298,7 @@ class OpObjectCenterImage(Operator):
                 a = b
                 T += 1
             time_index = self.BinaryImage.meta.axistags.index("t")
-            stop = numpy.asarray(self.BinaryImage.meta.shape, dtype=numpy.int)
+            stop = numpy.asarray(self.BinaryImage.meta.shape, dtype=numpy.int64)
             start = numpy.zeros_like(stop)
             stop[time_index] = T
             start[time_index] = t

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -110,10 +110,10 @@ def make_bboxes(binary_bbox, margin):
         dt = dt.reshape(dt.shape + (1,))
 
     assert dt.ndim == 3
-    passed = numpy.asarray(dt < max_margin).astype(numpy.bool)
+    passed = numpy.asarray(dt < max_margin).astype(bool)
 
     # context only
-    context = numpy.asarray(passed) ^ numpy.asarray(binary_bbox).astype(numpy.bool)
+    context = numpy.asarray(passed) ^ numpy.asarray(binary_bbox).astype(bool)
     return passed, context
 
 
@@ -713,7 +713,7 @@ class OpRegionFeatures(Operator):
                 extent = self.compute_extent(i, image, mincoords, maxcoords, axes, margin)
                 rawbbox = self.compute_rawbbox(image, extent, axes)
                 # it's i+1 here, because the background has label 0
-                binary_bbox = numpy.where(labels[tuple(extent)] == i + 1, 1, 0).astype(numpy.bool)
+                binary_bbox = numpy.where(labels[tuple(extent)] == i + 1, 1, 0).astype(bool)
                 for plugin_name, feature_dict in feature_names.items():
                     if not has_local_features[plugin_name]:
                         continue

--- a/ilastik/applets/thresholdTwoLevels/_OpObjectsSegment.py
+++ b/ilastik/applets/thresholdTwoLevels/_OpObjectsSegment.py
@@ -107,7 +107,7 @@ class OpObjectsSegment(OpGraphCut):
         # needs a shape
         shape = self.Prediction.meta.shape
         self.BoundingBoxes.meta.shape = shape
-        self.BoundingBoxes.meta.dtype = np.object
+        self.BoundingBoxes.meta.dtype = object
         self.BoundingBoxes.meta.axistags = vigra.defaultAxistags("tzyxc")
 
     def execute(self, slot, subindex, roi, result):

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -218,7 +218,7 @@ def prepare_list(list_, names, dtypes=None):
         for col, (item, col_name) in enumerate(zip(first_row, names)):
             item_dtype = np.dtype(type(item))
             col_dtype = (col_name, item_dtype)
-            if item_dtype == np.str:
+            if item_dtype == str:
                 maxlen = max(len(row_data[col]) for row_data in list_)
                 col_dtype = (col_name, item_dtype, maxlen)
             dtypes.append(col_dtype)

--- a/ilastik/workflows/voxelSegmentation/opSlic.py
+++ b/ilastik/workflows/voxelSegmentation/opSlic.py
@@ -61,7 +61,7 @@ class OpSlic(Operator):
 
         if n_segments == 0:
             # If the number of supervoxels was not given, use a default proportional to the number of voxels
-            n_segments = numpy.int(bigintprod(input_data.shape) / 2500)
+            n_segments = numpy.int64(bigintprod(input_data.shape) / 2500)
 
         logger.debug(
             "calling skimage.segmentation.slic with {}".format(

--- a/lazyflow/classifiers/vigraRfAdaptiveMaskPixelwiseClassifier.py
+++ b/lazyflow/classifiers/vigraRfAdaptiveMaskPixelwiseClassifier.py
@@ -112,13 +112,13 @@ class VigraRfAdaptiveMaskPixelwiseClassifier(LazyflowPixelwiseClassifierABC):
 
         # Allocate memory for probability volume and mask
         prob_vol = numpy.zeros((X.shape[:-1] + (len(self._known_labels),)), dtype=numpy.float32)
-        mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=numpy.bool)
+        mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=bool)
 
         frm_cnt = 0
 
         for X_t in X:
             if frm_cnt % FRAME_SPAN == 0:
-                mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=numpy.bool)
+                mask = numpy.ones(bigintprod(X.shape[1:-1]), dtype=bool)
 
             prob_mat = numpy.zeros((bigintprod(X.shape[1:-1]), len(self._known_labels)), dtype=numpy.float32)
 
@@ -140,7 +140,7 @@ class VigraRfAdaptiveMaskPixelwiseClassifier(LazyflowPixelwiseClassifierABC):
             # Recalculate the mask every 20 frames
             if frm_cnt % FRAME_SPAN == 0:
                 predicted_labels = numpy.argmax(prob_img[0], axis=-1) + 1
-                prob_slice = (predicted_labels != BACKGROUND_LABEL).astype(numpy.bool)
+                prob_slice = (predicted_labels != BACKGROUND_LABEL).astype(bool)
 
                 kernel = numpy.ones((DILATION_RADIUS * 2 + 1), dtype=bool)
 

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -351,13 +351,13 @@ class OpSingleChannelSelector(Operator):
 
         ideal = self.Output.meta.ideal_blockshape
         if ideal is not None and len(ideal) == len(inshape):
-            ideal = numpy.asarray(ideal, dtype=numpy.int)
+            ideal = numpy.asarray(ideal, dtype=numpy.int64)
             ideal[channelAxis] = 1
             self.Output.meta.ideal_blockshape = tuple(ideal)
 
         max_blockshape = self.Output.meta.max_blockshape
         if max_blockshape is not None and len(max_blockshape) == len(inshape):
-            max_blockshape = numpy.asarray(max_blockshape, dtype=numpy.int)
+            max_blockshape = numpy.asarray(max_blockshape, dtype=numpy.int64)
             max_blockshape[channelAxis] = 1
             self.Output.meta.max_blockshape = tuple(max_blockshape)
 

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -134,7 +134,7 @@ def _write_dict(fd, save_dict):
             dtype_char = bytes(larr.dtype.char, "utf-8")
             bytes_per_element = larr.dtype.itemsize
             b = b"a" + dtype_char + struct.pack("<L", len(larr) * bytes_per_element)
-            b += larr.tostring()
+            b += larr.tobytes()
             fd.write(b)
             continue
         raise ValueError("don't know how to save value %s" % (value,))
@@ -1322,7 +1322,7 @@ class UfmfSaverV1(UfmfSaverBase):
         self.file.write(
             struct.pack(FMT[1].HEADER, self.version, self.image_radius, self.timestamp0, self.width, self.height)
         )
-        bg_data = bg_frame.tostring()
+        bg_data = bg_frame.tobytes()
         assert len(bg_data) == self.height * self.width
         self.file.write(bg_data)
         self.last_timestamp = self.timestamp0
@@ -1358,7 +1358,7 @@ class UfmfSaverV1(UfmfSaverBase):
             assert xmax - xmin == (2 * self.image_radius)
 
             roi = origframe[ymin:ymax, xmin:xmax]
-            this_str_buf = roi.tostring()
+            this_str_buf = roi.tobytes()
             this_str_head = struct.pack(FMT[1].SUBHEADER, xmin, ymin)
 
             str_buf.append(this_str_head + this_str_buf)
@@ -1466,7 +1466,7 @@ class UfmfSaverV3(UfmfSaverBase):
         for region in regions:
             xmin, ymin, roi = region
             h, w = roi.shape
-            this_str_buf = roi.tostring()
+            this_str_buf = roi.tobytes()
             assert len(this_str_buf) == w * h
             this_str_head = struct.pack(FMT[self.version].POINTS2, xmin, ymin, w, h)
             str_buf.append(this_str_head + this_str_buf)

--- a/lazyflow/operators/opCompressedCache.py
+++ b/lazyflow/operators/opCompressedCache.py
@@ -297,7 +297,7 @@ class OpUnmanagedCompressedCache(Operator):
             ideal = self.Input.meta.ideal_blockshape
             if ideal is not None:
                 if len(ideal) == len(blockshape):
-                    ideal = numpy.asarray(ideal, dtype=numpy.int)
+                    ideal = numpy.asarray(ideal, dtype=numpy.int64)
                     for i, d in enumerate(ideal):
                         if d == 0:
                             ideal[i] = blockshape[i]

--- a/lazyflow/operators/opLabelVolume.py
+++ b/lazyflow/operators/opLabelVolume.py
@@ -252,7 +252,7 @@ class OpLabelingABC(with_metaclass(ABCMeta, Operator)):
                 raise ValueError(msg)
 
         # set cache chunk shape to the whole spatial volume
-        shape = np.asarray(self.Input.meta.shape, dtype=np.int)
+        shape = np.asarray(self.Input.meta.shape, dtype=np.int64)
         shape[0] = 1
         shape[4] = 1
         self._cache.BlockShape.setValue(tuple(shape))
@@ -303,8 +303,8 @@ class OpLabelingABC(with_metaclass(ABCMeta, Operator)):
         # do labeling in parallel over channels and time slices
         pool = RequestPool()
 
-        start = np.asarray(roi.start, dtype=np.int)
-        stop = np.asarray(roi.stop, dtype=np.int)
+        start = np.asarray(roi.start, dtype=np.int64)
+        stop = np.asarray(roi.stop, dtype=np.int64)
         for ti, t in enumerate(range(roi.start[0], roi.stop[0])):
             start[0], stop[0] = t, t + 1
             for ci, c in enumerate(range(roi.start[4], roi.stop[4])):

--- a/lazyflow/operators/opLazyConnectedComponents.py
+++ b/lazyflow/operators/opLazyConnectedComponents.py
@@ -288,7 +288,7 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
 
         self.OutputHdf5.meta.assignFrom(self.Input.meta)
         self.CleanBlocks.meta.shape = (1,)
-        self.CleanBlocks.meta.dtype = np.object
+        self.CleanBlocks.meta.dtype = object
 
         self._setDefaultInternals()
 

--- a/lazyflow/operators/opLazyConnectedComponents.py
+++ b/lazyflow/operators/opLazyConnectedComponents.py
@@ -610,7 +610,7 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
     # generate a list of adjacent chunks
     def _generateNeighbours(self, chunkIndex):
         n = []
-        idx = np.asarray(chunkIndex, dtype=np.int)
+        idx = np.asarray(chunkIndex, dtype=np.int64)
         # only spatial neighbours are considered
         for i in range(1, 4):
             if idx[i] > 0:
@@ -637,7 +637,7 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
         chunkShape = np.minimum(shape, chunkShape)
         f = lambda i: shape[i] // chunkShape[i] + (1 if shape[i] % chunkShape[i] else 0)
         self._chunkArrayShape = tuple(map(f, list(range(len(shape)))))
-        self._chunkShape = np.asarray(chunkShape, dtype=np.int)
+        self._chunkShape = np.asarray(chunkShape, dtype=np.int64)
         self._shape = shape
 
         # determine the background values

--- a/lazyflow/operators/opLazyConnectedComponents.py
+++ b/lazyflow/operators/opLazyConnectedComponents.py
@@ -680,7 +680,7 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
         gen = partial(InfiniteLabelIterator, 1, dtype=_LABEL_TYPE)
         self._labelIterators = defaultdict(gen)
         self._globalToFinal = defaultdict(dict)
-        self._isFinal = np.zeros(self._chunkArrayShape, dtype=np.bool)
+        self._isFinal = np.zeros(self._chunkArrayShape, dtype=bool)
 
         ### algorithmic ###
 

--- a/lazyflow/utility/chunkHelpers.py
+++ b/lazyflow/utility/chunkHelpers.py
@@ -39,7 +39,7 @@ def chooseChunkShape(outerShape, desiredChunkSize):
     @return the 'optimal' chunk shape as tuple of ints
     """
 
-    x = np.array(outerShape, dtype=np.int)
+    x = np.array(outerShape, dtype=np.int64)
     assert np.all(x > 0)
     size = np.prod(x)
     n = len(x)
@@ -56,5 +56,5 @@ def chooseChunkShape(outerShape, desiredChunkSize):
     f = np.power((size / float(desiredChunkSize)), (1.0 / float(n)))
 
     y = np.floor(x / f)
-    y = np.maximum(y, 1).astype(np.int)
+    y = np.maximum(y, 1).astype(np.int64)
     return tuple(y)

--- a/lazyflow/utility/helpers.py
+++ b/lazyflow/utility/helpers.py
@@ -150,7 +150,7 @@ def get_ram_per_element(dtype: Union[Type[object], numpy.dtype]) -> int:
         8
         >>> get_ram_per_element(numpy.uint8)
         1
-        >>> get_ram_per_element(numpy.bool)
+        >>> get_ram_per_element(bool)
         1
         >>> get_ram_per_element(int)
         8

--- a/tests/test_ilastik/bin/generate_test_data.py
+++ b/tests/test_ilastik/bin/generate_test_data.py
@@ -59,7 +59,7 @@ def cubes(dimblock, dimcube, cubedist, cubeoffset):
     indices = numpy.indices(dimblock)
     indices = numpy.rollaxis(indices, 0, len(dimblock) + 1)
 
-    out = numpy.ones(dimblock, dtype=numpy.bool)
+    out = numpy.ones(dimblock, dtype=bool)
 
     for i in range(len(dimblock)):
         out = numpy.bitwise_and(out, (indices[..., i] + cubeoffset[i]) % cubedist[i] < dimcube[i])

--- a/tests/test_ilastik/test_applets/base/testSerializer.py
+++ b/tests/test_ilastik/test_applets/base/testSerializer.py
@@ -82,7 +82,7 @@ class TestHDF5HelperFunctions(unittest.TestCase):
         self.tmpDir = tempfile.mkdtemp()
         self.tmpFile = h5py.File(os.path.join(self.tmpDir, "test.h5"), "a")
         self.tmpFile.create_group("a")
-        self.tmpFile.create_dataset("c", (2, 2), dtype=numpy.int)
+        self.tmpFile.create_dataset("c", (2, 2), dtype=numpy.int64)
 
     def test_getOrCreateGroup_1(self):
         self.assertTrue("a" in self.tmpFile)

--- a/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingGui.py
+++ b/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingGui.py
@@ -16,7 +16,7 @@ from PyQt5.QtCore import Qt, QUrl
 def prepare_widget(qtbot, widget):
     qtbot.addWidget(widget)
     widget.show()
-    qtbot.waitForWindowShown(widget)
+    qtbot.waitExposed(widget)
     return widget
 
 
@@ -66,7 +66,7 @@ def drag_n_drop_event(filenames):
     return dndevent
 
 
-def test_FileListWidget_drag_n_drop(file_list_widget, drag_n_drop_event, filenames):
+def test_FileListWidget_drag_n_drop(qtbot, file_list_widget, drag_n_drop_event, filenames):
     assert file_list_widget.count() == 0
 
     file_list_widget.dragEnterEvent(drag_n_drop_event)

--- a/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
+++ b/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
@@ -329,7 +329,7 @@ def cubes(dimblock, dimcube, cubedist=20, cubeoffset=0):
     indices = numpy.indices(dimblock)
     indices = numpy.rollaxis(indices, 0, len(dimblock) + 1)
 
-    out = numpy.ones(dimblock, dtype=numpy.bool)
+    out = numpy.ones(dimblock, dtype=bool)
 
     for i in range(len(dimblock)):
         out = numpy.bitwise_and(out, (indices[..., i] + cubeoffset[i]) % cubedist[i] < dimcube[i])

--- a/tests/test_ilastik/test_applets/objectClassification/testConvexHull.py
+++ b/tests/test_ilastik/test_applets/objectClassification/testConvexHull.py
@@ -36,7 +36,7 @@ feats_3D = {
 
 def segImage2D():
 
-    img = np.zeros((2, 50, 50, 1, 1), dtype=np.int)
+    img = np.zeros((2, 50, 50, 1, 1), dtype=np.int64)
     img[0, 0:10, 0:10, 0, 0] = 1
     img[0, 20:25, 20:25, 0, 0] = 2
     img[1, 0:10, 0:10, 0, 0] = 1
@@ -50,7 +50,7 @@ def segImage2D():
 
 def segImage3D():
 
-    img = np.zeros((2, 50, 50, 50, 1), dtype=np.int)
+    img = np.zeros((2, 50, 50, 50, 1), dtype=np.int64)
     img[0, 0:10, 0:10, 0:10, 0] = 1
     img[0, 20:25, 20:25, 20:25, 0] = 2
     img[1, 0:10, 0:10, 0:10, 0] = 1

--- a/tests/test_ilastik/test_applets/objectClassification/testOperators.py
+++ b/tests/test_ilastik/test_applets/objectClassification/testOperators.py
@@ -51,7 +51,7 @@ def segImage():
     #  * t=1: 1 object 5x5x5, 2 objects 10x10x10
     """
 
-    img = np.zeros((2, 50, 50, 50, 1), dtype=np.int)
+    img = np.zeros((2, 50, 50, 50, 1), dtype=np.int64)
     img[0, 0:10, 0:10, 0:10, 0] = 1
     img[0, 20:25, 20:25, 20:25, 0] = 2
     img[1, 0:10, 0:10, 0:10, 0] = 1
@@ -67,7 +67,7 @@ def emptyImage():
     """
     an empty 5D image
     """
-    img = np.zeros((2, 50, 50, 50, 0), dtype=np.int)
+    img = np.zeros((2, 50, 50, 50, 0), dtype=np.int64)
     img = img.view(vigra.VigraArray)
     img.axistags = vigra.defaultAxistags("txyzc")
     return img

--- a/tests/test_ilastik/test_applets/objectCounting/testObjectCountingOperators.py
+++ b/tests/test_ilastik/test_applets/objectCounting/testObjectCountingOperators.py
@@ -58,7 +58,7 @@ from ilastik.applets.counting.countingOperators import OpTrainCounter, OpPredict
 #     #  * t=1: 1 object 5x5x5, 2 objects 10x10x10
 #     '''
 #
-#     img = np.zeros((2, 50, 50, 50, 1), dtype=np.int)
+#     img = np.zeros((2, 50, 50, 50, 1), dtype=np.int64)
 #     img[0,  0:10,  0:10,  0:10, 0] = 1
 #     img[0, 20:25, 20:25, 20:25, 0] = 2
 #     img[1,  0:10,  0:10,  0:10, 0] = 1
@@ -73,7 +73,7 @@ def emptyImage():
     """
     an empty 5D image
     """
-    img = np.zeros((2, 50, 50, 50, 0), dtype=np.int)
+    img = np.zeros((2, 50, 50, 50, 0), dtype=np.int64)
     img = img.view(vigra.VigraArray)
     img.axistags = vigra.defaultAxistags("txyzc")
     return img

--- a/tests/test_ilastik/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
+++ b/tests/test_ilastik/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
@@ -738,7 +738,7 @@ class TestTTLUseCase(unittest.TestCase):
         # plus are around .9, predictions for background are around .1. The
         # axis order is a bit strange.
 
-        shift = np.asarray((5, 4, 3), dtype=np.int)
+        shift = np.asarray((5, 4, 3), dtype=np.int64)
         vol = np.ones((70, 60, 50)) * 0.1
         vol[11:13, 12:14, 5:15] = 0.9  # bar in z direction
         vol[11:13, 8:18, 9:11] = 0.9  # bar in y direction

--- a/tests/test_ilastik/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
+++ b/tests/test_ilastik/test_applets/thresholdTwoLevels/testThresholdTwoLevels.py
@@ -574,7 +574,7 @@ class TestThresholdTwoLevels(Generator2):
             else:
                 new_labels[icomp] = 1
 
-        cc_high_filtered = numpy.asarray(new_labels[cc_high]).astype(numpy.bool)
+        cc_high_filtered = numpy.asarray(new_labels[cc_high]).astype(bool)
 
         prod = cc_high_filtered.astype(numpy.uint8) * numpy.asarray(cc_low)
 

--- a/tests/test_ilastik/test_shell/test_license_dialog.py
+++ b/tests/test_ilastik/test_shell/test_license_dialog.py
@@ -7,10 +7,11 @@ from pytest import fixture
 from ilastik.shell.gui.licenseDialog import LicenseDialog
 
 
+@fixture
 def get_dlg(qtbot):
     dlg = LicenseDialog()
     qtbot.addWidget(dlg)
-    qtbot.waitForWindowShown(dlg)
+    qtbot.waitExposed(dlg)
     return dlg
 
 

--- a/tests/test_ilastik/widgets/test_appletDrawerToolBox.py
+++ b/tests/test_ilastik/widgets/test_appletDrawerToolBox.py
@@ -14,7 +14,7 @@ def widget(qtbot):
     qtbot.addWidget(w)
     w.show()
 
-    qtbot.waitForWindowShown(w)
+    qtbot.waitExposed(w)
 
     return w
 
@@ -99,7 +99,7 @@ def test_applet_manager_adds_widget(qtbot, widget, widget_mngr):
     provider = applet_provider(applet, name)
 
     widget.show()
-    qtbot.waitForWindowShown(widget)
+    qtbot.waitExposed(widget)
 
     assert not applet.isVisible()
     widget_mngr.addApplet(100, provider)
@@ -115,7 +115,7 @@ def test_applet_manager_not_interactive(qtbot, widget, widget_mngr):
 
     widget_mngr.addApplet(100, prov)
     widget.show()
-    qtbot.waitForWindowShown(widget)
+    qtbot.waitExposed(widget)
 
     assert widget.currentWidget() is None
     assert not applet.isVisible()
@@ -132,7 +132,7 @@ def test_applet_manager_change_focus_displays_corresponding_applets(qtbot, widge
     widget_mngr.addApplet(200, prov2)
 
     widget.show()
-    qtbot.waitForWindowShown(widget)
+    qtbot.waitExposed(widget)
 
     assert applet.isVisible()
     assert not applet2.isVisible()

--- a/tests/test_ilastik/widgets/test_featureTableWidget.py
+++ b/tests/test_ilastik/widgets/test_featureTableWidget.py
@@ -20,7 +20,7 @@ def widget(qtbot):
     qtbot.addWidget(w)
     w.show()
 
-    qtbot.waitForWindowShown(w)
+    qtbot.waitExposed(w)
 
     return w
 

--- a/tests/test_lazyflow/test_operators/testOpLabelVolume.py
+++ b/tests/test_lazyflow/test_operators/testOpLabelVolume.py
@@ -22,7 +22,7 @@ from lazyflow.operators.opLabelVolume import haveBlocked
 @pytest.mark.usefixtures("cacheMemoryManager")
 class TestVigra:
     def setup_method(self, method):
-        self.method = np.asarray(["vigra"], dtype=np.object)
+        self.method = np.asarray(["vigra"], dtype=object)
 
     def testSimpleUsage(self):
         vol = np.random.randint(255, size=(100, 30, 4))
@@ -342,7 +342,7 @@ if haveBlocked():
 
     class TestBlocked(TestVigra):
         def setup_method(self, method):
-            self.method = np.asarray(["blocked"], dtype=np.object)
+            self.method = np.asarray(["blocked"], dtype=object)
 
         # @unittest.skip("Not implemented yet")
         # def testUnsupported(self):
@@ -356,7 +356,7 @@ if haveBlocked():
 
 class TestLazy(TestVigra):
     def setup_method(self, method):
-        self.method = np.asarray(["lazy"], dtype=np.object)
+        self.method = np.asarray(["lazy"], dtype=object)
 
     @unittest.skip("This test does not make sense with lazy connected components")
     def testCorrectBlocking(self):

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -301,7 +301,7 @@ class TestOpZeroDefault:
 @pytest.mark.parametrize(
     "metadata",
     [
-        {"shape": (15, 1, 2), "dtype": numpy.bool},
+        {"shape": (15, 1, 2), "dtype": bool},
         {"shape": (200, 100, 42), "dtype": numpy.uint8, "axistags": vigra.defaultAxistags("xyz")},
         {"shape": (10, 20, 30, 1, 2), "dtype": numpy.float32, "something_else": "blah", "one_more": 42},
     ],


### PR DESCRIPTION
this fixes various warnings so for the tests this reduces the number of warnings from 20k+ to ~1.5k

notes:

* changed `np.int` to `np.int64` anywhere, althought this might result in different behavior on windows (but maybe in intended behavior as all devs are on either linux or osx, where `np.int` would get 8bytes..
* `np.bool` to `bool` doesn't change anything

| PR | `n_warnings` |
| --:| ---:|
| #2611 | 27863 |
| #2612 | 27856 |
| #2613 | 1301 |

<sub>numbers taken from circleci runs</sub>

ref: [numpy 1.20 deprecations](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)