### PR TITLE
#2627 carving loses labels after repeat preprocessing

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -68,7 +68,6 @@ class CarvingGui(LabelingGui):
         # members
         self._doneSegmentationLayer = None
         self._showSegmentationIn3D = False
-        # self._showUncertaintyLayer = False
         # end: members
 
         labelingSlots = LabelingGui.LabelingSlots()
@@ -136,46 +135,6 @@ class CarvingGui(LabelingGui):
 
         self.topLevelOperatorView.Segmentation.notifyDirty(bind(self._segmentation_dirty))
         self.topLevelOperatorView.HasSegmentation.notifyValueChanged(bind(self._updateGui))
-
-        ## uncertainty
-
-        # self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(False)
-        # self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(False)
-
-        # def onUncertaintyFGButton():
-        #    logger.debug( "uncertFG button clicked" )
-        #    pos = self.topLevelOperatorView.getMaxUncertaintyPos(label=2)
-        #    self.editor.posModel.slicingPos = (pos[0], pos[1], pos[2])
-        # self.labelingDrawerUi.pushButtonUncertaintyFG.clicked.connect(onUncertaintyFGButton)
-
-        # def onUncertaintyBGButton():
-        #    logger.debug( "uncertBG button clicked" )
-        #    pos = self.topLevelOperatorView.getMaxUncertaintyPos(label=1)
-        #    self.editor.posModel.slicingPos = (pos[0], pos[1], pos[2])
-        # self.labelingDrawerUi.pushButtonUncertaintyBG.clicked.connect(onUncertaintyBGButton)
-
-        # def onUncertaintyCombo(value):
-        #    if value == 0:
-        #        value = "none"
-        #        self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(False)
-        #        self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(False)
-        #        self._showUncertaintyLayer = False
-        #    else:
-        #        if value == 1:
-        #            value = "localMargin"
-        #        elif value == 2:
-        #            value = "exchangeCount"
-        #        elif value == 3:
-        #            value = "gabow"
-        #        else:
-        #            raise RuntimeError("unhandled case '%r'" % value)
-        #        self.labelingDrawerUi.pushButtonUncertaintyFG.setEnabled(True)
-        #        self.labelingDrawerUi.pushButtonUncertaintyBG.setEnabled(True)
-        #        self._showUncertaintyLayer = True
-        #        logger.debug( "uncertainty changed to %r" % value )
-        #    self.topLevelOperatorView.UncertaintyType.setValue(value)
-        #    self.updateAllLayers() #make sure that an added/deleted uncertainty layer is recognized
-        # self.labelingDrawerUi.uncertaintyCombo.currentIndexChanged.connect(onUncertaintyCombo)
 
         self.labelingDrawerUi.objPrefix.setText(self.objectPrefix)
         self.labelingDrawerUi.objPrefix.textChanged.connect(self.setObjectPrefix)

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -277,11 +277,10 @@ class CarvingGui(LabelingGui):
 
     def onSaveButton(self):
         logger.info("save object as?")
-        prevName = self.topLevelOperatorView.currentObjectName()
         if self.topLevelOperatorView.dataIsStorable():
             prevName = ""
             if self.topLevelOperatorView.hasCurrentObject():
-                prevName = self.topLevelOperatorView.currentObjectName()
+                prevName = self.topLevelOperatorView.getCurrentObjectName()
             if prevName == "<not saved yet>":
                 prevName = ""
             name = self.saveAsDialog(name=prevName)

--- a/ilastik/workflows/carving/carvingWorkflow.py
+++ b/ilastik/workflows/carving/carvingWorkflow.py
@@ -114,8 +114,6 @@ class CarvingWorkflow(Workflow):
             pmapOverlayFile=pmapoverlayFile,
         )
 
-        # self.carvingApplet.topLevelOperator.MST.connect(self.preprocessingApplet.topLevelOperator.PreprocessedData)
-
         # Expose to shell
         self._applets = []
         self._applets.append(self.dataSelectionApplet)

