### PR TITLE
Gh2657 carving does not save all preprocessing settings to project

### DIFF
--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 
-import warnings
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -26,7 +24,6 @@ import warnings
 # Python
 from builtins import range
 from past.utils import old_div
-import sys
 
 # SciPy
 import numpy
@@ -315,17 +312,17 @@ class OpPreprocessing(Operator):
 
     def __init__(self, *args, **kwargs):
         super(OpPreprocessing, self).__init__(*args, **kwargs)
-        self._prepData = [None]
+        self.cachedResult = [None]
         self.applet = self.parent.parent.preprocessingApplet
 
-        self._unsavedData = False  # set to True if data is not yet saved
-        self._dirty = False  # set to True if any Input is dirty
+        self.hasUnsavedData = False  # read by preprocessingSerializer
+        self._dirty = False  # to avoid generating new MST unless user has changed settings
 
-        self.initialSigma = None  # save settings of last preprocess
-        self.initialFilter = None  # applied to gui by pressing reset
-        self.initialDoAgglo = None
-        self.initialSizeRegularizer = None
-        self.initialReduceTo = None
+        self.cachedSigma = None  # keep settings of last preprocess execute
+        self.cachedFilter = None  # for saving in project file
+        self.cachedDoAgglo = None
+        self.cachedSizeRegularizer = None
+        self.cachedReduceTo = None
 
         self._opFilter = OpFilter(parent=self)
         self._opFilter.Input.connect(self.InputData)
@@ -401,33 +398,31 @@ class OpPreprocessing(Operator):
 
     def execute(self, slot, subindex, roi, result):
         assert slot == self.PreprocessedData, "Invalid output slot"
-        if not self._dirty and self._prepData[0] is not None:
-            return self._prepData
+        if not self._dirty and self.cachedResult[0] is not None:
+            return self.cachedResult
 
         mst = self._opMstProvider.MST.value
 
-        # save settings for reloading them if asked by user
-        self.initialSigma = self.Sigma.value
-        self.initialFilter = self.Filter.value
-        self.initialDoAgglo = self.DoAgglo.value
-        self.initialSizeRegularizer = self.SizeRegularizer.value
-        self.initialReduceTo = self.ReduceTo.value
+        self.cachedSigma = self.Sigma.value
+        self.cachedFilter = self.Filter.value
+        self.cachedDoAgglo = self.DoAgglo.value
+        self.cachedSizeRegularizer = self.SizeRegularizer.value
+        self.cachedReduceTo = self.ReduceTo.value
 
-        self._unsavedData = True
+        self.hasUnsavedData = True
         self._dirty = False
         self.enableDownstream(True)
 
         # copy over saved objects
-        if self._prepData[0] is not None:
-            mst.object_lut = self._prepData[0].object_lut
-            mst.object_names = self._prepData[0].object_names
-            mst.object_seeds_bg_voxels = self._prepData[0].object_seeds_bg_voxels
-            mst.object_seeds_fg_voxels = self._prepData[0].object_seeds_fg_voxels
-            mst.bg_priority = self._prepData[0].bg_priority
-            mst.no_bias_below = self._prepData[0].no_bias_below
+        if self.cachedResult[0] is not None:
+            mst.object_lut = self.cachedResult[0].object_lut
+            mst.object_names = self.cachedResult[0].object_names
+            mst.object_seeds_bg_voxels = self.cachedResult[0].object_seeds_bg_voxels
+            mst.object_seeds_fg_voxels = self.cachedResult[0].object_seeds_fg_voxels
+            mst.bg_priority = self.cachedResult[0].bg_priority
+            mst.no_bias_below = self.cachedResult[0].no_bias_below
 
-        # Cache result
-        self._prepData = result
+        self.cachedResult = result
 
         result[0] = mst
         return result
@@ -436,12 +431,12 @@ class OpPreprocessing(Operator):
         if slot == self.InputData:
             # complete restart
             # No values will be reused any more
