### PR TITLE
Fix suggest features for narrow stacks

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -14,8 +14,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      - uses: akaihola/darker@1.4.0
+      - uses: akaihola/darker@1.5.1
         with:
           options: "--check --diff --revision=origin/main..."
           src: "."
-          version: "1.4.0"
+          # due to incompatibility of black with the current release of the
+          # darker github action, we need to use a non-release version
+          # ref: https://github.com/ilastik/ilastik/issues/2640
+          version: "@3c675b009d747cadd6e8048d2c57a5b1cd54fb3e"

--- a/ilastik/applets/base/applet.py
+++ b/ilastik/applets/base/applet.py
@@ -115,16 +115,21 @@ class Applet(with_metaclass(ABCMeta, object)):
 
 
 class DatasetConstraintError(Exception):
-    def __init__(self, appletName, message, unfixable=False, fixing_dialogs=[]):
-        """
+    def __init__(self, appletName, message):
+        """Error to indicate unfitting data for operation
+
+        Exception to be raised in the context of some applet usage, so either
+        associated operators or GUIs.
+
+        Example: dimensionality not suitable (too many/not enough channels)
+
         Args:
-            fixing_dialogs: list of functions to show dialogs which can alleviate the dataset constraint.
+          appletName: applet where the exception is happening
+          message: description of error and possible mitigation measures
         """
         super().__init__()
         self.appletName = appletName
         self.message = message
-        self.unfixable = unfixable
-        self.fixing_dialogs = fixing_dialogs
 
     def __str__(self):
         return "Constraint of '{}' applet was violated: {}".format(self.appletName, self.message)

--- a/ilastik/applets/featureSelection/__init__.py
+++ b/ilastik/applets/featureSelection/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,4 +18,44 @@ from __future__ import absolute_import
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
+from typing import Callable, Iterable, Union
+
+from ilastik.applets.base.applet import DatasetConstraintError
+
+_SCALES = Iterable[Union[int, float]]
+
+
+class FeatureSelectionConstraintError(DatasetConstraintError):
+    def __init__(
+        self,
+        appletName: str,
+        invalid_scales: _SCALES,
+        invalid_z_scales: _SCALES,
+        fixing_dialogs=Iterable[Callable],
+    ):
+        """
+        Args:
+          appletName: applet where the exception is happening
+          invalid_scales: list of scales that are not compatible in the x-y plane
+          invalid_z_scales: list of scales that are not compatible in the z-plane
+          fixing_dialogs: list of functions to show dialogs which can alleviate the dataset constraint.
+        """
+        message = "\nSome of your selected feature scales are too large for your dataset.\n"
+        if invalid_scales:
+            message += f"Reduce or remove these scales:\n{invalid_scales}\n\n"
+
+        if invalid_z_scales:
+            message += f"Reduce, remove or switch to 2D computation for these scales:\n{invalid_z_scales}\n\n"
+
+        message += "Alternatively use another dataset."
+
+        super().__init__(appletName, message)
+        self.fixing_dialogs = fixing_dialogs
+        self.invalid_scales = invalid_scales
+        self.invalid_z_scales = invalid_z_scales
+
+    def __str__(self):
+        return f"Constraint of '{self.appletName}' applet was violated: {self.message}"
+
+
 from .featureSelectionApplet import FeatureSelectionApplet

--- a/ilastik/applets/featureSelection/__init__.py
+++ b/ilastik/applets/featureSelection/__init__.py
@@ -18,11 +18,11 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from typing import Callable, Iterable, Union
+from typing import Callable, Iterable, Sequence, Union
 
 from ilastik.applets.base.applet import DatasetConstraintError
 
-_SCALES = Iterable[Union[int, float]]
+_SCALES = Sequence[Union[int, float]]
 
 
 class FeatureSelectionConstraintError(DatasetConstraintError):
@@ -30,8 +30,8 @@ class FeatureSelectionConstraintError(DatasetConstraintError):
         self,
         appletName: str,
         invalid_scales: _SCALES,
-        invalid_z_scales: _SCALES,
-        fixing_dialogs=Iterable[Callable],
+        invalid_z_scales: _SCALES = (),
+        fixing_dialogs: Iterable[Callable] = (),
     ):
         """
         Args:
@@ -55,7 +55,7 @@ class FeatureSelectionConstraintError(DatasetConstraintError):
         self.invalid_z_scales = invalid_z_scales
 
     def __str__(self):
