### PR TITLE
delay bioimageio imports

### DIFF
--- a/ilastik/applets/neuralNetwork/bioimageiodl.py
+++ b/ilastik/applets/neuralNetwork/bioimageiodl.py
@@ -2,10 +2,6 @@ import pathlib
 from io import BytesIO
 from zipfile import ZIP_DEFLATED
 
-from bioimageio.core import load_raw_resource_description
-from bioimageio.core.resource_io.io_ import make_zip
-from bioimageio.spec import get_resource_package_content
-from bioimageio.spec.shared import resolve_source, raw_nodes, DownloadCancelled
 from PyQt5.QtCore import QThread, pyqtSignal
 from tqdm.auto import tqdm as std_tqdm
 
@@ -25,6 +21,10 @@ class TqdmExt(std_tqdm):
 
     def update(self, n=1):
         if self._cancellation_token and self._cancellation_token.cancelled:
+            # Note: bioimageio imports are delayed as to prevent https request to
+            # github and bioimage.io on ilastik startup
+            from bioimageio.spec.shared import DownloadCancelled
+
             raise DownloadCancelled()
 
         displayed = super().update(n)
@@ -49,6 +49,13 @@ class BioImageDownloader(QThread):
 
     def run(self):
         try:
+            # Note: bioimageio imports are delayed as to prevent https request to
+            # github and bioimage.io on ilastik startup
+            from bioimageio.core import load_raw_resource_description
+            from bioimageio.core.resource_io.io_ import make_zip
+            from bioimageio.spec import get_resource_package_content
+            from bioimageio.spec.shared import resolve_source, raw_nodes, DownloadCancelled
+
             logger.debug(f"Downloading model from {self._model_uri}")
             raw_rd = load_raw_resource_description(self._model_uri)
             package_content = get_resource_package_content(raw_rd, weights_priority_order=BIOIMAGEIO_WEIGHTS_PRIORITY)

--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -6,7 +6,6 @@ from functools import partial
 from textwrap import dedent
 from typing import Callable, List
 
-from bioimageio.core import load_raw_resource_description
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
@@ -273,6 +272,10 @@ class ModelStateControl(QWidget):
             self._showErrorMessage(e)
 
     def onModelInfoRequested(self):
+        # Note: bioimageio imports are delayed as to prevent https request to
+        # github and bioimage.io on ilastik startup
+        from bioimageio.core import load_raw_resource_description
+
         model_uri = self.modelSourceEdit.getModelSource().strip()
         if not model_uri:
             # try select file from file chooser

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -26,7 +26,6 @@ from functools import partial
 
 import numpy
 import yaml
-from bioimageio.spec.shared.raw_nodes import ParametrizedInputShape
 from PyQt5 import uic
 from PyQt5.QtCore import (
     QModelIndex,
@@ -742,6 +741,9 @@ class NNClassGui(LabelingGui):
 
     def _check_input_spec_compatible(self, model_info):
         """Check if spec is compatible with project data"""
+        # Note: bioimageio imports are delayed as to prevent https request to
+        # github and bioimage.io on ilastik startup
+        from bioimageio.spec.shared.raw_nodes import ParametrizedInputShape
 
         def _minimum_tagged_shape(input_spec):
             axes = input_spec.axes

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -803,6 +803,8 @@ class NNClassGui(LabelingGui):
             self.maxLabelNumber = num_classes
             self.updateAllLayers()
 
+        self.parentApplet.appletStateUpdateRequested()
+
     def _load_checkpoint(self, model_state: ModelState):
         self.topLevelOperatorView.set_model_state(model_state)
 

--- a/ilastik/applets/neuralNetwork/nnClassSerializer.py
+++ b/ilastik/applets/neuralNetwork/nnClassSerializer.py
@@ -23,6 +23,9 @@ import logging
 
 import numpy as np
 
+# Note: bioimageio imports are delayed as to prevent https request to
+# github and bioimage.io on ilastik startup
+
 from ilastik.applets.base.appletSerializer import (
     AppletSerializer,
     JSONSerialSlot,
@@ -33,8 +36,6 @@ from ilastik.applets.base.appletSerializer import (
 )
 
 from .tiktorchController import BIOModelData, ModelInfo
-from bioimageio.spec import serialize_raw_resource_description_to_dict, load_raw_resource_description
-
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,8 @@ class BioimageIOModelSlot(SerialSlot):
 
     @staticmethod
     def _getValue(subgroup, slot):
+        from bioimageio.spec import load_raw_resource_description
+
         try:
             model = BIOModelData(
                 modelUri=subgroup.attrs["modelUri"],

--- a/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
+++ b/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
@@ -166,14 +166,11 @@ class _NNWorkflowBase(Workflow):
         input_ready = len(opDataSelection.ImageGroup) > 0 and not self.dataSelectionApplet.busy
 
         opNNClassification = self.nnClassificationApplet.topLevelOperator
+        nn_ready = input_ready and opNNClassification.ModelSession.ready()
 
         opDataExport = self.dataExportApplet.topLevelOperator
 
-        predictions_ready = input_ready and len(opDataExport.Inputs) > 0
-
-        # Problems can occur if the features or input data are changed during live update mode.
-        # Don't let the user do that.
-        live_update_active = not opNNClassification.FreezePredictions.value
+        predictions_ready = nn_ready and len(opDataExport.Inputs) > 0
 
         # The user isn't allowed to touch anything while batch processing is running.
         batch_processing_busy = self.batchProcessingApplet.busy
@@ -185,7 +182,7 @@ class _NNWorkflowBase(Workflow):
         )
         self._shell.setAppletEnabled(
             self.dataExportApplet,
-            predictions_ready and not batch_processing_busy and not live_update_active and upstream_ready,
+            predictions_ready and not batch_processing_busy and upstream_ready,
         )
 
         if self.batchProcessingApplet is not None:


### PR DESCRIPTION
bioimageio.spec will try to fetch some data from github and bioimageio. This is necessary for its operation, but shouldn't be done on _every_ startup of ilastik.
This delays those imports until NN-related workflows are actually used.

[1c50af6eb7e664bf024a0c3e50f828d5d3325f09](https://github.com/ilastik/ilastik/pull/2655/commits/1c50af6eb7e664bf024a0c3e50f828d5d3325f09) is unrelated - it's a tiny change to applet readiness that I didn't want to bother anyone reviewing independently. Now Export and Batch processing are consistently enabled once a valid model is in the project.