### PR TITLE
release pin on pytest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
 
 cache:
-  - C:\Miniconda37-x64\pkgs -> appveyor.yml
+  - C:\Miniconda38-x64\pkgs -> appveyor.yml
 
 install:
   - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
@@ -20,28 +20,18 @@ install:
   # due to an incompatibility of mamba with conda 4.13, one currently cannot update conda first
   - cmd: conda install -n base -c conda-forge mamba
   - cmd: mamba update -n base -c conda-forge conda
-  - cmd: mamba install -n base -c conda-forge conda-build boa
-  # Get the current main of all submodules
-  - cmd: git clone https://github.com/ilastik/ilastik-meta %IlASTIK_ROOT%\ilastik-meta
-  - cmd: cd %IlASTIK_ROOT%\ilastik-meta
-  - cmd: git submodule update --init --recursive
-  - cmd: git submodule foreach "git checkout main"
-  - ps: rm -Force -Recurse $env:IlASTIK_ROOT\ilastik-meta\ilastik\
+  - cmd: mamba install -n base -c conda-forge conda-build boa setuptools_scm
   # replace with whatever version of ilastik triggered the appveyor
-  - ps: cp -recurse C:\projects\ilastik $env:IlASTIK_ROOT\ilastik-meta\ilastik
-  # Point to the current ilastik-meta
   - |
-    mamba env create --name %ENV_NAME% --file %IlASTIK_ROOT%\ilastik-meta\ilastik\dev\environment-dev.yml
-    mamba install --name %ENV_NAME% -c ilastik-forge -c conda-forge volumina
-    mamba run -n %ENV_NAME% pip install -e %IlASTIK_ROOT%\ilastik-meta\ilastik
+    mamba env create --name %ENV_NAME% --file dev\environment-dev.yml
+    mamba install --name %ENV_NAME% --freeze-installed -c ilastik-forge -c conda-forge volumina
+    mamba run -n %ENV_NAME% pip install -e .
   - mamba clean -p
 
 build: off
 
 test_script:
-  - cmd: set PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
   - cmd: CALL activate %ENV_NAME%
-  - cmd: cd %IlASTIK_ROOT%\ilastik-meta\ilastik
   - cmd: set VOLUMINA_SHOW_3D_WIDGET=0
   - cmd: pytest --run-legacy-gui
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -77,7 +77,7 @@ outputs:
         - pytest.ini
 
       requires:
-        - pytest >=3,<4
+        - pytest >4
         - pytest-qt
         - volumina
         - tiktorch
@@ -115,7 +115,7 @@ outputs:
         - pytest.ini
 
       requires:
-        - pytest >=3,<4
+        - pytest >4
         - pytest-qt
         # need to help mamba here a bit
         - ilastik-pytorch-version-helper-cpu
@@ -166,7 +166,7 @@ outputs:
         - pytest.ini
 
       requires:
-        - pytest >=3,<4
+        - pytest >4
         - pytest-qt
         - pytorch 1.12.*
         - cudatoolkit 11.*

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -54,7 +54,7 @@ dependencies:
   - conda-build
   - mypy
   - pre-commit
-  - pytest >=3,<4
+  - pytest >4
   - pytest-qt
 
   # ensure working environment on apple M1 via rosetta

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -265,7 +265,7 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
     # Custom format for warnings
     def simple_warning_format(message, category, filename, lineno, line=None):
         filename = os.path.split(filename)[1]
-        return filename + "(" + str(lineno) + "): " + category.__name__ + ": " + message.args[0]
+        return f"{filename}:({lineno}): {category.__name__}: {message!r}"
 
     warnings.formatwarning = simple_warning_format
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -322,8 +322,8 @@ def another_png_image(tmp_path) -> Path:
 
 @pytest.fixture
 def empty_project_file(tmp_path) -> h5py.File:
-    project_path = tmp_path / tempfile.mkstemp(suffix=".ilp")[1]
-    with h5py.File(project_path, "r+") as f:
+    project_path = tmp_path / "project_file.ilp"
+    with h5py.File(project_path, "a") as f:
         yield f
 
 

--- a/tests/test_ilastik/test_workflows/test_DatasetInfo.py
+++ b/tests/test_ilastik/test_workflows/test_DatasetInfo.py
@@ -14,12 +14,19 @@ from ilastik.applets.dataSelection import DatasetInfo, FilesystemDatasetInfo
 
 
 @pytest.fixture
-def png_stack_dir(tmp_path) -> Path:
+def stack_path(tmp_path) -> Path:
+    p = tmp_path / "stacksubpath"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def png_stack_dir(stack_path) -> Path:
     for i in range(3):
         pil_image = PilImage.fromarray((numpy.random.rand(520, 697, 3) * 255).astype(numpy.uint8))
-        with open(tmp_path / f"c_cells_{i}.png", "wb") as png_file:
+        with open(stack_path / f"c_cells_{i}.png", "wb") as png_file:
             pil_image.save(png_file, "png")
-    return tmp_path
+    return stack_path
 
 
 @pytest.fixture
@@ -32,13 +39,13 @@ def h5_1_100_200_1_1(tmp_path):
 
 
 @pytest.fixture
-def h5_stack_dir(tmp_path):
+def h5_stack_dir(stack_path):
     for i in range(3):
         raw = (numpy.random.rand(1, 100, 200, 1, 1) * 255).astype(numpy.uint8)
-        with h5py.File(tmp_path / f"2d_apoptotic_binary_{i}.h5", "w") as f:
+        with h5py.File(stack_path / f"2d_apoptotic_binary_{i}.h5", "w") as f:
             f.create_group("volume")
             f["volume/data"] = raw
-    return tmp_path
+    return stack_path
 
 
 def dir_to_colon_glob(dir_path: str):
@@ -79,11 +86,6 @@ def h5_colon_path_stack_with_inner_paths(h5_colon_path_stack) -> str:
 @pytest.fixture
 def h5_star_stack(h5_stack_dir) -> str:
     return dir_to_star_glob(h5_stack_dir)
-
-
-@pytest.fixture
-def empty_project_file() -> h5py.File:
-    return h5py.File(tempfile.mkstemp()[1], "r+")
 
 
 def test_create_nickname(h5_colon_path_stack):

--- a/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
+++ b/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
@@ -119,12 +119,16 @@ def test_headless_2d3c_with_same_raw_data_axis(testdir, pixel_classification_ilp
     )
 
 
-def test_headless_2d3c_with_permuted_raw_data_axis(testdir, pixel_classification_ilp_2d3c: Path, tmp_path: Path):
+def test_headless_2d3c_with_permuted_raw_data_axis_from_training_data_raises(
+    testdir, pixel_classification_ilp_2d3c: Path, tmp_path: Path
+):
+    """
+    default behavior is to try to apply training axistags to the batch data,
+    and therefore fail because raw data' axis (cyx) are not in the expected order (yxc)
+    """
     raw_3c100x100y: Path = create_h5(numpy.random.rand(3, 100, 100), axiskeys="cyx")
     output_path = tmp_path / "out_3c100x100y.h5"
 