-        return f"Constraint of '{self.appletName}' applet was violated: {self.message}"
+        return f"Constraint of {self.appletName!r} applet was violated: {self.message}"
 
 
 from .featureSelectionApplet import FeatureSelectionApplet

--- a/ilastik/applets/featureSelection/opFeatureSelection.py
+++ b/ilastik/applets/featureSelection/opFeatureSelection.py
@@ -31,7 +31,7 @@ from lazyflow.operators import OpPixelFeaturesPresmoothed
 from lazyflow.operators import OpReorderAxes
 from lazyflow.operatorWrapper import OperatorWrapper
 
-from ilastik.applets.base.applet import DatasetConstraintError
+from ilastik.applets.featureSelection import FeatureSelectionConstraintError
 
 logger = logging.getLogger(__name__)
 
@@ -168,14 +168,7 @@ class OpFeatureSelectionNoCache(Operator):
             invalid_scales, invalid_z_scales = self.opPixelFeatures.getInvalidScales()
             if invalid_scales or invalid_z_scales:
                 invalid_z_scales = [s for s in invalid_z_scales if s not in invalid_scales]  # 'do not complain twice'
-                msg = "Some of your selected feature scales are too large for your dataset.\n"
-                if invalid_scales:
-                    msg += f"Reduce or remove these scales:\n{invalid_scales}\n\n"
 
-                if invalid_z_scales:
-                    msg += f"Reduce, remove or switch to 2D computation for these scales:\n{invalid_z_scales}\n\n"
-
-                msg += "Alternatively use another dataset."
                 if self.parent.parent.featureSelectionApplet._gui is None:
                     # headless
                     fix_dlgs = []
@@ -186,7 +179,12 @@ class OpFeatureSelectionNoCache(Operator):
                         ).onFeatureButtonClicked
                     ]
 
-                raise DatasetConstraintError("Feature Selection", msg, fixing_dialogs=fix_dlgs)
+                raise FeatureSelectionConstraintError(
+                    "Feature Selection",
+                    invalid_scales=invalid_scales,
+                    invalid_z_scales=invalid_z_scales,
+                    fixing_dialogs=fix_dlgs,
+                )
 
             # Connect our external outputs to our internal operators
             self.OutputImage.connect(self.opReorderOut.Output)

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -528,7 +528,7 @@ class PixelClassificationGui(LabelingGui):
         self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData)
 
     def show_feature_selection_dialog(self):
-        self.featSelDlg.exec_()
+        self.featSelDlg.open()
 
     def update_features_from_dialog(self):
         if self.topLevelOperatorView.name == "OpPixelClassification":

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -554,9 +554,8 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
+        thisOpFeatureSelection.ComputeIn2d.setValue(self.featSelDlg.compute_in_2d_compat)
         thisOpFeatureSelection.SelectionMatrix.setValue(self.featSelDlg.selected_features_matrix)
-        thisOpFeatureSelection.SelectionMatrix.setDirty()
-        thisOpFeatureSelection.setupOutputs()
 
     def initViewerControlUi(self):
         localDir = os.path.split(__file__)[0]

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -77,7 +77,7 @@ from ilastik.shell.gui.variableImportanceDialog import VariableImportanceDialog
 from ilastik.applets.dataSelection import DatasetInfo
 
 # import IPython
-from .FeatureSelectionDialog import FeatureSelectionDialog
+from .suggestFeaturesDialog import SuggestFeaturesDialog
 
 try:
     from volumina.view3d.volumeRendering import RenderingManager
@@ -525,7 +525,7 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        self.featSelDlg = FeatureSelectionDialog(thisOpFeatureSelection, self, self.labelListData)
+        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData)
 
     def show_feature_selection_dialog(self):
         self.featSelDlg.exec_()

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -525,7 +525,7 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData)
+        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
 
     def show_feature_selection_dialog(self):
         self.featSelDlg.open()

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -465,9 +465,7 @@ class PixelClassificationGui(LabelingGui):
 
         self.labelingDrawerUi.liveUpdateButton.toggled.connect(self.setLiveUpdateEnabled)
 
