### PR TITLE
parallel dt watershed in multicut using elf

### DIFF
--- a/ilastik/applets/wsdt/wsdtApplet.py
+++ b/ilastik/applets/wsdt/wsdtApplet.py
@@ -50,6 +50,7 @@ class WsdtApplet(StandardApplet):
             "Alpha",
             "PixelPitch",
             "ApplyNonmaxSuppression",
+            "BlockwiseWatershed",
         ]
 
     @property

--- a/ilastik/applets/wsdt/wsdtSerializer.py
+++ b/ilastik/applets/wsdt/wsdtSerializer.py
@@ -18,10 +18,50 @@
 # on the ilastik web site at:
 #           http://ilastik.org/license.html
 ###############################################################################
-from ilastik.applets.base.appletSerializer import AppletSerializer, SerialSlot, SerialBlockSlot, SerialListSlot
+from ilastik.applets.base.appletSerializer import (
+    AppletSerializer,
+    SerialSlot,
+    SerialBlockSlot,
+    SerialListSlot,
+)
+
+
+class SerialDefaultSlot(SerialSlot):
+    """SerialSlot implementation that actually uses the default value
+
+    not recommended to use outside this serializer with default parameter
+    being deprecated on the SerialSlot.
+
+    Also _very_ limited implementation -> will only work with level0 slots
+    """
+
+    def __init__(self, slot, inslot=None, name=None, subname=None, default=None, depends=None, selfdepends=True):
+        assert default is not None, "must supply a default value"
+        super().__init__(slot, inslot, name, subname, default, depends, selfdepends)
+
+    def deserialize(self, group):
+        """Performs tasks common to all deserializations.
+
+        actually need to override this method to make use of the default value
+
+        :param group: The parent group in which to create this slot's
+            group.
+        :type group: h5py.Group
+
+        """
+        if self.name not in group:
+            if self.inslot.level == 0:
+                self.inslot.setValue(self.default)
+            else:
+                raise NotImplementedError("No deserialization for slots with level > 0 implemented.")
+        else:
+            super().deserialize(group)
+            self.dirty = False
 
 
 class WsdtSerializer(AppletSerializer):
+    version = "0.2"
+
     def __init__(self, operator, projectFileGroupName):
         slots = [
             SerialListSlot(operator.ChannelSelections),
@@ -30,6 +70,7 @@ class WsdtSerializer(AppletSerializer):
             SerialSlot(operator.Sigma),
             SerialSlot(operator.Alpha),
             SerialSlot(operator.PixelPitch),
+            SerialDefaultSlot(operator.BlockwiseWatershed, default=False),
             SerialBlockSlot(
                 operator.Superpixels,
                 operator.SuperpixelCacheInput,
@@ -41,4 +82,4 @@ class WsdtSerializer(AppletSerializer):
                 compression_level=1,
             ),
         ]
-        super(WsdtSerializer, self).__init__(projectFileGroupName, slots=slots, operator=operator)
+        super().__init__(projectFileGroupName, slots=slots, operator=operator)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,6 +328,13 @@ def empty_project_file(tmp_path) -> h5py.File:
 
 
 @pytest.fixture
+def empty_in_memory_project_file():
+    with h5py.File("test_project1.ilp", mode="a", driver="core", backing_store=False) as test_project:
+        test_project.create_dataset("ilastikVersion", data=b"1.0.0")
+        yield test_project
+
+
+@pytest.fixture
 def graph():
     return Graph()
 

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_Consistency.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_Consistency.py
@@ -30,7 +30,7 @@ from lazyflow.graph import Graph
 from lazyflow.operators.opArrayPiper import OpArrayPiper
 from lazyflow.utility import Pipeline
 
-from ilastik.applets.wsdt.opWsdt import OpCachedWsdt
+from ilastik.applets.wsdt.opWsdt import OpCachedWsdt, parallel_watershed
 
 from elf.segmentation.watershed import distance_transform_watershed
 
