### PR TITLE
maintenance: Fix numpy tuple warnings

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -93,7 +93,7 @@ def slicingToString(slicing):
 
 def stringToSlicing(strSlicing):
     """Parse a string of the form '[0:1,2:3,4:5]' into a slicing (i.e.
-    list of slices)
+    tuple of slices)
 
     """
     if isinstance(strSlicing, bytes):
@@ -108,7 +108,7 @@ def stringToSlicing(strSlicing):
         stop = int(ends[1])
         slicing.append(slice(start, stop))
 
-    return slicing
+    return tuple(slicing)
 
 
 class SerialSlot(object):

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -643,6 +643,7 @@ class OpRegionFeatures(Operator):
 
         slc3d = [slice(None)] * 4  # FIXME: do not hardcode
         slc3d[axes.c] = 0
+        slc3d = tuple(slc3d)
 
         labels = labels[slc3d]
 

--- a/ilastik/applets/trackingFeatureExtraction/trackingFeatures.py
+++ b/ilastik/applets/trackingFeatureExtraction/trackingFeatures.py
@@ -186,7 +186,7 @@ class FeatureManager(object):
         self.squared_distance_default = squared_distance_default
 
     def _getBestSquaredDistances(self, com_cur, coms_next, size_filter=None, sizes_next=[], default_value=9999):
-        """ returns the squared distances to the objects in the neighborhood of com_curr, optionally with size filter """
+        """returns the squared distances to the objects in the neighborhood of com_curr, optionally with size filter"""
         squaredDistances = []
 
         for label_next in list(coms_next.keys()):
@@ -258,7 +258,7 @@ class FeatureManager(object):
                     roi.append(slice(int(start), int(stop)))
 
                 # find all coms in the neighborhood of com_cur
-                subimg_next = img_next[roi]
+                subimg_next = img_next[tuple(roi)]
                 labels_next = np.sort(vigra.analysis.unique(subimg_next)).tolist()
 
                 for l in labels_next:

--- a/lazyflow/operators/oldVigraOperators.py
+++ b/lazyflow/operators/oldVigraOperators.py
@@ -617,7 +617,9 @@ class OpPixelFeaturesPresmoothed(Operator):
 
                 for channel in range(vol.channels):
                     chSlice[chInd] = slice(channel, channel + 1)
-                    result[chSlice] = fastfilters.gaussianSmoothing(vol[chSlice], sigma, window_size=self.WINDOW_SIZE)
+                    result[tuple(chSlice)] = fastfilters.gaussianSmoothing(
+                        vol[tuple(chSlice)], sigma, window_size=self.WINDOW_SIZE
+                    )
             else:
                 result = fastfilters.gaussianSmoothing(vol, sigma, window_size=self.WINDOW_SIZE)
 
@@ -923,7 +925,7 @@ class OpBaseFilter(Operator):
 
 # difference of Gaussians
 def differenceOfGausssians(image, sigma0, sigma1, window_size, roi, out=None):
-    """ difference of gaussian function"""
+    """difference of gaussian function"""
     return vigra.filters.gaussianSmoothing(
         image, sigma0, window_size=window_size, roi=roi
     ) - vigra.filters.gaussianSmoothing(image, sigma1, window_size=window_size, roi=roi)

--- a/lazyflow/operators/opVigraWatershed.py
+++ b/lazyflow/operators/opVigraWatershed.py
@@ -102,7 +102,7 @@ class OpVigraWatershed(Operator):
             o = slice(s.start - p.start, s.stop - p.start)
             outputSlices += [o]
 
-        return paddedSlices, outputSlices
+        return tuple(paddedSlices), tuple(outputSlices)
 
     def execute(self, slot, subindex, roi, result):
         assert slot == self.Output

--- a/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationSerializer.py
+++ b/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationSerializer.py
@@ -140,8 +140,8 @@ class OpMockPixelClassifier(Operator):
             slicing = [slice(0, maximum) for maximum in self.dataShape]
             for i in range(10):
                 slicing[2] = slice(i * 10, (i + 1) * 10)
-                if not (self._data[index][slicing] == 0).all():
-                    blocks.append(list(slicing))
+                if not (self._data[index][tuple(slicing)] == 0).all():
+                    blocks.append(tuple(slicing))
 
             result[0] = blocks
         if slot.name == "LabelImages":

--- a/tests/test_lazyflow/test_operators/testOpBlockedArrayCache.py
+++ b/tests/test_lazyflow/test_operators/testOpBlockedArrayCache.py
@@ -47,7 +47,7 @@ from functools import reduce
 
 class KeyMaker(object):
     def __getitem__(self, *args):
-        return list(*args)
+        return tuple(*args)
 
 
 make_key = KeyMaker()

--- a/tests/test_lazyflow/test_operators/testOpCompressedUserLabelArray.py
+++ b/tests/test_lazyflow/test_operators/testOpCompressedUserLabelArray.py
@@ -162,6 +162,7 @@ class TestOpCompressedUserLabelArray(object):
 
         erasedSlicing = list(slicing)
         erasedSlicing[1] = slice(1, 2)
+        erasedSlicing = tuple(erasedSlicing)
 
         outputWithEraser = data.copy()
         outputWithEraser[erasedSlicing] = 100
