### PR TITLE
add simple segmentation output to Pixel+Object Class workflow

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationDataExportGui.py
@@ -89,14 +89,15 @@ class ObjectClassificationResultsViewer(DataExportLayerViewerGui):
             "Blockwise Object Predictions",
             "Blockwise Object Probabilities",
             "Object Identities",
-            "Pixel Probabilities",
+            "Pixel Probabilities",  # for Pixel + Object Classification Workflow
+            "Simple Segmentation",  # for Pixel + Object Classification Workflow
         ]
 
-        if selection in ("Object Predictions", "Blockwise Object Predictions"):
+        if selection in ("Object Predictions", "Blockwise Object Predictions", "Simple Segmentation"):
             previewSlot = self.topLevelOperatorView.ImageToExport
             if previewSlot.ready():
                 previewLayer = ColortableLayer(createDataSource(previewSlot), colorTable=self._colorTable16)
-                previewLayer.name = "Prediction - Preview"
+                previewLayer.name = selection + "- Preview"
                 previewLayer.visible = False
                 layers.append(previewLayer)
 

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -24,6 +24,7 @@ import os
 import enum
 import argparse
 import csv
+import warnings
 
 import numpy
 import h5py
@@ -591,6 +592,7 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
     def ExportNames(self):
         class ExtraExportNames(SlotNameEnum):
             PIXEL_PROBABILITIES = super(self.__class__, self).ExportNames.getNext()
+            SIMPLE_SEGMENTATION = super(self.__class__, self).ExportNames.getNext() + 1
 
         return super().ExportNames.extendedWithEnum(ExtraExportNames)
 
@@ -641,8 +643,10 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
         # Pull from this slot since the data has already been through the Op5 operator
         # (All data in the export operator must have matching spatial dimensions.)
         opThreshold = self.thresholdingApplet.topLevelOperator.getLane(laneIndex)
+        opClassify = self.pcApplet.topLevelOperator.getLane(laneIndex)
         opDataExport = self.dataExportApplet.topLevelOperator.getLane(laneIndex)
         opDataExport.Inputs[self.ExportNames.PIXEL_PROBABILITIES].connect(opThreshold.InputImage)
+        opDataExport.Inputs[self.ExportNames.SIMPLE_SEGMENTATION].connect(opClassify.SimpleSegmentation)
 
     def createInputApplets(self):
         super().createInputApplets()


### PR DESCRIPTION
enables the export of the simple segmentation from the Pixel Classification stage

per user request... I'm not a fan of this since we [want to remove this workflow](#2621), but also because Simple Segmentation is often only used because it's more convenient to work with than a multi-channel probability image. But we allow export from pixel classification so I think it's fair to expect that it can be exported from the combined workflow as well.
