### PR TITLE
propagate dirtyness to layers

### DIFF
--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -262,6 +262,10 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
         def _invalidate_cache_on_sp_change(*args, **kwargs):
             op = opEdgeTrainingWithMulticut
             opEdgeTrainingWithMulticut.clear_caches(op.current_view_index())
+            # allow for dirty propagation to the volumina layers
+            if op.FreezeCache.value:
+                op.FreezeCache.setValue(False)
+                op.FreezeCache.setValue(True)
 
         opSuperpixelsSelect.Output.notifyDirty(_invalidate_cache_on_sp_change)
 


### PR DESCRIPTION
Enables immediate dirty propagation once super pixel change via a `FreezeCache` cycle  for the edge-training/multicut caches.
Fixes display of outdated multicut solution after superpixels have changed.