### PR TITLE
add qslider stylesheet on osx

### DIFF
--- a/ilastik/shell/gui/ilastik-style-osx.qss
+++ b/ilastik/shell/gui/ilastik-style-osx.qss
@@ -10,23 +10,23 @@
 QSlider::add-page:horizontal {
     background: #e0e0e0;
     border: 1px solid #dadada;
-    border-radius: 2px
+    border-radius: 2px;
 }
 
-QSlider{
-    margin: 2px 2px;
+QSlider {
+    margin: 2px;
 }
 
 QSlider::sub-page:horizontal {
     background: #0a82ff;
     border: 1px solid #097ef8;
-    border-radius: 2px
+    border-radius: 2px;
 }
 
 QSlider::groove:horizontal {
     border: 1px solid #000000;
     height: 2px;
-    border-radius: 2px
+    border-radius: 2px;
 }
 
 QSlider::handle:horizontal {

--- a/ilastik/shell/gui/ilastik-style-osx.qss
+++ b/ilastik/shell/gui/ilastik-style-osx.qss
@@ -1,0 +1,38 @@
+/*
+ * Adding style sheet for QSlider fixes an osx-specific issue: updating the
+ * handle programmatically via slider.setValue is not reflected in the UI once
+ * the slider has been moved manually.
+ * This behavior is gone after setting the style sheet.
+ * link to Qt issue: https://bugreports.qt.io/browse/QTBUG-96522
+ * ilastik issue: https://github.com/ilastik/ilastik/issues/2623
+ */
+
+QSlider::add-page:horizontal {
+    background: #e0e0e0;
+    border: 1px solid #dadada;
+    border-radius: 2px
+}
+
+QSlider{
+    margin: 2px 2px;
+}
+
+QSlider::sub-page:horizontal {
+    background: #0a82ff;
+    border: 1px solid #097ef8;
+    border-radius: 2px
+}
+
+QSlider::groove:horizontal {
+    border: 1px solid #000000;
+    height: 2px;
+    border-radius: 2px
+}
+
+QSlider::handle:horizontal {
+    background: #ffffff;
+    border-radius: 9px;
+    border: 1px solid #b7b7b7;
+    margin: -9px 0;
+    width: 18px;
+}

--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -74,8 +74,7 @@ def _applyStyleSheet(app):
     """
     Apply application-wide style-sheet rules.
     """
-    styleSheetPath = Path(__file__).parent / "ilastik-style.qss"
-    styleSheetText = styleSheetPath.read_text()
+    styleSheetText = (Path(__file__).parent / "ilastik-style.qss").read_text()
 
     # Adding style sheet for QSlider fixes an osx-specific issue: updating the
     # handle programmatically via slider.setValue is not reflected in the UI once
@@ -84,17 +83,13 @@ def _applyStyleSheet(app):
     # link to Qt issue: https://bugreports.qt.io/browse/QTBUG-96522
     # ilastik issue: https://github.com/ilastik/ilastik/issues/2623
     if platform.system() == "Darwin":
-        stylesheetPathOSX = Path(__file__).parent / "ilastik-style-osx.qss"
-        styleSheetText += stylesheetPathOSX.read_text()
+        styleSheetText += (Path(__file__).parent / "ilastik-style-osx.qss").read_text()
 
     app.setStyleSheet(styleSheetText)
 
 
 def getSplashScreen():
-    splash_path = Path(ilastik.__file__).parent / "ilastik-splash.png"
-    splashImage = QPixmap(str(splash_path))
-    splashScreen = QSplashScreen(splashImage)
-    return splashScreen
+    return QSplashScreen(QPixmap(str(Path(ilastik.__file__).parent / "ilastik-splash.png")))
 
 
 def launchShell(workflow_cmdline_args, preinit_funcs, postinit_funcs):

--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -20,9 +20,9 @@ from __future__ import absolute_import
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-import os
 import functools
 import platform
+from pathlib import Path
 
 # make the program quit on Ctrl+C
 import signal
@@ -74,15 +74,25 @@ def _applyStyleSheet(app):
     """
     Apply application-wide style-sheet rules.
     """
-    styleSheetPath = os.path.join(os.path.split(__file__)[0], "ilastik-style.qss")
-    with open(styleSheetPath, "r") as f:
-        styleSheetText = f.read()
-        app.setStyleSheet(styleSheetText)
+    styleSheetPath = Path(__file__).parent / "ilastik-style.qss"
+    styleSheetText = styleSheetPath.read_text()
+
+    # Adding style sheet for QSlider fixes an osx-specific issue: updating the
+    # handle programmatically via slider.setValue is not reflected in the UI once
+    # the slider has been moved manually.
+    # This behavior is gone after setting the style sheet.
+    # link to Qt issue: https://bugreports.qt.io/browse/QTBUG-96522
+    # ilastik issue: https://github.com/ilastik/ilastik/issues/2623
+    if platform.system() == "Darwin":
+        stylesheetPathOSX = Path(__file__).parent / "ilastik-style-osx.qss"
+        styleSheetText += stylesheetPathOSX.read_text()
+
+    app.setStyleSheet(styleSheetText)
 
 
 def getSplashScreen():
-    splash_path = os.path.join(os.path.dirname(ilastik.__file__), "ilastik-splash.png")
-    splashImage = QPixmap(splash_path)
+    splash_path = Path(ilastik.__file__).parent / "ilastik-splash.png"
+    splashImage = QPixmap(str(splash_path))
     splashScreen = QSplashScreen(splashImage)
     return splashScreen
 


### PR DESCRIPTION
`QSlider` on OSX is broken: updating the handle programmatically via `slider.setValue` is not reflected in the UI once the slider has been moved manually before.

Adding a stylesheet "resolves" this issue. I tried to make it as similar to the default stylesheet as possible (see screenshots below).

Side note: Also switched to using `pathlib` in favor of `os` in `startShellGui.py`.

ref: https://bugreports.qt.io/browse/QTBUG-96522

slider before: 
![image](https://user-images.githubusercontent.com/24434157/206113134-cc9c62de-b001-4df5-a57b-a624ce1ce41f.png)


slider with this PR: 
![image](https://user-images.githubusercontent.com/24434157/206113192-6fb423bc-dd13-46a7-ba15-c273dcb2a37c.png)


fixes #2623

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->