-        self.initFeatSelDlg()
-        self.labelingDrawerUi.suggestFeaturesButton.clicked.connect(self.show_feature_selection_dialog)
-        self.featSelDlg.accepted.connect(self.update_features_from_dialog)
+        self.labelingDrawerUi.suggestFeaturesButton.clicked.connect(self.show_suggest_features_dialog)
         self.labelingDrawerUi.suggestFeaturesButton.setEnabled(False)
 
         # Always force at least two labels because it makes no sense to have less here
@@ -501,7 +499,7 @@ class PixelClassificationGui(LabelingGui):
         self.__cleanup_fns.append(unsub_callback)
         self.setLiveUpdateEnabled()
 
-    def initFeatSelDlg(self):
+    def initSuggestFeaturesDialog(self):
         if self.topLevelOperatorView.name == "OpPixelClassification":
             thisOpFeatureSelection = (
                 self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
@@ -525,12 +523,14 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
+        return SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
 
-    def show_feature_selection_dialog(self):
-        self.featSelDlg.open()
+    def show_suggest_features_dialog(self):
+        suggestFeaturesDialog = self.initSuggestFeaturesDialog()
+        suggestFeaturesDialog.resultSelected.connect(self.update_features_from_dialog)
+        suggestFeaturesDialog.open()
 
-    def update_features_from_dialog(self):
+    def update_features_from_dialog(self, feature_matrix, compute_in_2d):
         if self.topLevelOperatorView.name == "OpPixelClassification":
             thisOpFeatureSelection = (
                 self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
@@ -554,8 +554,9 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        thisOpFeatureSelection.ComputeIn2d.setValue(self.featSelDlg.compute_in_2d_compat)
-        thisOpFeatureSelection.SelectionMatrix.setValue(self.featSelDlg.selected_features_matrix)
+        thisOpFeatureSelection.SelectionMatrix.setValue(None)
+        thisOpFeatureSelection.ComputeIn2d.setValue(compute_in_2d)
+        thisOpFeatureSelection.SelectionMatrix.setValue(feature_matrix)
 
     def initViewerControlUi(self):
         localDir = os.path.split(__file__)[0]

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -554,7 +554,6 @@ class PixelClassificationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        thisOpFeatureSelection.SelectionMatrix.setValue(None)
         thisOpFeatureSelection.ComputeIn2d.setValue(compute_in_2d)
         thisOpFeatureSelection.SelectionMatrix.setValue(feature_matrix)
 

--- a/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
+++ b/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 __author__ = "fabian"
 
+import os
+
 import numpy
 
 # import scipy
@@ -499,7 +501,6 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
         If the user selects a specific feature set in the comboBox in the bottom row then the segmentation of this
         feature set will be displayed in the viewer
         """
-
         id = self.all_feature_sets_combo_box.currentIndex()
         for i, layer in enumerate(self.layerstack):
             layer.visible = i == id
@@ -812,7 +813,10 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
                     msg += f"Calculating features at sigmas {err.invalid_z_scales} in 2D only."
 
                 logger.info(msg)
-                QMessageBox.information(self, "Not all features are compatible with your data!", msg)
+
+                # suppress the popup in pytest:
+                if "PYTEST_CURRENT_TEST" not in os.environ:
+                    QMessageBox.information(self, "Not all features are compatible with your data!", msg)
 
             # self.opFeatureSelection.change_feature_cache_size()
             self.feature_channel_names = self.opPixelClassification.FeatureImages.meta["channel_names"]
@@ -940,6 +944,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
             self.opFeatureSelection.ComputeIn2d.setValue(user_compute_in_2d)
             self.opFeatureSelection.SelectionMatrix.setValue(user_defined_matrix)
             QtWidgets.QApplication.instance().restoreOverrideCursor()
+            self._runComplete.emit()
 
 
 ## Start Qt event loop unless running in interactive mode.

--- a/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
+++ b/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
@@ -170,7 +170,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
 
         self.resize(1366, 768)
 
-    def exec_(self):
+    def open(self):
         """
         as explained in the __init__, we only display one slice of the datastack. Here we find out which slice is
 
@@ -238,7 +238,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
             self._add_grayscale_layer(self.raw_xy_slice, "raw_data", True)
 
         # now launch the dialog
-        super().exec_()
+        super().open()
 
     def reset_me(self):
         """
@@ -446,7 +446,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
             text += "</html>"
             text_edit.setText(text)
 
-        dialog.exec_()
+        dialog.open()
 
     def _add_color_layer(self, data, name=None, visible=False):
         """
@@ -904,7 +904,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
 if __name__ == "__main__":
     # import sys
     # if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
-    #    QtWidgets.QApplication.instance().exec_()
+    #    QtWidgets.QApplication.instance().open()
     app = QtWidgets.QApplication([])
     win = QtWidgets.QMainWindow()
     win.resize(800, 800)
@@ -921,4 +921,4 @@ if __name__ == "__main__":
     win.setCentralWidget(central_widget)
 
     win.show()
-    QtWidgets.QApplication.instance().exec_()
+    QtWidgets.QApplication.instance().open()

--- a/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
+++ b/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
@@ -86,13 +86,13 @@ class SuggestFeaturesResult(object):
 
 
 class SuggestFeaturesDialog(QtWidgets.QDialog):
-    def __init__(self, current_opFeatureSelection, current_pixelClassificationApplet, labels_list_data):
+    def __init__(self, current_opFeatureSelection, current_pixelClassificationApplet, labels_list_data, parent=None):
         """
 
         :param current_opFeatureSelection: opFeatureSelection from ilastik
         :param current_opPixelClassification: opPixelClassification form Ilastik
         """
-        super().__init__()
+        super().__init__(parent)
 
         self.pixelClassificationApplet = current_pixelClassificationApplet
         self.opPixelClassification = current_pixelClassificationApplet.topLevelOperatorView
@@ -415,7 +415,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
             self._gui_initialized = True
 
     def _show_feature_name_dialog(self):
-        dialog = QtWidgets.QDialog()
+        dialog = QtWidgets.QDialog(self)
         dialog.resize(350, 650)
 
         ok_button = QtWidgets.QPushButton("ok")

--- a/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
+++ b/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
@@ -92,6 +92,12 @@ class SuggestFeaturesResult(object):
 
 
 class SuggestFeaturesDialog(QtWidgets.QDialog):
+
+    # publish the new feature_matrix, and compute_in_2d list
+    resultSelected = QtCore.pyqtSignal(numpy.ndarray, list)
+    # for testing purposes
+    _runComplete = QtCore.pyqtSignal()
+
     def __init__(self, current_opFeatureSelection, current_pixelClassificationApplet, labels_list_data, parent=None):
         """
 
@@ -175,7 +181,11 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
         self._handle_selected_method_changed()
         self._update_parameters()
 
+        self.accepted.connect(self._emitResults)
         self.resize(1366, 768)
+
+    def _emitResults(self):
+        self.resultSelected.emit(self.selected_features_matrix, self.compute_in_2d_compat)
 
     def open(self):
         """
@@ -926,6 +936,7 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
 
         finally:
             # revert changes to matrix
+            self.opFeatureSelection.SelectionMatrix.setValue(None)
             self.opFeatureSelection.ComputeIn2d.setValue(user_compute_in_2d)
             self.opFeatureSelection.SelectionMatrix.setValue(user_defined_matrix)
             QtWidgets.QApplication.instance().restoreOverrideCursor()

--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -255,17 +255,6 @@ class NewAutocontextWorkflowBase(Workflow):
         opFinalClassify = self.pcApplets[-1].topLevelOperator.getLane(laneIndex)
         opDataExport = self.dataExportApplet.topLevelOperator.getLane(laneIndex)
 
-        def checkConstraints(*_):
-            # if (opData.Image.meta.dtype in [np.uint8, np.uint16]) == False:
-            #    msg = "The Autocontext Workflow only supports 8-bit images (UINT8 pixel type)\n"\
-            #          "or 16-bit images (UINT16 pixel type)\n"\
-            #          "Your image has a pixel type of {}.  Please convert your data to UINT8 and try again."\
-            #          .format( str(np.dtype(opData.Image.meta.dtype)) )
-            #    raise DatasetConstraintError( "Autocontext Workflow", msg, unfixable=True )
-            pass
-
-        opData.Image.notifyReady(checkConstraints)
-
         # Input Image -> Feature Op
         #         and -> Classification Op (for display)
         opFirstFeatures.InputImage.connect(opData.Image)

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -545,7 +545,6 @@ class VoxelSegmentationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        thisOpFeatureSelection.SelectionMatrix.setValue(None)
         thisOpFeatureSelection.ComputeIn2d.setValue(compute_in_2d)
         thisOpFeatureSelection.SelectionMatrix.setValue(self.featSelDlg.selected_features_matrix)
 

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -20,7 +20,7 @@ from lazyflow.operators.ioOperators import OpInputDataReader
 
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.applets.pixelClassification import pixelClassificationGui
-from ilastik.applets.pixelClassification.FeatureSelectionDialog import FeatureSelectionDialog
+from ilastik.applets.pixelClassification.suggestFeaturesDialog import SuggestFeaturesDialog
 from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.utility import bind
 
@@ -151,7 +151,7 @@ class VoxelSegmentationGui(LabelingGui):
         thisOpFeatureSelection = (
             self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
         )
-        self.featSelDlg = FeatureSelectionDialog(thisOpFeatureSelection, self, self.labelListData)
+        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData)
 
     def menus(self):
         menus = super().menus()

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -77,9 +77,7 @@ class VoxelSegmentationGui(LabelingGui):
         self.labelingDrawerUi.liveUpdateButton.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self.labelingDrawerUi.liveUpdateButton.toggled.connect(self.toggleInteractive)
 
-        self.initFeatSelDlg()
-        self.labelingDrawerUi.suggestFeaturesButton.clicked.connect(self.show_feature_selection_dialog)
-        self.featSelDlg.accepted.connect(self.update_features_from_dialog)
+        self.labelingDrawerUi.suggestFeaturesButton.clicked.connect(self.show_suggest_features_dialog)
         self.labelingDrawerUi.suggestFeaturesButton.setEnabled(False)
 
         # Always force at least two labels because it makes no sense to have less here
@@ -147,11 +145,11 @@ class VoxelSegmentationGui(LabelingGui):
         self.topLevelOperatorView.LabelImages.notifyDirty(bind(resetBestPlanes))
         self.labelingDrawerUi.bestAnnotationPlaneButton.clicked.connect(SelectBestAnnotationPlane)
 
-    def initFeatSelDlg(self):
+    def initSuggestFeaturesDialog(self):
         thisOpFeatureSelection = (
             self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
         )
-        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
+        return SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
 
     def menus(self):
         menus = super().menus()
@@ -518,10 +516,12 @@ class VoxelSegmentationGui(LabelingGui):
     ###########################################
     ###########################################
 
-    def show_feature_selection_dialog(self):
-        self.featSelDlg.open()
+    def show_suggest_features_dialog(self):
+        suggestFeaturesDialog = self.initSuggestFeaturesDialog()
+        suggestFeaturesDialog.resultSelected.connect(self.update_features_from_dialog)
+        suggestFeaturesDialog.open()
 
-    def update_features_from_dialog(self):
+    def update_features_from_dialog(self, feature_matrix, compute_in_2d):
         if self.topLevelOperatorView.name == "OpPixelClassification":
             thisOpFeatureSelection = (
                 self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
@@ -545,7 +545,8 @@ class VoxelSegmentationGui(LabelingGui):
         else:
             raise NotImplementedError
 
-        thisOpFeatureSelection.ComputeIn2d.setValue(self.featSelDlg.compute_in_2d_compat)
+        thisOpFeatureSelection.SelectionMatrix.setValue(None)
+        thisOpFeatureSelection.ComputeIn2d.setValue(compute_in_2d)
         thisOpFeatureSelection.SelectionMatrix.setValue(self.featSelDlg.selected_features_matrix)
 
     def initViewerControlUi(self):

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -151,7 +151,7 @@ class VoxelSegmentationGui(LabelingGui):
         thisOpFeatureSelection = (
             self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
         )
-        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData)
+        self.featSelDlg = SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
 
     def menus(self):
         menus = super().menus()

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -545,9 +545,8 @@ class VoxelSegmentationGui(LabelingGui):
         else:
             raise NotImplementedError
 
+        thisOpFeatureSelection.ComputeIn2d.setValue(self.featSelDlg.compute_in_2d_compat)
         thisOpFeatureSelection.SelectionMatrix.setValue(self.featSelDlg.selected_features_matrix)
-        thisOpFeatureSelection.SelectionMatrix.setDirty()
-        thisOpFeatureSelection.setupOutputs()
 
     def initViewerControlUi(self):
         localDir = os.path.split(__file__)[0]

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -519,7 +519,7 @@ class VoxelSegmentationGui(LabelingGui):
     ###########################################
 
     def show_feature_selection_dialog(self):
-        self.featSelDlg.exec_()
+        self.featSelDlg.open()
 
     def update_features_from_dialog(self):
         if self.topLevelOperatorView.name == "OpPixelClassification":

--- a/lazyflow/operators/oldVigraOperators.py
+++ b/lazyflow/operators/oldVigraOperators.py
@@ -1178,7 +1178,7 @@ from lazyflow.operators import OpSlicedBlockedArrayCache, OpMultiArraySlicer2
 from lazyflow.operators import OpReorderAxes
 from lazyflow.operatorWrapper import OperatorWrapper
 
-from ilastik.applets.base.applet import DatasetConstraintError
+from ilastik.applets.featureSelection import FeatureSelectionConstraintError
 
 
 # Constants
@@ -1320,12 +1320,9 @@ class OpFeatureSelectionNoCache(Operator):
             self.opPixelFeatures.Matrix.setValue(selections)
             invalid_scales = self.opPixelFeatures.getInvalidScales()
             if invalid_scales:
-                msg = (
-                    "Some of your selected feature scales are too large for your dataset.\n"
-                    "Choose smaller scales (sigma) or use a larger dataset.\n"
-                    "The invalid scales are: {}".format(invalid_scales)
+                raise FeatureSelectionConstraintError(
+                    "Feature Selection (oldVigraOperators)", invalid_scales=invalid_scales, invalid_z_scales=[]
                 )
-                raise DatasetConstraintError("Feature Selection", msg)
 
             # Connect our external outputs to our internal operators
             self.OutputImage.connect(self.opReorderOut.Output)

--- a/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
+++ b/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
@@ -266,14 +266,14 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             #                    sigma:   0.3    0.7    1.0    1.6    3.5    5.0   10.0
             selections = numpy.array(
                 [
-                    [True, False, False, False, False, False, False],
-                    [False, True, False, False, False, False, False],
-                    [False, True, False, False, False, False, False],
-                    [False, False, False, False, False, False, False],
-                    [False, False, False, False, False, False, False],
-                    [False, False, False, False, False, False, False],
+                    [1, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
                 ]
-            )
+            ).astype(bool)
 
             opFeatures.SelectionMatrix.setValue(selections)
 
@@ -715,18 +715,18 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             scales = [0.3, 0.7, 15.0]
             selections = numpy.array(
                 [
-                    [True, False, False],
-                    [False, True, False],
-                    [False, True, False],
-                    [False, False, False],
-                    [False, False, False],
-                    [False, False, False],
+                    [1, 0, 0],
+                    [0, 1, 0],
+                    [0, 1, 0],
+                    [0, 0, 0],
+                    [0, 0, 0],
+                    [0, 0, 0]
                 ]
-            )
+            ).astype(bool)  # fmt: skip
 
             opFeatures.SelectionMatrix.setValue(None)
             opFeatures.Scales.setValue(scales)
-            opFeatures.ComputeIn2d.setValue([False for _ in scales])
+            opFeatures.ComputeIn2d.setValue([False] * len(scales))
             opFeatures.SelectionMatrix.setValue(selections)
 
             gui.currentGui()._labelControlUi.suggestFeaturesButton.click()

--- a/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
+++ b/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
@@ -38,6 +38,7 @@ from lazyflow.utility.timer import Timer, timeLogged
 from tests.test_ilastik.helpers import ShellGuiTestCaseBase
 
 from ilastik.applets.pixelClassification.pixelClassificationApplet import PixelClassificationApplet
+from ilastik.applets.pixelClassification.suggestFeaturesDialog import SuggestFeaturesDialog
 
 DATA_SELECTION_INDEX = 0
 PIXEL_CLASSIFICATION_INDEX = 2
@@ -152,7 +153,7 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
         else:
             cls.using_random_data = True
             cls.SAMPLE_DATA = os.path.split(__file__)[0] + "/random_data.npy"
-            data = numpy.random.random((1, 200, 200, 50, 1))
+            data = numpy.random.random((1, 50, 200, 200, 1))
             data *= 256
             numpy.save(cls.SAMPLE_DATA, data.astype(numpy.uint8))
 
@@ -266,8 +267,8 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             selections = numpy.array(
                 [
                     [True, False, False, False, False, False, False],
-                    [True, False, False, False, False, False, False],
-                    [True, False, False, False, False, False, False],
+                    [False, True, False, False, False, False, False],
+                    [False, True, False, False, False, False, False],
                     [False, False, False, False, False, False, False],
                     [False, False, False, False, False, False, False],
                     [False, False, False, False, False, False, False],
@@ -675,6 +676,79 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             gui.currentGui()._labelControlUi.liveUpdateButton.click()
 
             self.waitForViews(gui.currentGui().editor.imageViews)
+
+        # Run this test from within the shell event loop
+        self.exec_in_shell(impl)
+
+    def test_91_suggestFeaturesDlg_close_no_change(self):
+        """
+        Click the "interactive mode" checkbox and see if any errors occur.
+        """
+
+        def impl():
+            workflow = self.shell.projectManager.workflow
+            pixClassApplet = workflow.pcApplet
+            gui = pixClassApplet.getMultiLaneGui()
+
+            gui.currentGui()._labelControlUi.suggestFeaturesButton.click()
+            wait_until(lambda: isinstance(QApplication.instance().activeModalWidget(), SuggestFeaturesDialog))
+            dlg = QApplication.instance().activeModalWidget()
+            dlg.accept()
+
+        # Run this test from within the shell event loop
+        self.exec_in_shell(impl)
+
+    def test_92_suggestFeaturesDlg_run(self):
+        """
+        Click the "interactive mode" checkbox and see if any errors occur.
+        """
+
+        def impl():
+            workflow = self.shell.projectManager.workflow
+            pixClassApplet = workflow.pcApplet
+            gui = pixClassApplet.getMultiLaneGui()
+            opFeatures = workflow.featureSelectionApplet.topLevelOperator
+
+            # this time we want to trigger the message box that informs us,
+            # that some sigmas can only be computed in 2D
+            # so we add a sigma that doesn't fit into size of 50 along z:
+            scales = [0.3, 0.7, 15.0]
+            selections = numpy.array(
+                [
+                    [True, False, False],
+                    [False, True, False],
+                    [False, True, False],
+                    [False, False, False],
+                    [False, False, False],
+                    [False, False, False],
+                ]
+            )
+
+            opFeatures.SelectionMatrix.setValue(None)
+            opFeatures.Scales.setValue(scales)
+            opFeatures.ComputeIn2d.setValue([False for _ in scales])
+            opFeatures.SelectionMatrix.setValue(selections)
+
+            gui.currentGui()._labelControlUi.suggestFeaturesButton.click()
+            wait_until(lambda: isinstance(QApplication.instance().activeModalWidget(), SuggestFeaturesDialog))
+            dlg = QApplication.instance().activeModalWidget()
+            dlg.number_of_feat_box.setValue(2)
+
+            with wait_signal(dlg._runComplete, timeout=10000):
+                dlg.run_button.click()
+
+            # select the filtered feature set in the dialog and accept
+            idx = dlg.all_feature_sets_combo_box.findText("2 features, filter selection", Qt.MatchContains)
+            dlg.all_feature_sets_combo_box.setCurrentIndex(idx)
+            QApplication.processEvents()
+            dlg.accept()
+            QApplication.processEvents()
+
+            features_dlg = dlg.selected_features_matrix
+            features_after = opFeatures.SelectionMatrix.value
+
+            numpy.testing.assert_array_equal(features_dlg, features_after)
+            numpy.testing.assert_array_equal(opFeatures.ComputeIn2d.value, [False, False, True])
 
         # Run this test from within the shell event loop
         self.exec_in_shell(impl)


### PR DESCRIPTION
Enable _SuggestFeatures_ Dialog to deal with "narrow" stacks. Previously it would error out and might even produce segfaults :o.

On the way there was
* refactoring - naming _is_ important. It is frustrating every time I am looking for this particular dialog. Now naming reflects what is shown in the UI.
* made the dialog properly modal and made it run in the same eventloop
* made its `_run_selection` method somewhat more robust to errors - at least the graph is reverted to the same state as before
* by adding some attributes to the error that is raised by the `OpFeatureSelection` when incompatible scales are used, the dialog now automatically deselects the ones that do not work (for features that only don't fit in _z_, they are now calculated in 2D).

See also #2637 

Bottom line: Ideally this whole functionality would be reworked from the ground up. This is just a patch.

fixes #1280 

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