@@ -65,7 +65,7 @@ def get_result_function(input_data):
     the core function.
     """
 
-    ws, max_id = distance_transform_watershed(
+    ws, max_id = parallel_watershed(
         input_data[..., 0],
         WS_PARAMS["threshold"],
         WS_PARAMS["sigma"],

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_parallel_watershed.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_parallel_watershed.py
@@ -1,0 +1,51 @@
+import numpy
+import pytest
+
+from elf.parallel.common import get_blocking
+from lazyflow.roi import roiToSlice
+
+from ilastik.applets.wsdt.opWsdt import parallel_watershed
+
+
+@pytest.fixture
+def data():
+    data = numpy.zeros((64, 64, 64), dtype=numpy.float32)
+    # fmt: off
+    data[ 0,  0, 0] = 0.7
+    data[ 0, -1, 0] = 0.7
+    data[-1,  0, 0] = 0.7
+    data[-1, -1, 0] = 0.7
+    # fmt: on
+    return data
+
+
+def test_parallel_watershed_consistency(data):
+    block_shape = (32, 32, 32)
+    halo = [10, 10, 10]
+
+    ws, max_label = parallel_watershed(
+        data=data,
+        threshold=0.5,
+        sigma_seeds=0.7,
+        sigma_weights=0.7,
+        minsize=1,
+        alpha=0.9,
+        pixel_pitch=None,
+        non_max_suppression=False,
+        block_shape=block_shape,
+        halo=halo,
+        max_workers=None,
+    )
+
+    assert max_label == 8
+    assert ws.min() == 1
+
+    blocking = get_blocking(data, block_shape, roi=None)
+    running_max = 1
+    for block_index in range(blocking.numberOfBlocks):
+        block = blocking.getBlockWithHalo(blockIndex=block_index, halo=halo)
+        inner_slicing = roiToSlice(block.innerBlock.begin, block.innerBlock.end)
+
+        block_data = ws[inner_slicing]
+        assert block_data.min() == running_max
+        running_max = block_data.max() + 1

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_wsdtSerializer.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_wsdtSerializer.py
@@ -1,0 +1,32 @@
+import h5py
+import pytest
+
+from ilastik.applets.wsdt.opWsdt import OpCachedWsdt
+from ilastik.applets.wsdt.wsdtSerializer import WsdtSerializer
+
+
+@pytest.mark.parametrize(
+    "serializer_version,serialized_value,expected_blockwise_value",
+    [("0.1", None, False), ("0.2", True, True), ("0.2", False, False)],
+)
+def test_01_02_compat(
+    graph, empty_in_memory_project_file, serializer_version, serialized_value, expected_blockwise_value
+):
+    """Test reading of legacy multicut projects
+
+    with projects saved with WsdtSerializer(0.1), the BlockwiseWatershed
+    was not present and not serialized. Here we want it to default to False,
+    whereas in the 0.2 case, we want this slot to be correctly deserialized.
+    """
+    serializer_group = "wsdt"
+
+    g = empty_in_memory_project_file.create_group(serializer_group)
+    if serialized_value is not None:
+        g.create_dataset("BlockwiseWatershed", data=serialized_value)
+    g.create_dataset("StorageVersion", data=serializer_version)
+
+    op = OpCachedWsdt(graph=graph)
+    serializer = WsdtSerializer(op, serializer_group)
+    serializer.deserializeFromHdf5(empty_in_memory_project_file, empty_in_memory_project_file.name)
+
+    assert op.BlockwiseWatershed.value == expected_blockwise_value

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -236,7 +236,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             # activate the carving applet
             shell.setSelectedAppletDrawer(2)
             # let the gui catch up
-            QApplication.processEvents()
+            waitProcessEvents(timeout=0.1)
             self.waitForViews(gui.editor.imageViews)
 
             gui.train_edge_clf_box.setChecked(False)
@@ -313,15 +313,16 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             opMulticut.FeatureNames.setValue(features)
 
             labeldict = {
-                (1, 7): 1,
-                (1, 15): 1,
-                (1, 11): 2,
-                (12, 18): 1,
+                (3, 15): 1,
+                (9, 17): 1,
+                (3, 11): 2,
+                (9, 11): 2,
+                (11, 17): 2,
+                (1, 4): 2,
+                (4, 16): 1,
+                (16, 17): 1,
                 (10, 11): 1,
-                (6, 9): 1,
-                (9, 16): 1,
-                (10, 17): 2,
-                (6, 8): 2,
+                (7, 10): 2,
             }
 
             opMulticut.EdgeLabelsDict.setValue(labeldict)


### PR DESCRIPTION
**Summary**:

This PR enables parallel waterershed in multicut following the pattern outlined in [carvingtools.py](https://github.com/ilastik/ilastik/blob/4f673a68ff5b49b52c6b911d67ceec6234260810/ilastik/workflows/carving/carvingTools.py#L108)

Note, that in future, we want to [use the same watershed methods in Carving and Multicut](https://github.com/ilastik/ilastik/issues/2081), but this will not be addressed in this PR.

Quirks to find here:
* in order to make this backwards compatible I added an additional slot - `BlockwiseWatershed` to the op. In order to not do it blockwise for legacy projects, I didn't see another way then reviving the deprecated default value for serialSlots. For now I put it into a separate class. The deprecation [needs a separate investigation](). If someone has a better idea how to solve this without losing annotations due to dirtyness (say, post-deserialization) I'd be happy to adapt the code.
* needed to adapt the gui multicut test, as the parallel watershed used here will relabel the volume (after removing halo) and hence introduce different superpixel indices.
* needed to adapt `test_Consistency.py`, which is a bit of a weird test on its own - not sure it achieves something of value.

Todo:

- [x] add compatibility mode for legacy projects - should not use parallel watershed (classifier is not trained on such data and probably hasn't seen stuff like block boundaries
- [x] add test for compatibility mode 
