### PR TITLE
mnt: update darker version in ci

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -14,11 +14,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      - uses: akaihola/darker@1.5.1
+      - uses: akaihola/darker@1.6.0
         with:
           options: "--check --diff --revision=origin/main..."
           src: "."
-          # due to incompatibility of black with the current release of the
-          # darker github action, we need to use a non-release version
-          # ref: https://github.com/ilastik/ilastik/issues/2640
-          version: "@3c675b009d747cadd6e8048d2c57a5b1cd54fb3e"
+          version: "1.6.0"


### PR DESCRIPTION
darker release 1.6.0 is available that fixes incompatibility with newer black versions.

fixes #2640