-            self.initialSigma = None
-            self.initialFilter = None
-            self.initialDoAgglo = None
-            self.initialSizeRegularizer = None
-            self.initialReduceTo = None
-            self._prepData = [None]
+            self.cachedSigma = None
+            self.cachedFilter = None
+            self.cachedDoAgglo = None
+            self.cachedSizeRegularizer = None
+            self.cachedReduceTo = None
+            self.cachedResult = [None]
 
         self._dirty = True
         self.enableDownstream(False)

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -413,7 +413,6 @@ class OpPreprocessing(Operator):
         self.initalReduceTo = self.ReduceTo.value
         self.initalSizeRegularizer = self.SizeRegularizer.value
 
-        self.enableReset(False)
         self._unsavedData = True
         self._dirty = False
         self.enableDownstream(True)
@@ -433,27 +432,6 @@ class OpPreprocessing(Operator):
         result[0] = mst
         return result
 
-    def AreSettingsInitial(self):
-        """analyse settings for sigma and filter
-        return True if they are equal to those of last preprocess"""
-        warnings.warn(
-            "OpPreprocessing.AreSettingsInitial() is deprecated and will soon be removed. Please contact the ilastik dev team if you need it.",
-            DeprecationWarning,
-        )
-        if self.initialFilter is None:
-            return False
-        if self.Filter.value != self.initialFilter:
-            return False
-        if self.DoAgglo.value != self.initialDoAgglo:
-            return False
-        if abs(self.Sigma.value - self.initialSigma) > 0.005:
-            return False
-        if abs(self.ReduceTo.value - self.initialReduceTo) > 0.005:
-            return False
-        if abs(self.SizeRegularizer.value - self.initalSizeRegularizer) > 0.005:
-            return False
-        return True
-
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.InputData:
             # complete restart
@@ -467,19 +445,8 @@ class OpPreprocessing(Operator):
 
         self._dirty = True
         self.enableDownstream(False)
-        if self._prepData[0] is not None:
-            self.enableReset(True)
         self.PreprocessedData.setDirty(slice(None))
-
-    def enableReset(self, er):
-        """set enabled of resetButton to er"""
-        self.applet.enableReset(er)
 
     def enableDownstream(self, ed):
         """set enable of carving applet to ed"""
         self.applet.enableDownstream(ed)
-
-    def reset(self):
-        """reset sigma and filter to values of last preprocess"""
-        self.applet._gui.setSigma(self.initialSigma)
-        self.applet._gui.setFilter(self.initialFilter)

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -409,9 +409,9 @@ class OpPreprocessing(Operator):
         # save settings for reloading them if asked by user
         self.initialSigma = self.Sigma.value
         self.initialFilter = self.Filter.value
-        self.initalDoAgglo = self.DoAgglo.value
-        self.initalReduceTo = self.ReduceTo.value
-        self.initalSizeRegularizer = self.SizeRegularizer.value
+        self.initialDoAgglo = self.DoAgglo.value
+        self.initialSizeRegularizer = self.SizeRegularizer.value
+        self.initialReduceTo = self.ReduceTo.value
 
         self._unsavedData = True
         self._dirty = False

--- a/ilastik/workflows/carving/preprocessingApplet.py
+++ b/ilastik/workflows/carving/preprocessingApplet.py
@@ -40,23 +40,11 @@ class PreprocessingApplet(StandardApplet):
         self.writeprotected = False
         self._enabledWriteprotect = True
         self._enabledDS = True
-        self._enabledReset = False
 
     def enableWriteprotect(self, value):
         if self._enabledWriteprotect != value:
             self._enabledWriteprotect = value
             self._gui.enableWriteprotect(value)
-
-    def enableReset(self, er):
-        if self._workflow._headless:
-            return
-        from .preprocessingGui import PreprocessingGui
-
-        if self._enabledReset != er:
-            self._enabledReset = er
-            # if GUI is not set up, _gui is an Adapter
-            if type(self._gui) == PreprocessingGui:
-                self._gui.enableReset(er)
 
     def enableDownstream(self, ed):
         if self._workflow._headless:
@@ -82,7 +70,6 @@ class PreprocessingApplet(StandardApplet):
             self._gui.setWriteprotect()
 
         self.enableDownstream(self._enabledDS)
