### PR TITLE
Pytest generator test deprecation

### DIFF
--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -726,150 +726,195 @@ class TestOpDataSelection_FakeDataReader:
         numpy.testing.assert_array_equal(imgData, imgData)
 
 
-class TestOpDataSelection_stack_along_parameter:
-    @classmethod
-    def setup_class(cls):
-        cls.tmpdir = tempfile.mkdtemp()
+def _make_data():
+    data_dict = {}
+    data_dict["rgb00c"] = numpy.array(
+        [
+            [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=numpy.float32,
+    )
 
-        cls.rgb00c = numpy.array(
+    data_dict["rgb10c"] = numpy.array(
+        [
+            [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=numpy.float32,
+    )
+
+    data_dict["rgb20c"] = numpy.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
+        ],
+        dtype=numpy.float32,
+    )
+
+    data_dict["grey0c"] = (
+        numpy.array(
             [
-                [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                [1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1],
+                [1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0],
+                [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0],
+                [1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0],
             ],
             dtype=numpy.float32,
         )
+        / 2
+    )
 
-        cls.rgb10c = numpy.array(
-            [
-                [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-            ],
-            dtype=numpy.float32,
-        )
+    data_dict["rgb01c"] = data_dict["rgb00c"][..., None]
+    data_dict["rgb11c"] = data_dict["rgb10c"][..., None]
+    data_dict["rgb21c"] = data_dict["rgb20c"][..., None]
+    data_dict["grey1c"] = data_dict["grey0c"][..., None]
 
-        cls.rgb20c = numpy.array(
-            [
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1],
-                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-            ],
-            dtype=numpy.float32,
-        )
+    data_dict["rgb03c"] = numpy.zeros(
+        (data_dict["rgb00c"].shape[0], data_dict["rgb00c"].shape[1], 3), dtype=numpy.float32
+    )
+    data_dict["rgb13c"] = numpy.zeros(
+        (data_dict["rgb10c"].shape[0], data_dict["rgb10c"].shape[1], 3), dtype=numpy.float32
+    )
+    data_dict["rgb23c"] = numpy.zeros(
+        (data_dict["rgb20c"].shape[0], data_dict["rgb20c"].shape[1], 3), dtype=numpy.float32
+    )
+    data_dict["rgb03c"][..., 0] = data_dict["rgb00c"]
+    data_dict["rgb13c"][..., 1] = data_dict["rgb10c"]
+    data_dict["rgb23c"][..., 2] = data_dict["rgb20c"]
+    data_dict["grey3c"] = numpy.repeat(data_dict["grey1c"], 3, axis=2)
+    return data_dict
 
-        cls.grey0c = (
-            numpy.array(
-                [
-                    [1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1],
-                    [1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1],
-                    [1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0],
-                    [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0],
-                    [1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0],
-                ],
-                dtype=numpy.float32,
+
+_data = _make_data()
+
+
+@pytest.fixture(scope="module")
+def test_data_dir(tmp_path_factory):
+    base = tmp_path_factory.mktemp("test_stack_along_data")
+    for name, data in _data.items():
+        # save as h5
+        save_to_hdf5(dataset_name="data", data=data, filename=base / f"{name}.h5")
+
+        # save as png and tiff, if possible
+        if name.endswith("0c"):
+            im = Image.fromarray(data)
+            im.save(base / f"{name}.tiff")
+            vigra.impex.writeImage(image=(data.T * 255).astype(numpy.uint8), filename=str(base / f"{name}.png"))
+        elif name.endswith("1c"):
+            vigra.impex.writeImage(
+                image=(data.transpose(1, 0, 2) * 255).astype(numpy.uint8), filename=str(base / f"{name}.png")
             )
-            / 2
-        )
+        elif name.endswith("3c"):
+            data = (data * 255).astype(numpy.uint8)
+            im = Image.fromarray(data, mode="RGB")
+            im.save(base / f"{name}.tiff")
+            vigra.impex.writeImage(image=data.transpose(1, 0, 2), filename=str(base / f"{name}.png"))
+        else:
+            raise NotImplementedError(f"How to create PIL/png image with c == {c}?")
 
-        cls.rgb01c = cls.rgb00c[..., None]
-        cls.rgb11c = cls.rgb10c[..., None]
-        cls.rgb21c = cls.rgb20c[..., None]
-        cls.grey1c = cls.grey0c[..., None]
+    return base
 
-        cls.rgb03c = numpy.zeros((cls.rgb00c.shape[0], cls.rgb00c.shape[1], 3), dtype=numpy.float32)
-        cls.rgb13c = numpy.zeros((cls.rgb10c.shape[0], cls.rgb10c.shape[1], 3), dtype=numpy.float32)
-        cls.rgb23c = numpy.zeros((cls.rgb20c.shape[0], cls.rgb20c.shape[1], 3), dtype=numpy.float32)
-        cls.rgb03c[..., 0] = cls.rgb00c
-        cls.rgb13c[..., 1] = cls.rgb10c
-        cls.rgb23c[..., 2] = cls.rgb20c
-        cls.grey3c = numpy.repeat(cls.grey1c, 3, axis=2)
 
-        for name, c in itertools.product(["rgb0", "rgb1", "rgb2", "grey"], ["0c", "1c", "3c"]):
-            name += c
-            data = eval("cls." + name)
+@pytest.mark.parametrize(
+    "name, extension, sequence_axis, expected",
+    [
+        ["rgb*0c", ".h5/data", "c", numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)],
+        [
+            "rgb*0c",
+            ".png",
+            "c",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=2).transpose(1, 0, 2) * 255,
+        ],
+        ["rgb*0c", ".tiff", "c", numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)],
+        ["rgb*1c", ".h5/data", "c", numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=2)],
+        [
+            "rgb*1c",
+            ".png",
+            "c",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=2).transpose(1, 0, 2) * 255,
+        ],
+        ["rgb*3c", ".h5/data", "c", numpy.concatenate([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=2)],
+        [
+            "rgb*3c",
+            ".png",
+            "c",
+            numpy.concatenate([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=2).transpose(1, 0, 2) * 255,
+        ],
+        ["rgb*3c", ".tiff", "c", numpy.concatenate([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=2) * 255],
+        [
+            "rgb*0c",
+            ".h5/data",
+            "z",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None],
+        ],
+        [
+            "rgb*0c",
+            ".png",
+            "z",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None] * 255,
+        ],
+        ["rgb*0c", ".tiff", "z", numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None]],
+        [
+            "rgb*1c",
+            ".h5/data",
+            "z",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None],
+        ],
+        [
+            "rgb*1c",
+            ".png",
+            "z",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None] * 255,
+        ],
+        ["rgb*3c", ".h5/data", "z", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0)],
+        ["rgb*3c", ".png", "z", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0) * 255],
+        ["rgb*3c", ".tiff", "z", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0) * 255],
+        [
+            "rgb*0c",
+            ".h5/data",
+            "t",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None],
+        ],
+        [
+            "rgb*0c",
+            ".png",
+            "t",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None] * 255,
+        ],
+        ["rgb*0c", ".tiff", "t", numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None]],
+        [
+            "rgb*1c",
+            ".h5/data",
+            "t",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None],
+        ],
+        [
+            "rgb*1c",
+            ".png",
+            "t",
+            numpy.stack([_data["rgb00c"], _data["rgb10c"], _data["rgb20c"]], axis=0)[..., None] * 255,
+        ],
+        ["rgb*3c", ".h5/data", "t", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0)],
+        ["rgb*3c", ".png", "t", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0) * 255],
+        ["rgb*3c", ".tiff", "t", numpy.stack([_data["rgb03c"], _data["rgb13c"], _data["rgb23c"]], axis=0) * 255],
+    ],
+)
+def test_stack_along(test_data_dir, graph, name, extension, sequence_axis, expected):
+    fileName = test_data_dir / f"{name}{extension}"
+    reader = OpDataSelection(graph=graph, forceAxisOrder=False)
+    reader.WorkingDirectory.setValue(os.getcwd())
+    reader.Dataset.setValue(FilesystemDatasetInfo(filePath=str(fileName), sequence_axis=sequence_axis))
+    read = reader.Image[...].wait()
 
