### PR TITLE
reorganize startup screen

### DIFF
--- a/ilastik/widgets/collapsibleWidget.py
+++ b/ilastik/widgets/collapsibleWidget.py
@@ -31,6 +31,7 @@ class CollapsibleWidget(QWidget):
         widget: QWidget,
         header: str = "Details",
         animation_duration: int = 100,
+        expanded=False,
         parent=None,
     ):
         """
@@ -40,7 +41,8 @@ class CollapsibleWidget(QWidget):
             should be configured fully when passing it (to ensure correct sizing).
             No resizing is taken into account.
           header: Text displayed next to the arrow toolbutton
-          start_collapsed: Control initial state. Set to False to have widget expanded
+          animation_duration: duration of collapse/expand animation in ms
+          expanded: Control initial state. Set to False to have widget expanded
             visible upon construction.
         """
 
@@ -52,7 +54,7 @@ class CollapsibleWidget(QWidget):
         toggleButton.setArrowType(Qt.ArrowType.RightArrow)
         toggleButton.setText(header)
         toggleButton.setCheckable(True)
-        toggleButton.setChecked(False)
+        toggleButton.setChecked(expanded)
 
         # for testing:
         self._toggleButton = toggleButton
@@ -93,11 +95,15 @@ class CollapsibleWidget(QWidget):
 
         for i in range(animation.animationCount() - 1):
             anim = animation.animationAt(i)
-            anim.setDuration(animation_duration)
             anim.setStartValue(collapsedHeight)
             anim.setEndValue(collapsedHeight + contentHeight)
 
         anim = animation.animationAt(animation.animationCount() - 1)
-        anim.setDuration(animation_duration)
         anim.setStartValue(0)
         anim.setEndValue(contentHeight)
+
+        updateState(expanded)
+
+        # set animation duration after widget is in correct state
+        for i in range(animation.animationCount()):
+            animation.animationAt(i).setDuration(animation_duration)

--- a/tests/test_ilastik/widgets/test_collapsibleWidget.py
+++ b/tests/test_ilastik/widgets/test_collapsibleWidget.py
@@ -23,12 +23,12 @@ def test_state_change(qtbot, widget):
 
         # expand
         qtbot.mouseClick(w._toggleButton, Qt.MouseButton.LeftButton)
-        qtbot.wait(50)  # wait for change to settle, since we're querying gui state
+        qtbot.wait(150)  # wait for change to settle, since we're querying gui state
 
         assert not widget.visibleRegion().isEmpty()
 
         # collapse again
         qtbot.mouseClick(w._toggleButton, Qt.MouseButton.LeftButton)
-        qtbot.wait(50)  # wait for change to settle, since we're querying gui state
+        qtbot.wait(150)  # wait for change to settle, since we're querying gui state
 
         assert widget.visibleRegion().isEmpty()


### PR DESCRIPTION
A controversial one (must be) to end the year :)

the startup screen became quite crowded. On normal machines, users sometimes don't even see that they can load their previous projects and such.

* Grouping of workflows according to task.
* order explicitly not via the order of imports in workflows.__init__.py
* Tracking, and Other workflows collapsed per default

Preview on OSX:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/24434157/209171635-a61aca2f-3b64-4cd2-8069-df13ec312961.png">