--- a/ilastik/workflows/carving/carvingWorkflow.py
+++ b/ilastik/workflows/carving/carvingWorkflow.py
@@ -126,8 +126,6 @@ class CarvingWorkflow(Workflow):
         opPreprocessing = self.preprocessingApplet.topLevelOperator.getLane(laneIndex)
         opCarvingLane = self.carvingApplet.topLevelOperator.getLane(laneIndex)
 
-        opCarvingLane.connectToPreprocessingApplet(self.preprocessingApplet)
-
         op5Raw = OpReorderAxes(parent=self)
         op5Raw.AxisOrder.setValue("txyzc")
         op5Raw.Input.connect(opData.ImageGroup[DATA_ROLE_RAW_DATA])

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -676,6 +676,14 @@ class OpCarving(Operator):
         elif slot == self.MST:
             self._opMstCache.Input.disconnect()
             self._mst = self.MST.value
+
+            if self.has_seeds:
+                fgVoxels, bgVoxels = self.get_label_voxels()
+                fgArraySeedPos = numpy.array(fgVoxels)
+                bgArraySeedPos = numpy.array(bgVoxels)
+                self._mst.setSeeds(
+                    fgArraySeedPos, bgArraySeedPos
+                )  # TODO gh2627: the voxels are not in the correct format here (ValueError: vertex or face count are zero: terminating marching cubes; on line 62, in volumina/meshgenerator.py#labeling_to_mesh)
             self._opMstCache.Input.setValue(self._mst)
         elif (
             slot == self.OverlayData

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -670,15 +670,11 @@ class OpCarving(Operator):
         elif slot == self.MST:
             self._opMstCache.Input.disconnect()
             self._mst = self.MST.value
+            self._opMstCache.Input.setValue(self._mst)
 
             if self.has_seeds:
                 fgVoxels, bgVoxels = self.get_label_voxels()
-                fgArraySeedPos = numpy.array(fgVoxels)
-                bgArraySeedPos = numpy.array(bgVoxels)
-                self._mst.setSeeds(
-                    fgArraySeedPos, bgArraySeedPos
-                )  # TODO gh2627: the voxels are not in the correct format here (ValueError: vertex or face count are zero: terminating marching cubes; on line 62, in volumina/meshgenerator.py#labeling_to_mesh)
-            self._opMstCache.Input.setValue(self._mst)
+                self.set_labels_into_WriteSeeds_input(fgVoxels, bgVoxels)
         elif (
             slot == self.OverlayData
             or slot == self.InputData

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -257,9 +257,6 @@ class OpCarving(Operator):
 
         self.AllObjectNames.meta.dtype = object
 
-    def connectToPreprocessingApplet(self, applet):
-        self.PreprocessingApplet = applet
-
     def hasCurrentObject(self):
         """
         Returns current object name. None if it is not set.

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -621,13 +621,12 @@ class OpCarving(Operator):
                 logger.info("Writing seeds to label array took {} seconds".format(timer.seconds()))
 
             assert self._mst is not None
-            assert hasattr(key, "__len__")
 
             # Important: mst.seeds will requires erased values to be 255 (a.k.a -1)
             with Timer() as timer:
                 logger.info("Writing seeds to MST")
                 self._mst.addSeeds(roi=roi, brushStroke=value.squeeze())
-                logger.info("Writing seeds to MST took {} seconds".format(timer.seconds()))
+                logger.info(f"Writing seeds to MST took {timer.seconds()} seconds")
 
             self.has_seeds = True
         else:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -79,7 +79,6 @@ class OpCarving(Operator):
     # below the number, no background bias will be applied to the edge weights
     NoBiasBelow = InputSlot(value=64)
 
-    # uncertainty type
     UncertaintyType = InputSlot()
 
     # O u t p u t s #
@@ -99,13 +98,10 @@ class OpCarving(Operator):
 
     AllObjectNames = OutputSlot(rtype=List, stype=Opaque)
 
-    # current object has an actual segmentation
     HasSegmentation = OutputSlot(stype="bool")
 
-    # Hint Overlay
     HintOverlay = OutputSlot()
 
-    # Pmap Overlay
     PmapOverlay = OutputSlot()
 
     MstOut = OutputSlot()
@@ -116,7 +112,6 @@ class OpCarving(Operator):
     def __init__(self, graph=None, hintOverlayFile=None, pmapOverlayFile=None, parent=None):
         super(OpCarving, self).__init__(graph=graph, parent=parent)
         self.opLabelArray = OpDenseLabelArray(parent=self)
-        # self.opLabelArray.EraserLabelValue.setValue( 100 )
         self.opLabelArray.MetaInput.connect(self.InputData)
 
         self._hintOverlayFile = hintOverlayFile
@@ -265,15 +260,6 @@ class OpCarving(Operator):
     def connectToPreprocessingApplet(self, applet):
         self.PreprocessingApplet = applet
 
-    #     def updatePreprocessing(self):
-    #         if self.PreprocessingApplet is None or self._mst is None:
-    #             return
-    # FIXME: why were the following lines needed ?
-    # if len(self._mst.object_names)==0:
-    #     self.PreprocessingApplet.enableWriteprotect(True)
-    # else:
-    #     self.PreprocessingApplet.enableWriteprotect(False)
-
     def hasCurrentObject(self):
         """
         Returns current object name. None if it is not set.
@@ -328,11 +314,6 @@ class OpCarving(Operator):
         """
         self._clearLabels()
         self._mst.gridSegmentor.clearSeeds()
-        # lut_segmentation = self._mst.segmentation.lut[:]
-        # lut_segmentation[:] = 0
-        # lut_seeds = self._mst.seeds.lut[:]
-        # lut_seeds[:] = 0
-        # self.HasSegmentation.setValue(False)
 
         self.Trigger.setDirty(slice(None))
 
@@ -350,12 +331,6 @@ class OpCarving(Operator):
         assert name in self._mst.bg_priority
         assert name in self._mst.no_bias_below
 
-        # lut_segmentation = self._mst.segmentation.lut[:]
-        # lut_objects = self._mst.objects.lut[:]
-        # lut_seeds = self._mst.seeds.lut[:]
-        ## clean seeds
-        # lut_seeds[:] = 0
-
         # set foreground and background seeds
         fgVoxelsSeedPos = self._mst.object_seeds_fg_voxels[name]
         bgVoxelsSeedPos = self._mst.object_seeds_bg_voxels[name]
@@ -368,10 +343,6 @@ class OpCarving(Operator):
         fgNodes = self._mst.object_lut[name]
 
         self._mst.setResulFgObj(fgNodes[0])
-
-        # newSegmentation = numpy.ones(len(lut_objects), dtype=numpy.int32)
-        # newSegmentation[ self._mst.object_lut[name] ] = 2
-        # lut_segmentation[:] = newSegmentation
 
         self._setCurrObjectName(name)
         self.HasSegmentation.setValue(True)
@@ -441,7 +412,6 @@ class OpCarving(Operator):
         self.BackgroundPriority.setValue(mst.bg_priority[name])
         self.NoBiasBelow.setValue(mst.no_bias_below[name])
 
-        # self.updatePreprocessing()
         # The entire segmentation layer needs to be refreshed now.
         self.Segmentation.setDirty()
 
@@ -452,9 +422,6 @@ class OpCarving(Operator):
         """
         Deletes an object called name.
         """
-        # lut_seeds = self._mst.seeds.lut[:]
-        # clean seeds
-        # lut_seeds[:] = 0
 
         del self._mst.object_lut[name]
         del self._mst.object_seeds_fg_voxels[name]
@@ -471,7 +438,6 @@ class OpCarving(Operator):
 
         # now that 'name' has been deleted, rebuild the done overlay
         self._buildDone()
-        # self.updatePreprocessing()
 
     def deleteObject(self, name):
         logger.info("want to delete object with name = %s" % name)
@@ -480,7 +446,6 @@ class OpCarving(Operator):
             return False
 
         self.deleteObject_impl(name)
-        # clear the user labels
         self._clearLabels()
         # trigger a re-computation
         self.Trigger.setDirty(slice(None))
@@ -540,14 +505,7 @@ class OpCarving(Operator):
         self.AllObjectNames.meta.shape = (len(objects),)
 
         # now that 'name' is no longer part of the set of finished objects, rebuild the done overlay
-
         self._buildDone()
-        # self._clearLabels()
-        # self._mst.clearSegmentation()
-        # self.clearCurrentLabeling()
-        # self._mst.gridSegmentor.clearSeeds()
-        # self.Trigger.setDirty(slice(None))
-        # self.updatePreprocessing()
 
     def get_label_voxels(self):
         # the voxel coordinates of fg and bg labels
@@ -580,9 +538,7 @@ class OpCarving(Operator):
         return (coors2, coors1)
 
     def saveObjectAs(self, name):
-        # first, save the object under "name"
         self.saveCurrentObjectAs(name)
-        # Sparse label array automatically shifts label values down 1
 
         sVseed = self._mst.getSuperVoxelSeeds()
         # fgVoxels = numpy.where(sVseed==2)
@@ -718,7 +674,6 @@ class OpCarving(Operator):
             self.Segmentation.setDirty(slice(None))
             self.DoneSegmentation.setDirty(slice(None))
             hasSeg = numpy.any(self._mst.hasSeg)
-            # hasSeg = numpy.any(self._mst.segmentation.lut > 0 )
             self.HasSegmentation.setValue(hasSeg)
 
         elif slot == self.MST:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -540,10 +540,6 @@ class OpCarving(Operator):
     def saveObjectAs(self, name):
         self.saveCurrentObjectAs(name)
 
-        sVseed = self._mst.getSuperVoxelSeeds()
-        # fgVoxels = numpy.where(sVseed==2)
-        # bgVoxels = numpy.where(sVseed==1)
-
         fgVoxels, bgVoxels = self.get_label_voxels()
 
         self.attachVoxelLabelsToObject(name, fgVoxels=fgVoxels, bgVoxels=bgVoxels)
@@ -625,18 +621,13 @@ class OpCarving(Operator):
                 logger.info("Writing seeds to label array took {} seconds".format(timer.seconds()))
 
             assert self._mst is not None
+            assert hasattr(key, "__len__")
 
             # Important: mst.seeds will requires erased values to be 255 (a.k.a -1)
-            # value[:] = numpy.where(value == 100, 255, value)
-            seedVal = value.max()
             with Timer() as timer:
                 logger.info("Writing seeds to MST")
-                if hasattr(key, "__len__"):
-                    self._mst.addSeeds(roi=roi, brushStroke=value.squeeze())
-                else:
-                    raise RuntimeError("when is this part of the code called")
-                    self._mst.seeds[key] = value
-            logger.info("Writing seeds to MST took {} seconds".format(timer.seconds()))
+                self._mst.addSeeds(roi=roi, brushStroke=value.squeeze())
+                logger.info("Writing seeds to MST took {} seconds".format(timer.seconds()))
 
             self.has_seeds = True
         else:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -518,13 +518,13 @@ class OpCarving(Operator):
         fg = [[], [], []]
         for sl in nonzeroSlicings:
             label = self.opLabelArray.Output[sl].wait()
-            labels_fg = numpy.where(label == 1)
-            labels_bg = numpy.where(label == 2)
-            labels_fg = [labels_fg[i] + sl[i].start for i in range(1, 4)]
+            labels_bg = numpy.where(label == 1)
+            labels_fg = numpy.where(label == 2)
             labels_bg = [labels_bg[i] + sl[i].start for i in range(1, 4)]
+            labels_fg = [labels_fg[i] + sl[i].start for i in range(1, 4)]
             for i in range(3):
-                bg[i].append(labels_fg[i])
-                fg[i].append(labels_bg[i])
+                bg[i].append(labels_bg[i])
+                fg[i].append(labels_fg[i])
 
         for i in range(3):
             if len(bg[i]) > 0:

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -401,7 +401,7 @@ class OpPreprocessing(Operator):
 
     def execute(self, slot, subindex, roi, result):
         assert slot == self.PreprocessedData, "Invalid output slot"
-        if self._prepData[0] is not None and not self._dirty:
+        if not self._dirty and self._prepData[0] is not None:
             return self._prepData
 
         mst = self._opMstProvider.MST.value

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -469,6 +469,7 @@ class OpPreprocessing(Operator):
         self.enableDownstream(False)
         if self._prepData[0] is not None:
             self.enableReset(True)
+        self.PreprocessedData.setDirty(slice(None))
 
     def enableReset(self, er):
         """set enabled of resetButton to er"""

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import warnings
+
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -434,6 +436,10 @@ class OpPreprocessing(Operator):
     def AreSettingsInitial(self):
         """analyse settings for sigma and filter
         return True if they are equal to those of last preprocess"""
+        warnings.warn(
+            "OpPreprocessing.AreSettingsInitial() is deprecated and will soon be removed. Please contact the ilastik dev team if you need it.",
+            DeprecationWarning,
+        )
         if self.initialFilter is None:
             return False
         if self.Filter.value != self.initialFilter:

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -349,8 +349,6 @@ class OpPreprocessing(Operator):
 
         self._opWatershedSourceCache = OpBlockedArrayCache(parent=self)
 
-        # self.PreprocessedData.connect( self._opMstProvider.MST )
-
         # Display slots
         self.FilteredImage.connect(self._opFilterCache.Output)
         self.WatershedImage.connect(self._opWatershedCache.Output)
@@ -418,9 +416,8 @@ class OpPreprocessing(Operator):
         self._dirty = False
         self.enableDownstream(True)
 
-        # copy over seeds, and saved objects
+        # copy over saved objects
         if self._prepData[0] is not None:
-            # mst.seeds[:] = self._prepData[0].seeds[:]
             mst.object_lut = self._prepData[0].object_lut
             mst.object_names = self._prepData[0].object_names
             mst.object_seeds_bg_voxels = self._prepData[0].object_seeds_bg_voxels
@@ -430,13 +427,6 @@ class OpPreprocessing(Operator):
 
         # Cache result
         self._prepData = result
-
-        # Wonder why this is set?
-        # The preprocess is only called by the run button.
-        # By setting the output dirty, this event is propagated to the
-        # carving-Operator, who copies the result just calculated.
-        # This is to gain control over when the preprocess is executed.
-        # self.PreprocessedData.setDirty()
 
         result[0] = mst
         return result

--- a/ilastik/workflows/carving/watershed_segmentor.py
+++ b/ilastik/workflows/carving/watershed_segmentor.py
@@ -1,6 +1,5 @@
 import ilastiktools
 import h5py
-import numpy
 
 
 class WatershedSegmentor(object):

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -24,7 +24,6 @@ import functools
 import logging
 import threading
 import sys
-import inspect
 
 from abc import ABCMeta
 from contextlib import contextmanager


### PR DESCRIPTION
This fixes https://github.com/ilastik/ilastik/issues/2627

For the moment it implements a workaround: When the user changes the preprocessing, the carving operator reapplies existing labels as if they were new user input.

There would be a "proper" way to do this that does not require the carving operator to write to its own input. The MST provides a ["setSeeds" function](https://github.com/ilastik/ilastiktools/blob/main/include/ilastiktools/carving.hxx#L478), but this is currently buggy (you give it foreground and background labels, but it writes all of them into the MST as background seeds). I have left it at the workaround fix until we fix this bug in ilastiktools.

- [x] Format code and imports.
- [x] Rebase commits into a logical sequence.