@@ -190,6 +191,7 @@ class TestOpCompressedUserLabelArray(object):
 
         newSlicing = list(slicing)
         newSlicing[1] = slice(1, 2)
+        newSlicing = tuple(newSlicing)
 
         # Add some new labels for a class that hasn't been seen yet (3)
         threeData = numpy.ndarray(slicing2shape(newSlicing), dtype=numpy.uint8)
@@ -453,6 +455,7 @@ class TestOpCompressedUserLabelArray_masked(object):
 
         erasedSlicing = list(slicing)
         erasedSlicing[1] = slice(1, 2)
+        erasedSlicing = tuple(erasedSlicing)
 
         outputWithEraser = data
         outputWithEraser[erasedSlicing] = 100
@@ -484,6 +487,7 @@ class TestOpCompressedUserLabelArray_masked(object):
 
         newSlicing = list(slicing)
         newSlicing[1] = slice(1, 2)
+        newSlicing = tuple(newSlicing)
 
         # Add some new labels for a class that hasn't been seen yet (3)
         threeData = numpy.ndarray(slicing2shape(newSlicing), dtype=numpy.uint8)

--- a/tests/test_lazyflow/test_operators/testOpCompressedUserLabelArray.py
+++ b/tests/test_lazyflow/test_operators/testOpCompressedUserLabelArray.py
@@ -65,8 +65,6 @@ class TestOpCompressedUserLabelArray(object):
         Verify that the label array has all of the data it was given.
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # Output
@@ -95,9 +93,6 @@ class TestOpCompressedUserLabelArray(object):
         Check behavior after deleting an entire label class from the sparse array.
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
-        data = self.data
 
         op.deleteLabel.setValue(1)
         outputData = op.Output[...].wait()
@@ -118,8 +113,6 @@ class TestOpCompressedUserLabelArray(object):
         This one ensures that different blocks have different max label values before the delete occurs.
         """
         op = self.op
-        slicing = self.slicing
-        data = self.data
 
         # assert op.maxLabel.value == 2
 
@@ -163,7 +156,6 @@ class TestOpCompressedUserLabelArray(object):
         """
         op = self.op
         slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # assert op.maxLabel.value == 2
@@ -233,8 +225,6 @@ class TestOpCompressedUserLabelArray(object):
         it should be removed from the CleanBlocks slot.
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # BEFORE (convert to tuple)
@@ -266,8 +256,6 @@ class TestOpCompressedUserLabelArray(object):
         then reconfigure it with a different input shape and dimensionality?
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # Output
@@ -353,8 +341,6 @@ class TestOpCompressedUserLabelArray_masked(object):
         Verify that the label array has all of the data it was given.
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # Output
@@ -386,9 +372,6 @@ class TestOpCompressedUserLabelArray_masked(object):
         Check behavior after deleting an entire label class from the sparse array.
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
-        data = self.data
 
         op.deleteLabel.setValue(1)
         outputData = op.Output[...].wait()
@@ -415,8 +398,6 @@ class TestOpCompressedUserLabelArray_masked(object):
         This one ensures that different blocks have different max label values before the delete occurs.
         """
         op = self.op
-        slicing = self.slicing
-        data = self.data
 
         # assert op.maxLabel.value == 2
 
@@ -466,7 +447,6 @@ class TestOpCompressedUserLabelArray_masked(object):
         """
         op = self.op
         slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # assert op.maxLabel.value == 2
@@ -541,8 +521,6 @@ class TestOpCompressedUserLabelArray_masked(object):
         What happens if we configure the operator, use it a bit, then reconfigure it with a different input shape and dimensionality?
         """
         op = self.op
-        slicing = self.slicing
-        inData = self.inData
         data = self.data
 
         # Output

--- a/tests/test_lazyflow/test_operators/testOpDenseLabelArray.py
+++ b/tests/test_lazyflow/test_operators/testOpDenseLabelArray.py
@@ -168,6 +168,7 @@ class TestOpDenseLabelArray(object):
 
         erasedSlicing = list(slicing)
         erasedSlicing[1] = slice(1, 2)
+        erasedSlicing = tuple(erasedSlicing)
 
         outputWithEraser = data
         outputWithEraser[erasedSlicing] = 100
@@ -196,6 +197,7 @@ class TestOpDenseLabelArray(object):
 
         newSlicing = list(slicing)
         newSlicing[1] = slice(1, 2)
+        newSlicing = tuple(newSlicing)
 
         # Add some new labels for a class that hasn't been seen yet (3)
         threeData = numpy.ndarray(slicing2shape(newSlicing), dtype=numpy.uint8)

--- a/tests/test_lazyflow/test_operators/testOpSlicedBlockedArrayCache.py
+++ b/tests/test_lazyflow/test_operators/testOpSlicedBlockedArrayCache.py
@@ -36,7 +36,7 @@ from lazyflow.operators.opSlicedBlockedArrayCache import OpSlicedBlockedArrayCac
 
 class KeyMaker(object):
     def __getitem__(self, *args):
-        return list(*args)
+        return tuple(*args)
 
 
 make_key = KeyMaker()


### PR DESCRIPTION
further reduce number of warnings - and be compatible with numpy 1.23 and up

`n_warnings` 1301 -> 1163