### PR TITLE
add "i" shortcut some preprocessing applets

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -104,7 +104,7 @@ outputs:
       run:
         - python 3.7.*
         - ilastik-core {{ setup_py_data.version }}
-        - volumina >=1.3.3
+        - volumina >=1.3.8
         - pytorch >=1.6
         - tensorflow 1.14.*
         - tiktorch 22.12.0*
@@ -153,7 +153,7 @@ outputs:
       run:
         - python 3.7.*
         - ilastik-core {{ setup_py_data.version }}
-        - volumina >=1.3.3
+        - volumina >=1.3.8
         - pytorch >=1.6
         - tensorflow 1.14.*
         - tiktorch 22.12.0*

--- a/ilastik/applets/blockwiseObjectClassification/blockwiseObjectClassificationGui.py
+++ b/ilastik/applets/blockwiseObjectClassification/blockwiseObjectClassificationGui.py
@@ -31,6 +31,7 @@ from PyQt5.QtGui import QColor
 from ilastik.utility.gui import threadRouted
 from volumina.api import createDataSource, ColortableLayer
 from volumina import colortables
+from volumina.utility import ShortcutManager
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
 logger = logging.getLogger(__name__)
@@ -110,6 +111,18 @@ class BlockwiseObjectClassificationGui(LayerViewerGui):
             rawLayer = self.createStandardLayerFromSlot(rawSlot)
             rawLayer.name = "Raw data"
             layers.append(rawLayer)
