### PR TITLE
make model text edit non-editable on error

### DIFF
--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -124,6 +124,7 @@ class ModelSourceEdit(QTextEdit):
             )
         )
         self._model_source = model_source
+        self.setTextInteractionFlags(Qt.NoTextInteraction)
 
     def dropEvent(self, dropEvent):
         urls = dropEvent.mimeData().urls()
@@ -156,6 +157,7 @@ class ModelSourceEdit(QTextEdit):
     def setModelIncompatibleState(self, model_source, model_info, error_message):
         self.setToolTip(f"Model not compatible with data:\n\n{error_message}")
         self.setModelInfo(model_source, model_info, template=f"<red>{display_template}</red>")
+        self.setHtml(f"{self.toHtml()}\n<b><red>{error_message}</red></b>")
 
     def setEmptyState(self):
         self.clear()
@@ -164,7 +166,6 @@ class ModelSourceEdit(QTextEdit):
         self.btn_container.setEnabled(True)
         self.setTextInteractionFlags(Qt.NoTextInteraction)
         self.setToolTip("Remove the model by clicking the 'x' in the upper right corner.")
-        self.setModelInfo(model_source, model_info)
 
     def setReadyState(self, model_source, model_info):
         self.btn_container.setEnabled(False)
@@ -312,7 +313,7 @@ class ModelStateControl(QWidget):
         downloader = BioImageDownloader(model_uri, cancelSrc.token, self)
         dialog = PercentProgressDialog(self, title="Downloading model", secondary_bar=True)
         dialog.rejected.connect(cancelSrc.cancel)
-        dialog.show()
+        dialog.open()
         downloader.finished.connect(dialog.accept)
         downloader.error.connect(self._showErrorMessage)
         downloader.progress0.connect(dialog.updateProgress)

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -798,11 +798,13 @@ class NNClassGui(LabelingGui):
         self.labelingDrawerUi.checkpoints.setVisible(False)
 
         if state is TiktorchOperatorModel.State.Empty:
+            self.toggleLivePrediction(False)
             self.labelingDrawerUi.livePrediction.setEnabled(False)
             self.updateAllLayers()
 
         elif state is TiktorchOperatorModel.State.ModelDataAvailable:
             num_classes = self.tiktorchModel.modelData.numClasses
+            self.toggleLivePrediction(False)
             self.labelingDrawerUi.livePrediction.setEnabled(False)
 
             self.minLabelNumber = num_classes


### PR DESCRIPTION
previously it was possible to edit content, delete everything - but it wouldn't behave properly - keeping the old model source.

Now even on error you have to clear the model (this gives you a chance of noting what model causes the problem and also the cause via the error message).

fixes #2624 
