### PR TITLE
fixes filter offset for 2d filters on 3D presmoothed data along z-axis

### DIFF
--- a/lazyflow/operators/filterOperators.py
+++ b/lazyflow/operators/filterOperators.py
@@ -194,7 +194,7 @@ class OpBaseFilter(Operator):
                 if process_in_2d:
                     # eliminate singleton z dimension
                     assert isinstance(target_z_slice, int)
-                    source = source[:, target_z_slice]  # in 2d z is shared between source and target (like time)
+                    source = source[:, full_input_slice[2]]  # in 2d z is shared between source and target (like time)
 
             source = numpy.require(source, dtype=self.input_dtype)
             source = source.view(vigra.VigraArray)

--- a/tests/test_lazyflow/test_operators/test_opBaseFilter.py
+++ b/tests/test_lazyflow/test_operators/test_opBaseFilter.py
@@ -1,0 +1,78 @@
+import numpy
+import pytest
+import vigra
+
+from lazyflow.operators.filterOperators import OpBaseFilter
+from lazyflow.roi import sliceToRoi
+from lazyflow.graph import InputSlot
+from lazyflow.rtype import SubRegion
+
+
+@pytest.fixture
+def dummy_filter_op(graph):
+    """OpBaseFilter that passes through input"""
+
+    def _filter_func(source, **filter_kwargs):
+        return source
+
+    class OpPassthroughFilter(OpBaseFilter):
+        _scale = InputSlot(value=0.5)
+        minimum_scale = 0.3
+
+        supports_window = True
+
+        name = "OpPassthroughFilter"
+        filter_fn = staticmethod(_filter_func)
+
+        def resultingChannels(self):
+            return 1
+
+    op = OpPassthroughFilter(graph=graph)
+    return op
+
+
+@pytest.mark.parametrize(
+    "slice1,computeIn2d",
+    [
+        (numpy.s_[0:1, 0:1, 0:1, 0:20, 0:30], True),
+        (numpy.s_[0:1, 0:1, 1:2, 0:20, 0:30], True),  # previous failure case
+        (numpy.s_[0:1, 0:1, 2:3, 0:20, 0:30], True),  # previous failure case
+        (numpy.s_[0:1, 0:1, 3:4, 0:20, 0:30], True),  # previous failure case
+        (numpy.s_[0:1, 0:1, 0:10, 0:1, 0:30], True),
+        (numpy.s_[0:1, 0:1, 0:10, 1:2, 0:30], True),
+        (numpy.s_[0:1, 0:1, 0:10, 2:3, 0:30], True),
+        (numpy.s_[0:1, 0:1, 0:10, 3:4, 0:30], True),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 0:1], True),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 1:2], True),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 2:3], True),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 3:4], True),
+        (numpy.s_[0:1, 0:1, 0:1, 0:20, 0:30], False),
+        (numpy.s_[0:1, 0:1, 1:2, 0:20, 0:30], False),
+        (numpy.s_[0:1, 0:1, 2:3, 0:20, 0:30], False),
+        (numpy.s_[0:1, 0:1, 0:10, 0:1, 0:30], False),
+        (numpy.s_[0:1, 0:1, 0:10, 1:2, 0:30], False),
+        (numpy.s_[0:1, 0:1, 0:10, 2:3, 0:30], False),
+        (numpy.s_[0:1, 0:1, 0:10, 3:4, 0:30], False),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 0:1], False),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 1:2], False),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 2:3], False),
+        (numpy.s_[0:1, 0:1, 0:10, 0:20, 3:4], False),
+    ],
+)
+def test_single_slice_requests_first_slices(dummy_filter_op, slice1, computeIn2d):
+    data_ref = numpy.arange(10 * 20 * 30).astype(numpy.float32).reshape((1, 1, 10, 20, 30))
+    data = vigra.taggedView(data_ref.copy(), "tczyx")
+    dummy_filter_op.Input.setValue(data)
+    dummy_filter_op.ComputeIn2d.setValue(computeIn2d)
+    req_roi = SubRegion(dummy_filter_op.Output, *sliceToRoi(slice1, data_ref.shape))
+    target0 = numpy.zeros([x.stop - x.start for x in slice1], dtype=numpy.float32)
+
+    dummy_filter_op.call_execute(
+        slot=dummy_filter_op.Output,
+        subindex=(),
+        roi=req_roi,
+        result=target0,
+        sourceArray=data,
+    )
+
+    numpy.testing.assert_array_almost_equal(data_ref[slice1], target0)


### PR DESCRIPTION
for the special case of mixtures of 2D filters on 3D presmoothed data, `OpBaseFilter` will get a 3D source array. From this array one has to access the correct z-slice. This fixes a bug for single z-slice requests which previously returned the bottom-most slice of the source array. Now the correct slice is returned.

thanks @FredHamprecht for discovering the issue!