-            # save as h5
-            save_to_hdf5(dataset_name="data", data=data, filename=os.path.join(cls.tmpdir, f"{name}.h5"))
-
-            # save as png and tiff, if possible
-            if c == "0c":
-                im = Image.fromarray(data)
-                im.save(os.path.join(cls.tmpdir, f"{name}.tiff"))
-                vigra.impex.writeImage(
-                    image=(data.T * 255).astype(numpy.uint8), filename=os.path.join(cls.tmpdir, f"{name}.png")
-                )
-            elif c == "1c":
-                vigra.impex.writeImage(
-                    image=(data.transpose(1, 0, 2) * 255).astype(numpy.uint8),
-                    filename=os.path.join(cls.tmpdir, f"{name}.png"),
-                )
-            elif c == "3c":
-                data = (data * 255).astype(numpy.uint8)
-                im = Image.fromarray(data, mode="RGB")
-                im.save(os.path.join(cls.tmpdir, f"{name}.tiff"))
-                vigra.impex.writeImage(image=data.transpose(1, 0, 2), filename=os.path.join(cls.tmpdir, f"{name}.png"))
-            else:
-                raise NotImplementedError(f"How to create PIL/png image with c == {c}?")
-
-    def _test_stack_along(self, name, extension, sequence_axis, expected):
-        fileName = os.path.join(self.tmpdir, f"{name}{extension}")
-        reader = OpDataSelection(graph=Graph(), forceAxisOrder=False)
-        reader.WorkingDirectory.setValue(os.getcwd())
-        reader.Dataset.setValue(FilesystemDatasetInfo(filePath=fileName, sequence_axis=sequence_axis))
-        read = reader.Image[...].wait()
-
-        assert numpy.allclose(read, expected), f"{name}: {read.shape}, {expected.shape}"
-
-    def test_stack_along(self):
-
-        testcases = [
-            ["rgb*0c", ".h5/data", "c", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)],
-            [
-                "rgb*0c",
-                ".png",
-                "c",
-                numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=2).transpose(1, 0, 2) * 255,
-            ],
-            ["rgb*0c", ".tiff", "c", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)],
-            ["rgb*1c", ".h5/data", "c", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=2)],
-            [
-                "rgb*1c",
-                ".png",
-                "c",
-                numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=2).transpose(1, 0, 2) * 255,
-            ],
-            ["rgb*3c", ".h5/data", "c", numpy.concatenate([self.rgb03c, self.rgb13c, self.rgb23c], axis=2)],
-            [
-                "rgb*3c",
-                ".png",
-                "c",
-                numpy.concatenate([self.rgb03c, self.rgb13c, self.rgb23c], axis=2).transpose(1, 0, 2) * 255,
-            ],
-            ["rgb*3c", ".tiff", "c", numpy.concatenate([self.rgb03c, self.rgb13c, self.rgb23c], axis=2) * 255],
-            ["rgb*0c", ".h5/data", "z", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*0c", ".png", "z", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None] * 255],
-            ["rgb*0c", ".tiff", "z", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*1c", ".h5/data", "z", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*1c", ".png", "z", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None] * 255],
-            ["rgb*3c", ".h5/data", "z", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0)],
-            ["rgb*3c", ".png", "z", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0) * 255],
-            ["rgb*3c", ".tiff", "z", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0) * 255],
-            ["rgb*0c", ".h5/data", "t", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*0c", ".png", "t", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None] * 255],
-            ["rgb*0c", ".tiff", "t", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*1c", ".h5/data", "t", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None]],
-            ["rgb*1c", ".png", "t", numpy.stack([self.rgb00c, self.rgb10c, self.rgb20c], axis=0)[..., None] * 255],
-            ["rgb*3c", ".h5/data", "t", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0)],
-            ["rgb*3c", ".png", "t", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0) * 255],
-            ["rgb*3c", ".tiff", "t", numpy.stack([self.rgb03c, self.rgb13c, self.rgb23c], axis=0) * 255],
-        ]
-
-        for name, extension, sequence_axis, expected in testcases:
-            yield self._test_stack_along, name, extension, sequence_axis, expected
+    assert numpy.allclose(read, expected), f"{name}: {read.shape}, {expected.shape}"

