### PR TITLE
avoid showing multiple overlapping edge layers

### DIFF
--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -81,7 +81,8 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         # -> Show segmentation edges layer only when no RF is trained as it will
         # have the perfectly overlapping edgelabels layer.
         segmentation_edges_layer = self.getLayerByName("Superpixel Edges")
-        segmentation_edges_layer.visible = not checked
+        if segmentation_edges_layer:
+            segmentation_edges_layer.visible = not checked
 
     def stopAndCleanUp(self):
         # Unsubscribe to all signals

--- a/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
+++ b/ilastik/applets/edgeTrainingWithMulticut/edgeTrainingWithMulticutGui.py
@@ -76,6 +76,12 @@ class EdgeTrainingWithMulticutGui(MulticutGuiMixin, EdgeTrainingMixin, LayerView
         if not checked:
             op.FreezeClassifier.setValue(True)
         self.updateAllLayers()
+        # optimize rendering - showing multiple perfectly overlaying superpixel
+        # edge layers, noticeably slows down rendering.
+        # -> Show segmentation edges layer only when no RF is trained as it will
+        # have the perfectly overlapping edgelabels layer.
+        segmentation_edges_layer = self.getLayerByName("Superpixel Edges")
+        segmentation_edges_layer.visible = not checked
 
     def stopAndCleanUp(self):
         # Unsubscribe to all signals


### PR DESCRIPTION
This is a bit of a tiny optimization, but it feels like it is doubling the fps you get in multicut.

Painting overlapping paths is probably quite costly (I guess to check what parts need to be painted, basically the whole path has to be compared).

There is no visible difference doing that, just faster rendering.