### PR TITLE
mnt: gh is deprecating save-output command

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash -l {0}
         run: |
           vers=$( python setup.py --version )
-          echo "::set-output name=version::${vers}"
+          echo "version=${vers}" >> $GITHUB_OUTPUT
       - name: linux conda build test
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
