### PR TITLE
fixes a segfault if model initialization fails

### DIFF
--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -362,6 +362,7 @@ class ModelStateControl(QWidget):
 
         return checks
 
+    @threadRouted
     def _showErrorMessage(self, exc):
         logger.error("".join(traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__)))
         QMessageBox.critical(


### PR DESCRIPTION
showing the errormessage from within the Qthread leads to segfaults - of course. Make sure to call the method from the gui thread.