-        self._gui.enableReset(self._enabledReset)
 
         return self._gui
 

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -83,9 +83,6 @@ class PreprocessingGui(QMainWindow):
 
         self.parentApplet.appletStateUpdateRequested.subscribe(self.processingFinished)
 
-        # FIXME: for release 0.6, disable this (the reset button made the gui even more complicated)
-        # self.drawer.resetButton.clicked.connect(self.topLevelOperatorView.reset)
-
         # Slot change handlers (in case the operator is somehow changed *outside* the gui, such as by the workflow.
         self.topLevelOperatorView.Filter.notifyDirty(self.updateFilterFromOperator)
         self.topLevelOperatorView.Sigma.notifyDirty(self.updateSigmaFromOperator)
@@ -164,11 +161,6 @@ class PreprocessingGui(QMainWindow):
 
     def setSigma(self, sigma):
         self.drawer.sigmaSpin.setValue(sigma)
-
-    def enableReset(self, er):
-        pass
-        # TODO: re-enable this after the 0.6 release
-        # self.drawer.resetButton.setEnabled(er)
 
     def centralWidget(self):
         return self.centralGui

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -47,10 +47,16 @@ class PreprocessingSerializer(AppletSerializer):
 
                 deleteIfPresent(preproc, "sigma")
                 deleteIfPresent(preproc, "filter")
+                deleteIfPresent(preproc, "do_agglomeration")
+                deleteIfPresent(preproc, "size_regularizer")
+                deleteIfPresent(preproc, "reduce_to")
                 deleteIfPresent(preproc, "graph")
 
                 preproc.create_dataset("sigma", data=opPre.initialSigma)
                 preproc.create_dataset("filter", data=opPre.initialFilter)
+                preproc.create_dataset("do_agglomeration", data=opPre.initialDoAgglo)
+                preproc.create_dataset("size_regularizer", data=opPre.initialSizeRegularizer)
+                preproc.create_dataset("reduce_to", data=opPre.initialReduceTo)
 
                 preprocgraph = getOrCreateGroup(preproc, "graph")
                 mst.saveH5G(preprocgraph)
@@ -64,6 +70,11 @@ class PreprocessingSerializer(AppletSerializer):
 
         sigma = topGroup["sigma"][()]
         sfilter = topGroup["filter"][()]
+
+        # Pre-1.4.0rc9 project files do not contain doAgglo, sizeRegularizer and reduceTo - use defaults
+        doAgglo = topGroup["do_agglomeration"][()] if "do_agglomeration" in list(topGroup.keys()) else 1
+        sizeRegularizer = topGroup["size_regularizer"][()] if "size_regularizer" in list(topGroup.keys()) else 0.5
+        reduceTo = topGroup["reduce_to"][()] if "reduce_to" in list(topGroup.keys()) else 0.2
 
         if "graph" in list(topGroup.keys()):
             graphgroup = topGroup["graph"]
@@ -80,9 +91,16 @@ class PreprocessingSerializer(AppletSerializer):
         for opPre in self._o.innerOperators:
 
             opPre.initialSigma = sigma
-            opPre.Sigma.setValue(sigma)
             opPre.initialFilter = sfilter
+            opPre.initialDoAgglo = doAgglo
+            opPre.initialSizeRegularizer = sizeRegularizer
+            opPre.initialReduceTo = reduceTo
+
+            opPre.Sigma.setValue(sigma)
             opPre.Filter.setValue(sfilter)
+            opPre.DoAgglo.setValue(doAgglo)
+            opPre.SizeRegularizer.setValue(sizeRegularizer)
+            opPre.ReduceTo.setValue(reduceTo)
 
             mst = WatershedSegmentor(h5file=graphgroup)
             opPre._prepData = numpy.array([mst])

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -37,13 +37,12 @@ class PreprocessingSerializer(AppletSerializer):
         preproc = topGroup
 
         for opPre in self._o.innerOperators:
-            mst = opPre._prepData[0]
+            mst = opPre.cachedResult[0]
 
             if mst is not None:
 