--- a/tests/test_ilastik/test_applets/featureSelection/testNewFeatureSelection.py
+++ b/tests/test_ilastik/test_applets/featureSelection/testNewFeatureSelection.py
@@ -105,7 +105,7 @@ class TestCompareOpFeatureSelectionToOld:
         ]:
             result = output[roi].wait()
             resultOld = outputOld[roi].wait()
-            yield self.compare, result, resultOld
+            self.compare(result, resultOld)
 
     def test_output(self):
         self.opFeatures.InputImage[0].disconnect()
@@ -225,7 +225,7 @@ class TestCompareOpFeatureSelectionToOld:
                     pass
                 plt.show()
 
-            yield self.compare, result, resultOld
+            self.compare(result, resultOld)
 
     def test_features(self):
         # Configure selection matrix
@@ -321,7 +321,7 @@ class TestCompareOpFeatureSelectionToOld:
                     pass
                 plt.show()
 
-            yield self.compare, result, resultOld
+            self.compare(result, resultOld)
 
     def test_ComputeIn2d(self):
         # tests ComputIn2d flag on smoothing of a 3d block (smoothing across all three, or only 2 dimensions)

--- a/tests/test_ilastik/test_shell/test_license_dialog.py
+++ b/tests/test_ilastik/test_shell/test_license_dialog.py
@@ -7,7 +7,6 @@ from pytest import fixture
 from ilastik.shell.gui.licenseDialog import LicenseDialog
 
 