+
+            rawLayer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Prediction Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    partial(self.layerstack.toggleTopToBottom, rawLayer),
+                    self.viewerControlWidget(),
+                    rawLayer,
+                ),
+            )
 
         return layers
 

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -979,21 +979,13 @@ class LabelingGui(LayerViewerGui):
             else:
                 self.labelingDrawerUi.thresToolButton.hide()
 
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(layer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
             layer.shortcutRegistration = (
                 "i",
                 ShortcutManager.ActionInfo(
                     "Prediction Layers",
                     "Bring Input To Top/Bottom",
                     "Bring Input To Top/Bottom",
-                    toggleTopToBottom,
+                    partial(self.layerstack.toggleTopToBottom, layer),
                     self.viewerControlWidget(),
                     layer,
                 ),

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -462,7 +462,9 @@ class NNClassGui(LabelingGui):
             localDir = os.path.split(__file__)[0]
             labelingDrawerUiPath = os.path.join(localDir, "nnClass.ui")
 
-        super(NNClassGui, self).__init__(parentApplet, labelSlots, topLevelOperatorView, labelingDrawerUiPath)
+        super(NNClassGui, self).__init__(
+            parentApplet, labelSlots, topLevelOperatorView, labelingDrawerUiPath, topLevelOperatorView.InputImages
+        )
 
         self._initCheckpointActions()
 
@@ -606,7 +608,7 @@ class NNClassGui(LabelingGui):
         Triggers the prediction by setting the layer on visible
         """
 
-        layers = super(NNClassGui, self).setupLayers()
+        layers = super().setupLayers()
 
         labels = self.labelListData
 
@@ -627,36 +629,6 @@ class NNClassGui(LabelingGui):
             overlayLayer.opacity = 1.0
 
             layers.append(overlayLayer)
-
-        # Add the raw data last (on the bottom)
-        inputDataSlot = self.topLevelOperatorView.InputImages
-        if inputDataSlot.ready():
-            inputLayer = self.createStandardLayerFromSlot(inputDataSlot)
-            inputLayer.name = "Input Data"
-            inputLayer.visible = True
-            inputLayer.opacity = 1.0
-            # the flag window_leveling is used to determine if the contrast
-            # of the layer is adjustable
-            if isinstance(inputLayer, GrayscaleLayer):
-                inputLayer.window_leveling = True
-            else:
-                inputLayer.window_leveling = False
-
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(inputLayer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
-            layers.append(inputLayer)
-
-            # The thresholding button can only be used if the data is displayed as grayscale.
-            if inputLayer.window_leveling:
-                self.labelingDrawerUi.thresToolButton.show()
-            else:
-                self.labelingDrawerUi.thresToolButton.hide()
 
         self.handleLabelSelectionChange()
 

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -44,6 +44,7 @@ from ilastik.utility import log_exception
 from ilastik.config import cfg as ilastik_config
 
 from volumina.api import createDataSource, GrayscaleLayer, ColortableLayer
+from volumina.utility import ShortcutManager
 import volumina.colortables as colortables
 from ilastik.applets.objectExtraction.opObjectExtraction import default_features_key
 
@@ -470,6 +471,19 @@ class ObjectExtractionGui(LayerViewerGui):
         self.rawsrc.setObjectName("Raw Lazyflow Src")
         layerraw = GrayscaleLayer(self.rawsrc)
         layerraw.name = "Raw data"
+
+        layerraw.shortcutRegistration = (
+            "i",
+            ShortcutManager.ActionInfo(
+                "Prediction Layers",
+                "Bring Input To Top/Bottom",
+                "Bring Input To Top/Bottom",
+                partial(self.layerstack.toggleTopToBottom, layerraw),
+                self.viewerControlWidget(),
+                layerraw,
+            ),
+        )
+
         layers.insert(len(layers), layerraw)
 
         mainOperator.RawImage.notifyReady(self._onReady)

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -432,21 +432,13 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
             rawLayer.opacity = 1.0
             layers.append(rawLayer)
 
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(rawLayer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
             rawLayer.shortcutRegistration = (
                 "i",
                 ShortcutManager.ActionInfo(
                     "Thresholding Layers",
                     "Bring Input To Top/Bottom",
                     "Bring Input To Top/Bottom",
-                    toggleTopToBottom,
+                    partial(self.layerstack.toggleTopToBottom, rawLayer),
                     self.viewerControlWidget(),
                     rawLayer,
                 ),

--- a/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
+++ b/ilastik/applets/thresholdTwoLevels/thresholdTwoLevelsGui.py
@@ -38,6 +38,7 @@ from PyQt5.QtWidgets import QMessageBox
 from volumina.api import createDataSource, AlphaModulatedLayer, ColortableLayer
 from volumina import colortables
 from volumina.colortables import create_default_16bit
+from volumina.utility import ShortcutManager
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 from ilastik.utility import bind
 from ilastik.utility.gui import threadRouted
@@ -430,5 +431,25 @@ class ThresholdTwoLevelsGui(LayerViewerGui):
             rawLayer.visible = True
             rawLayer.opacity = 1.0
             layers.append(rawLayer)
+
+            def toggleTopToBottom():
+                index = self.layerstack.layerIndex(rawLayer)
+                self.layerstack.selectRow(index)
+                if index == 0:
+                    self.layerstack.moveSelectedToBottom()
+                else:
+                    self.layerstack.moveSelectedToTop()
+
+            rawLayer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Thresholding Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    toggleTopToBottom,
+                    self.viewerControlWidget(),
+                    rawLayer,
+                ),
+            )
 
         return layers

--- a/ilastik/applets/tracking/base/trackingBaseGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseGui.py
@@ -38,6 +38,7 @@ import h5py
 from ilastik.applets.labeling.labelingGui import LabelingGui
 from ilastik.applets.tracking.base.trackingUtilities import relabel, write_events
 from volumina.layer import GrayscaleLayer
+from volumina.utility import ShortcutManager
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
 from ilastik.config import cfg as ilastik_config
@@ -157,6 +158,18 @@ class TrackingBaseGui(LayerViewerGui):
         if self.mainOperator.RawImage.ready():
             rawLayer = self.createStandardLayerFromSlot(self.mainOperator.RawImage)
             rawLayer.name = "Raw"
+            rawLayer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Prediction Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    partial(self.layerstack.toggleTopToBottom, rawLayer),
+                    self.viewerControlWidget(),
+                    rawLayer,
+                ),
+            )
+
             layers.insert(len(layers), rawLayer)
 
         if self.topLevelOperatorView.LabelImage.meta.shape:

--- a/ilastik/applets/tracking/manual/manualTrackingGui.py
+++ b/ilastik/applets/tracking/manual/manualTrackingGui.py
@@ -20,6 +20,7 @@
 ###############################################################################
 from __future__ import division
 from builtins import range
+from functools import partial
 from PyQt5 import uic, QtWidgets, QtCore
 from PyQt5.QtGui import QColor, QTextCursor
 
@@ -278,6 +279,18 @@ class ManualTrackingGui(LayerViewerGui, ExportingGui):
             self.rawsrc = createDataSource(self.mainOperator.RawImage)
             rawLayer = GrayscaleLayer(self.rawsrc)
             rawLayer.name = "Raw"
+            rawLayer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Prediction Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    partial(self.layerstack.toggleTopToBottom, rawLayer),
+                    self.viewerControlWidget(),
+                    rawLayer,
+                ),
+            )
+
             layers.insert(len(layers), rawLayer)
 
         self.topLevelOperatorView.RawImage.notifyReady(self._onReady)

--- a/ilastik/applets/wsdt/wsdtGui.py
+++ b/ilastik/applets/wsdt/wsdtGui.py
@@ -362,21 +362,13 @@ class WsdtGui(LayerViewerGui):
             layer.opacity = 1.0
             layers.append(layer)
 
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(layer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
             layer.shortcutRegistration = (
                 "i",
                 ShortcutManager.ActionInfo(
                     "Watershed Layers",
                     "Bring Input To Top/Bottom",
                     "Bring Input To Top/Bottom",
-                    toggleTopToBottom,
+                    partial(self.layerstack.toggleTopToBottom, layer),
                     self.viewerControlWidget(),
                     layer,
                 ),

--- a/ilastik/applets/wsdt/wsdtGui.py
+++ b/ilastik/applets/wsdt/wsdtGui.py
@@ -47,6 +47,7 @@ from PyQt5.QtWidgets import (
 from ilastik.utility.gui import threadRouted
 from volumina.api import createDataSource, ArraySource
 from volumina.layer import GrayscaleLayer, ColortableLayer, generateRandomColors
+from volumina.utility import ShortcutManager
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
 from lazyflow.request import Request
@@ -360,6 +361,25 @@ class WsdtGui(LayerViewerGui):
             layer.visible = True
             layer.opacity = 1.0
             layers.append(layer)
-            del layer
+
+            def toggleTopToBottom():
+                index = self.layerstack.layerIndex(layer)
+                self.layerstack.selectRow(index)
+                if index == 0:
+                    self.layerstack.moveSelectedToBottom()
+                else:
+                    self.layerstack.moveSelectedToTop()
+
+            layer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Watershed Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    toggleTopToBottom,
+                    self.viewerControlWidget(),
+                    layer,
+                ),
+            )
 
         return layers

--- a/ilastik/workflows/carving/preprocessingViewerGui.py
+++ b/ilastik/workflows/carving/preprocessingViewerGui.py
@@ -25,6 +25,7 @@ from PyQt5.QtGui import QColor
 
 from volumina.api import createDataSource
 from volumina.layer import ColortableLayer
+from volumina.utility import ShortcutManager
 
 # ilastik
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
@@ -54,16 +55,6 @@ class PreprocessingViewerGui(LayerViewerGui):
 
             layers.append(watershedLayer)
 
-        """ FIXME: disabled for 0.6 release
-        wsSourceSlot = opLane.WatershedSourceImage
-        if wsSourceSlot.ready():
-            wsSourceLayer = self.createStandardLayerFromSlot( wsSourceSlot )
-            wsSourceLayer.name = "Watershed Source"
-            wsSourceLayer.visible = False
-            wsSourceLayer.opacity = 1.0
-            layers.append( wsSourceLayer )
-        """
-
         filteredSlot = opLane.FilteredImage
         if filteredSlot.ready():
             filteredLayer = self.createStandardLayerFromSlot(filteredSlot)
@@ -87,5 +78,25 @@ class PreprocessingViewerGui(LayerViewerGui):
             inputLayer.visible = True
             inputLayer.opacity = 1.0
             layers.append(inputLayer)
+
+            def toggleTopToBottom():
+                index = self.layerstack.layerIndex(inputLayer)
+                self.layerstack.selectRow(index)
+                if index == 0:
+                    self.layerstack.moveSelectedToBottom()
+                else:
+                    self.layerstack.moveSelectedToTop()
+
+            inputLayer.shortcutRegistration = (
+                "i",
+                ShortcutManager.ActionInfo(
+                    "Preprocessing Layers",
+                    "Bring Input To Top/Bottom",
+                    "Bring Input To Top/Bottom",
+                    toggleTopToBottom,
+                    self.viewerControlWidget(),
+                    inputLayer,
+                ),
+            )
 
         return layers

--- a/ilastik/workflows/carving/preprocessingViewerGui.py
+++ b/ilastik/workflows/carving/preprocessingViewerGui.py
@@ -18,7 +18,7 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
+from functools import partial
 import numpy
 
 from PyQt5.QtGui import QColor
@@ -79,21 +79,13 @@ class PreprocessingViewerGui(LayerViewerGui):
             inputLayer.opacity = 1.0
             layers.append(inputLayer)
 
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(inputLayer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
             inputLayer.shortcutRegistration = (
                 "i",
                 ShortcutManager.ActionInfo(
                     "Preprocessing Layers",
                     "Bring Input To Top/Bottom",
                     "Bring Input To Top/Bottom",
-                    toggleTopToBottom,
+                    partial(self.layerstack.toggleTopToBottom, inputLayer),
                     self.viewerControlWidget(),
                     inputLayer,
                 ),

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationGui.py
@@ -446,21 +446,13 @@ class VoxelSegmentationGui(LabelingGui):
             else:
                 inputLayer.window_leveling = False
 
-            def toggleTopToBottom():
-                index = self.layerstack.layerIndex(inputLayer)
-                self.layerstack.selectRow(index)
-                if index == 0:
-                    self.layerstack.moveSelectedToBottom()
-                else:
-                    self.layerstack.moveSelectedToTop()
-
             inputLayer.shortcutRegistration = (
                 "i",
                 ActionInfo(
                     "Prediction Layers",
                     "Bring Input To Top/Bottom",
                     "Bring Input To Top/Bottom",
-                    toggleTopToBottom,
+                    partial(self.layerstack.toggleTopToBottom, inputLayer),
                     self.viewerControlWidget(),
                     inputLayer,
                 ),


### PR DESCRIPTION
homogenizes user experience by making the "i" shortcut available in
* thresholding (object classification)
* preprocessing (carving)
* watershed (multicut)
* Tracking
* Manual Tracking
* Blockwise Object Classification
* Object Extraction

needs `volumina>=1.3.8`

fixes #2628


Missing is only Carving, where the existence of the Overlay layer makes it impossible to use with the `toggleTopToBottom` method.