-                # The values to be saved for sigma and filter are the
-                # values of the last valid preprocess
-                #!These may differ from the current settings!
+                # These are the values of the last valid preprocess.
+                # They may differ from the current settings!
 
                 deleteIfPresent(preproc, "sigma")
                 deleteIfPresent(preproc, "filter")
@@ -52,16 +51,16 @@ class PreprocessingSerializer(AppletSerializer):
                 deleteIfPresent(preproc, "reduce_to")
                 deleteIfPresent(preproc, "graph")
 
-                preproc.create_dataset("sigma", data=opPre.initialSigma)
-                preproc.create_dataset("filter", data=opPre.initialFilter)
-                preproc.create_dataset("do_agglomeration", data=opPre.initialDoAgglo)
-                preproc.create_dataset("size_regularizer", data=opPre.initialSizeRegularizer)
-                preproc.create_dataset("reduce_to", data=opPre.initialReduceTo)
+                preproc.create_dataset("sigma", data=opPre.cachedSigma)
+                preproc.create_dataset("filter", data=opPre.cachedFilter)
+                preproc.create_dataset("do_agglomeration", data=opPre.cachedDoAgglo)
+                preproc.create_dataset("size_regularizer", data=opPre.cachedSizeRegularizer)
+                preproc.create_dataset("reduce_to", data=opPre.cachedReduceTo)
 
                 preprocgraph = getOrCreateGroup(preproc, "graph")
                 mst.saveH5G(preprocgraph)
 
-            opPre._unsavedData = False
+            opPre.hasUnsavedData = False
 
     def _deserializeFromHdf5(self, topGroup, groupVersion, hdf5File, projectFilePath, headless=False):
 
@@ -90,11 +89,11 @@ class PreprocessingSerializer(AppletSerializer):
 
         for opPre in self._o.innerOperators:
 
-            opPre.initialSigma = sigma
-            opPre.initialFilter = sfilter
-            opPre.initialDoAgglo = doAgglo
-            opPre.initialSizeRegularizer = sizeRegularizer
-            opPre.initialReduceTo = reduceTo
+            opPre.cachedSigma = sigma
+            opPre.cachedFilter = sfilter
+            opPre.cachedDoAgglo = doAgglo
+            opPre.cachedSizeRegularizer = sizeRegularizer
+            opPre.cachedReduceTo = reduceTo
 
             opPre.Sigma.setValue(sigma)
             opPre.Filter.setValue(sfilter)
@@ -103,7 +102,7 @@ class PreprocessingSerializer(AppletSerializer):
             opPre.ReduceTo.setValue(reduceTo)
 
             mst = WatershedSegmentor(h5file=graphgroup)
-            opPre._prepData = numpy.array([mst])
+            opPre.cachedResult = numpy.array([mst])
 
             opPre._dirty = False
             opPre.applet.writeprotected = True
@@ -113,7 +112,7 @@ class PreprocessingSerializer(AppletSerializer):
 
     def isDirty(self):
         for opPre in self._o.innerOperators:
-            if opPre._unsavedData:
+            if opPre.hasUnsavedData:
                 return True
         return False
 

--- a/ilastik/workflows/carving/preprocessingSerializer.py
+++ b/ilastik/workflows/carving/preprocessingSerializer.py
@@ -111,10 +111,7 @@ class PreprocessingSerializer(AppletSerializer):
             opPre.enableDownstream(True)
 
     def isDirty(self):
-        for opPre in self._o.innerOperators:
-            if opPre.hasUnsavedData:
-                return True
-        return False
+        return any(op.hasUnsavedData for op in self._o.innerOperators)
 
     # this is present only for the serializer AppletInterface
     def unload(self):


### PR DESCRIPTION
Added the missing Preprocessing settings to the serializer and changed the naming as the "reset" mechanism no longer exists (removed in 2013 - see 89e5559ae8534b4b231f4385347965984be99b4b).

This is branched from https://github.com/ilastik/ilastik/pull/2658 to save myself some merge conflicts, so we should merge that first if it hasn't happened yet. The commits to be reviewed in this PR are only the last three.

## Checklist

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