-@fixture
 def get_dlg(qtbot):
     dlg = LicenseDialog()
     qtbot.addWidget(dlg)

--- a/tests/test_ilastik/test_workflows/axesOrderPreservation/testAxesOrderPreservation.py
+++ b/tests/test_ilastik/test_workflows/axesOrderPreservation/testAxesOrderPreservation.py
@@ -32,6 +32,8 @@ import vigra
 import warnings
 import zipfile
 
+import pytest
+
 from lazyflow.graph import Graph
 from lazyflow.operators.ioOperators import OpInputDataReader
 from lazyflow.operators.ioOperators.opFormattedDataExport import OpFormattedDataExport
@@ -211,20 +213,38 @@ class TestAxesOrderPreservation(object):
             writer.run_export()
             warnings.warn(f"created comparison data: {compare_path} with axis order {input_axes}")
 
-    def test_pixel_classification(self):
-        options = []
-        options.append((["2d"], ["xy", "yx"]))
-        options.append((["2d", "2d3c"], ["cxy", "yxc", "xyc", "ycx"]))
-        options.append((["3d", "3d1c", "3d2c"], ["xyzc", "czyx"]))
-        options.append((["5t2d1c", "5t2d2c"], ["tyxc", "txyc", "xytc"]))
-        options.append((["5t3d2c"], ["tzyxc", "ztxyc", "xyztc"]))
-
-        for combination in options:
-            for dims, order in itertools.product(*combination):
-                yield self._test_pixel_classification, dims, order
-
+    @pytest.mark.parametrize(
+        "dims, input_axes",
+        [
+            ("2d", "xy"),
+            ("2d", "yx"),
+            ("2d", "cxy"),
+            ("2d", "yxc"),
+            ("2d", "xyc"),
+            ("2d", "ycx"),
+            ("2d3c", "cxy"),
+            ("2d3c", "yxc"),
+            ("2d3c", "xyc"),
+            ("2d3c", "ycx"),
+            ("3d", "xyzc"),
+            ("3d", "czyx"),
+            ("3d1c", "xyzc"),
+            ("3d1c", "czyx"),
+            ("3d2c", "xyzc"),
+            ("3d2c", "czyx"),
+            ("5t2d1c", "tyxc"),
+            ("5t2d1c", "txyc"),
+            ("5t2d1c", "xytc"),
+            ("5t2d2c", "tyxc"),
+            ("5t2d2c", "txyc"),
+            ("5t2d2c", "xytc"),
+            ("5t3d2c", "tzyxc"),
+            ("5t3d2c", "ztxyc"),
+            ("5t3d2c", "xyztc"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_pixel_classification(self, dims, input_axes):
+    def test_pixel_classification(self, dims, input_axes):
         # NOTE: In this test, cmd-line args to test runner will also end up
         #       getting "parsed" by ilastik. That shouldn't be an issue, since
         #       the pixel classification workflow ignores unrecognized options.
@@ -291,19 +311,20 @@ class TestAxesOrderPreservation(object):
 
         self.compare_results(opReaderResult, compare_path, input_axes, max_mse=0.001)
 
-    def test_autocontext(self):
-        options = []
-        # todo: single channel, same as for autocontext
-        # options.append((['2d'], ['xy', 'yx']))
-        options.append((["2d3c"], ["cxy", "yxc", "xyc", "ycx"]))
-        options.append((["5t2d1c"], ["tyxc", "txcy", "cxyt"]))
-
-        for combination in options:
-            for dims, order in itertools.product(*combination):
-                yield self._test_autocontext, dims, order
-
+    @pytest.mark.parametrize(
+        "dims, input_axes",
+        [
+            ("2d3c", "cxy"),
+            ("2d3c", "yxc"),
+            ("2d3c", "xyc"),
+            ("2d3c", "ycx"),
+            ("5t2d1c", "tyxc"),
+            ("5t2d1c", "txcy"),
+            ("5t2d1c", "cxyt"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_autocontext(self, dims, input_axes):
+    def test_autocontext(self, dims, input_axes):
         # NOTE: In this test, cmd-line args to test runner will also end up
         #       getting "parsed" by ilastik. That shouldn't be an issue, since
         #       the pixel classification workflow ignores unrecognized options.
@@ -365,18 +386,45 @@ class TestAxesOrderPreservation(object):
 
         self.compare_results(opReaderResult, compare_path, input_axes)
 
-    def test_object_classification(self):
-        options = []
-        options.append((["2d", "2d3c"], ["wPred", "wSeg"], ["yxc", "xcy", "cyx"]))
-        options.append((["5t2d1c", "5t2d2c"], ["wPred", "wSeg"], ["tyxc", "txyc", "xytc"]))
-        options.append((["5t3d2c"], ["wPred", "wSeg"], ["tzyxc", "xztyc", "tczyx", "cztxy"]))
-
-        for combination in options:
-            for dims, variant, order in itertools.product(*combination):
-                yield self._test_object_classification, dims, variant, order
-
+    @pytest.mark.parametrize(
+        "dims, variant, input_axes",
+        [
+            ("2d", "wPred", "yxc"),
+            ("2d", "wPred", "xcy"),
+            ("2d", "wPred", "cyx"),
+            ("2d", "wSeg", "yxc"),
+            ("2d", "wSeg", "xcy"),
+            ("2d", "wSeg", "cyx"),
+            ("2d3c", "wPred", "yxc"),
+            ("2d3c", "wPred", "xcy"),
+            ("2d3c", "wPred", "cyx"),
+            ("2d3c", "wSeg", "yxc"),
+            ("2d3c", "wSeg", "xcy"),
+            ("2d3c", "wSeg", "cyx"),
+            ("5t2d1c", "wPred", "tyxc"),
+            ("5t2d1c", "wPred", "txyc"),
+            ("5t2d1c", "wPred", "xytc"),
+            ("5t2d1c", "wSeg", "tyxc"),
+            ("5t2d1c", "wSeg", "txyc"),
+            ("5t2d1c", "wSeg", "xytc"),
+            ("5t2d2c", "wPred", "tyxc"),
+            ("5t2d2c", "wPred", "txyc"),
+            ("5t2d2c", "wPred", "xytc"),
+            ("5t2d2c", "wSeg", "tyxc"),
+            ("5t2d2c", "wSeg", "txyc"),
+            ("5t2d2c", "wSeg", "xytc"),
+            ("5t3d2c", "wPred", "tzyxc"),
+            ("5t3d2c", "wPred", "xztyc"),
+            ("5t3d2c", "wPred", "tczyx"),
+            ("5t3d2c", "wPred", "cztxy"),
+            ("5t3d2c", "wSeg", "tzyxc"),
+            ("5t3d2c", "wSeg", "xztyc"),
+            ("5t3d2c", "wSeg", "tczyx"),
+            ("5t3d2c", "wSeg", "cztxy"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_object_classification(self, dims, variant, input_axes):
+    def test_object_classification(self, dims, variant, input_axes):
         project = f"ObjectClassification{dims}_{variant}.ilp"
         try:
             self.untested_projects.remove(project)
@@ -444,18 +492,23 @@ class TestAxesOrderPreservation(object):
 
         self.compare_results(opReaderResult, compare_path, input_axes)
 
-    def test_boundarybased_segmentation_with_multicut(self):
-        options = []
-        options.append((["3d"], ["xyz", "zcyx", "xycz", "yxcz"]))
-        options.append((["3d1c"], ["zyxc", "xyzc", "cxzy"]))
-        options.append((["3d2c"], ["zyxc", "xcyz", "czxy"]))
-
-        for combination in options:
-            for dims, order in itertools.product(*combination):
-                yield self._test_boundarybased_segmentation_with_multicut, dims, order
-
+    @pytest.mark.parametrize(
+        "dims, input_axes",
+        [
+            ("3d", "xyz"),
+            ("3d", "zcyx"),
+            ("3d", "xycz"),
+            ("3d", "yxcz"),
+            ("3d1c", "zyxc"),
+            ("3d1c", "xyzc"),
+            ("3d1c", "cxzy"),
+            ("3d2c", "zyxc"),
+            ("3d2c", "xcyz"),
+            ("3d2c", "czxy"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_boundarybased_segmentation_with_multicut(self, dims, input_axes):
+    def test_boundarybased_segmentation_with_multicut(self, dims, input_axes):
         project = f"Boundary-basedSegmentationwMulticut{dims}.ilp"
         try:
             self.untested_projects.remove(project)
@@ -517,19 +570,17 @@ class TestAxesOrderPreservation(object):
 
         self.compare_results(opReaderResult, compare_path, input_axes, post_process=detect_edges, max_part_uneqaul=0.02)
 
-    def test_counting(self):
-        options = []
-        # todo: add 2d[1c] counting project (missing channel leads to 'no image data' error)
-        # options.append((['2d'], ['xy', 'yx']))
-        # options.append((['2d1c', '2d3c'], ['yxc', 'cxy']))  # 'xyc', 'cxy', 'ycx
-        options.append((["2d3c"], ["yxc", "xyc", "cxy", "ycx"]))
-
-        for combination in options:
-            for dims, order in itertools.product(*combination):
-                yield self._test_counting, dims, order
-
+    @pytest.mark.parametrize(
+        "dims, input_axes",
+        [
+            ("2d3c", "yxc"),
+            ("2d3c", "xyc"),
+            ("2d3c", "cxy"),
+            ("2d3c", "ycx"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_counting(self, dims, input_axes):
+    def test_counting(self, dims, input_axes):
         project = f"CellDensityCounting{dims}.ilp"
         try:
             self.untested_projects.remove(project)
@@ -582,22 +633,32 @@ class TestAxesOrderPreservation(object):
         self.compare_results(opReaderResult, compare_path, input_axes, max_mse=0.001)
 
     # todo: exchange nonsense data and labels in tracking projects (wBin)
-    def test_tracking_with_learning(self):
-        options = []
-        # test configurations
-        options.append((["5t2d"], ["_wPred"], ["tyx", "txy", "xyt"]))
-        options.append((["5t2d1c"], ["_wBin", "_wPred"], ["tyxc", "txyc", "xytc"]))
-        options.append((["5t2d2c"], ["_wBin"], ["tyxc", "txyc", "xytc"]))
-        options.append((["5t2d3c"], ["_wPred"], ["tyxc", "txyc", "xytc"]))
-        options.append((["5t3d"], ["_wPred"], ["tzyxc", "xztyc"]))
-        options.append((["5t3d2c"], ["_wBin"], ["tzyxc", "xztyc"]))
-
-        for combination in options:
-            for dims, variant, order in itertools.product(*combination):
-                yield self._test_tracking_with_learning, dims, variant, order
-
+    @pytest.mark.parametrize(
+        "dims, variant, input_axes",
+        [
+            ("5t2d", "_wPred", "tyx"),
+            ("5t2d", "_wPred", "txy"),
+            ("5t2d", "_wPred", "xyt"),
+            ("5t2d1c", "_wBin", "tyxc"),
+            ("5t2d1c", "_wBin", "txyc"),
+            ("5t2d1c", "_wBin", "xytc"),
+            ("5t2d1c", "_wPred", "tyxc"),
+            ("5t2d1c", "_wPred", "txyc"),
+            ("5t2d1c", "_wPred", "xytc"),
+            ("5t2d2c", "_wBin", "tyxc"),
+            ("5t2d2c", "_wBin", "txyc"),
+            ("5t2d2c", "_wBin", "xytc"),
+            ("5t2d3c", "_wPred", "tyxc"),
+            ("5t2d3c", "_wPred", "txyc"),
+            ("5t2d3c", "_wPred", "xytc"),
+            ("5t3d", "_wPred", "tzyxc"),
+            ("5t3d", "_wPred", "xztyc"),
+            ("5t3d2c", "_wBin", "tzyxc"),
+            ("5t3d2c", "_wBin", "xztyc"),
+        ],
+    )
     @timeLogged(logger)
-    def _test_tracking_with_learning(self, dims, variant, input_axes):
+    def test_tracking_with_learning(self, dims, variant, input_axes):
         project = "TrackingwLearning" + dims + variant + ".ilp"
         try:
             self.untested_projects.remove(project)


### PR DESCRIPTION
this was another source of warnings (and was keeping us from updating pytest).

I'm fine with most of it, except for the last commit (`testOpDataSelection.py`)- this test was a bit awkward to rewrite. Maybe @emilmelnikov has an elegant idea how to make this nicer - on the other hand - it's just a test.

Note: total number of tests run goes from 1150 -> 1125 because of `tests/test_ilastik/test_applets/featureSelection/testNewFeatureSelection.py`. There the yield tests have been changed to direct calls and, hence, don't show up individually anymore.