-    # default behavior is to try to apply training axistags to the batch data, and therefore fail because raw data's
-    # axis (cyx) are not in the expected order (yxc)
     with pytest.raises(FailedHeadlessExecutionException):
         run_headless_pixel_classification(
             testdir,
@@ -133,7 +137,14 @@ def test_headless_2d3c_with_permuted_raw_data_axis(testdir, pixel_classification
             output_filename_format=str(output_path),
         )
 
-    # forcing correct input axes should pass
+
+def test_headless_2d3c_with_permuted_raw_data_axis_explicit_axes(
+    testdir, pixel_classification_ilp_2d3c: Path, tmp_path: Path
+):
+    """forcing correct input axes should pass"""
+    raw_3c100x100y: Path = create_h5(numpy.random.rand(3, 100, 100), axiskeys="cyx")
+    output_path = tmp_path / "out_3c100x100y.h5"
+
     run_headless_pixel_classification(
         testdir,
         project=pixel_classification_ilp_2d3c,
@@ -142,8 +153,17 @@ def test_headless_2d3c_with_permuted_raw_data_axis(testdir, pixel_classification
         input_axes="cyx",
     )
 
-    # alternatively, since the generated h5 data has the axistags property, we can ignore training data and use that
-    # instead, by using the '--ignore_training_axistags' flag
+
+def test_headless_2d3c_with_permuted_raw_data_axis_use_h5_tags(
+    testdir, pixel_classification_ilp_2d3c: Path, tmp_path: Path
+):
+    """
+    alternatively, since the generated h5 data has the axistags property, we can ignore training data and use that
+    instead, by using the '--ignore_training_axistags' flag
+    """
+    raw_3c100x100y: Path = create_h5(numpy.random.rand(3, 100, 100), axiskeys="cyx")
+    output_path = tmp_path / "out_3c100x100y.h5"
+
     run_headless_pixel_classification(
         testdir,
         project=pixel_classification_ilp_2d3c,

--- a/tests/test_ilastik/widgets/test_datasetInfoEditorWidget.py
+++ b/tests/test_ilastik/widgets/test_datasetInfoEditorWidget.py
@@ -29,11 +29,6 @@ def image_zyxc_stack_path(png_image, another_png_image):
     return str(png_image) + os.path.pathsep + str(another_png_image)
 
 
-@pytest.fixture
-def empty_project_file() -> h5py.File:
-    return h5py.File(tempfile.mkstemp()[1], "r+")
-
-
 DONT_SET_NORMALIZE = object()
 TOP_GROUP_NAME = "my_group"
 
@@ -216,12 +211,12 @@ def test_too_few_axeskeys_shows_error(qtbot, image_yxc_fs_info, empty_project_fi
     assert widget.axes_error_display.text() != ""
 
 
-def test_garbled_axeskeys_shows_error(qtbot, image_yxc_fs_info):
+def test_garbled_axeskeys_shows_error(qtbot, image_yxc_fs_info, empty_project_file):
     widget = create_and_modify_widget(qtbot, [image_yxc_fs_info], empty_project_file, axiskeys="ab")
     assert widget.axes_error_display.text() != ""
 
 
-def test_repeated_axeskeys_shows_error(qtbot, image_yxc_fs_info):
+def test_repeated_axeskeys_shows_error(qtbot, image_yxc_fs_info, empty_project_file):
     widget = create_and_modify_widget(qtbot, [image_yxc_fs_info], empty_project_file, axiskeys="yy")
     assert widget.axes_error_display.text() != ""
 


### PR DESCRIPTION
Final blocking thing preventing us from updating Python was pytest. This updates pytest from `3.x` pin to 7.2.0 (latest, not pinned)

There were some small real issues

* `tmp_path` magic that would resolve symlinks vs `tempfile.mk*` not doing it.
* in one of the tests, we use [`pytester`](https://docs.pytest.org/en/6.2.x/reference.html#pytest.Pytester), which is supposed to run tests in a more isolated manner (guess that was the motivation for using it, from the docs I take it is used to test pytest itself). Behavior of `pytester` `testdir` fixture seems to have changed - since pytest 3.x. I didn't dig into the pytest source code, but somehow invoking `run` seems to alter the environment for subsequent calls to `run` in the same test function. Splitting those functions means better reporting anyway. (In addition we could think about dropping the use of `pytester` here - I'm not sure it's supposed to be used outside the context of testing pytest itself).

while debugging I simplified `appveyor.yml` a bit - but [these changes](https://github.com/ilastik/ilastik/pull/2633/commits/293caf0344eae8ec25791ea0fbf52562ca16d362) are unrelated and I can also remove them. 