### PR TITLE
Carving drop saved objects when changing preprocessing

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -45,7 +45,6 @@ from volumina.view3d.volumeRendering import RenderingManager
 # ilastik
 from ilastik.utility import bind
 from ilastik.applets.labeling.labelingGui import LabelingGui
-from ilastik.workflows.carving.opCarving import DEFAULT_OBJECT_NAME
 
 
 import logging
@@ -53,6 +52,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 CURRENT_SEGMENTATION_NAME = "__current_segmentation__"
+DEFAULT_OBJECT_NAME = "<not saved yet>"
 # ===----------------------------------------------------------------------------------------------------------------===
 
 
@@ -280,7 +280,7 @@ class CarvingGui(LabelingGui):
             logger.error("object not saved due to faulty data.")
             return
 
-        old_name = self.topLevelOperatorView.getCurrentObjectName()
+        old_name = self.topLevelOperatorView.CurrentObjectName.value
         saved_object_names = self.getObjectNames()
         was_object_previously_saved = old_name in saved_object_names
 
@@ -655,8 +655,9 @@ class CarvingGui(LabelingGui):
         def onButtonsEnabled(slot, roi):
             currObj = self.topLevelOperatorView.CurrentObjectName.value
             canSave = self.topLevelOperatorView.CanObjectBeSaved.value
+            label = currObj if currObj else DEFAULT_OBJECT_NAME
 
-            self.labelingDrawerUi.currentObjectLabel.setText(currObj)
+            self.labelingDrawerUi.currentObjectLabel.setText(label)
             self.labelingDrawerUi.save.setEnabled(canSave)
 
         self.topLevelOperatorView.CurrentObjectName.notifyDirty(onButtonsEnabled)

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -132,7 +132,7 @@ class CarvingGui(LabelingGui):
         self.labelingDrawerUi.segment.setEnabled(True)
 
         self.topLevelOperatorView.Segmentation.notifyDirty(bind(self._segmentation_dirty))
-        self.topLevelOperatorView.HasSegmentation.notifyValueChanged(bind(self._updateGui))
+        self.topLevelOperatorView.CanObjectBeSaved.notifyValueChanged(bind(self._updateGui))
 
         self.labelingDrawerUi.objPrefix.setText(self.objectPrefix)
         self.labelingDrawerUi.objPrefix.textChanged.connect(self.setObjectPrefix)
@@ -637,13 +637,13 @@ class CarvingGui(LabelingGui):
 
         def onButtonsEnabled(slot, roi):
             currObj = self.topLevelOperatorView.CurrentObjectName.value
-            hasSeg = self.topLevelOperatorView.HasSegmentation.value
+            canSave = self.topLevelOperatorView.CanObjectBeSaved.value
 
             self.labelingDrawerUi.currentObjectLabel.setText(currObj)
-            self.labelingDrawerUi.save.setEnabled(hasSeg)
+            self.labelingDrawerUi.save.setEnabled(canSave)
 
         self.topLevelOperatorView.CurrentObjectName.notifyDirty(onButtonsEnabled)
-        self.topLevelOperatorView.HasSegmentation.notifyDirty(onButtonsEnabled)
+        self.topLevelOperatorView.CanObjectBeSaved.notifyDirty(onButtonsEnabled)
         self.topLevelOperatorView.opLabelArray.NonzeroBlocks.notifyDirty(onButtonsEnabled)
 
         # Labels

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -316,8 +316,8 @@ class CarvingGui(LabelingGui):
             if len(selected) != 1:
                 return
             name = selected[0].text()
+            dialog.close()
             if self.confirmLoadObject():
-                dialog.close()
                 self.topLevelOperatorView.loadObject(name)
 
         def deleteSelection():

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -240,17 +240,14 @@ class CarvingGui(LabelingGui):
 
         return last + 1
 
-    def saveAsDialog(self, name=""):
-        """special functionality: reject names given to other objects"""
-        namesInUse = self.getObjectNames()
-
+    def saveAsDialog(self, name_input_default: str, existing_names: List[str]):
         def generateObjectName():
             return f"{self.objectPrefix}{self.findNextPrefixNumber()}"
 
-        name = name or generateObjectName()
+        name_input_default = name_input_default or generateObjectName()
 
         dialog = uic.loadUi(self.dialogdirSAD)
-        dialog.lineEdit.setText(name)
+        dialog.lineEdit.setText(name_input_default)
         dialog.lineEdit.selectAll()
         dialog.warning.setVisible(False)
         dialog.Ok.clicked.connect(dialog.accept)
@@ -259,7 +256,7 @@ class CarvingGui(LabelingGui):
 
         def validate():
             name = dialog.lineEdit.text()
-            if name in namesInUse:
+            if name in existing_names:
                 dialog.Ok.setEnabled(False)
                 dialog.warning.setVisible(True)
                 dialog.isDisabled = True
@@ -268,6 +265,7 @@ class CarvingGui(LabelingGui):
                 dialog.warning.setVisible(False)
                 dialog.isDisabled = False
 
+        validate()
         dialog.lineEdit.textChanged.connect(validate)
         result = dialog.exec_()
         if result:
@@ -284,7 +282,7 @@ class CarvingGui(LabelingGui):
         saved_object_names = self.getObjectNames()
         was_object_previously_saved = old_name in saved_object_names
 
-        new_name = self.saveAsDialog(name=(old_name if was_object_previously_saved else ""))
+        new_name = self.saveAsDialog(old_name, saved_object_names)
         if new_name is None:
             return
 

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -214,7 +214,7 @@ class CarvingGui(LabelingGui):
             self._toggleSegmentation3D()
 
     def _updateGui(self):
-        self.labelingDrawerUi.save.setEnabled(self.topLevelOperatorView.dataIsStorable())
+        self.labelingDrawerUi.save.setEnabled(self.topLevelOperatorView.CanObjectBeSaved.value)
 
     def onSegmentButton(self):
         logger.debug("segment button clicked")
@@ -275,7 +275,7 @@ class CarvingGui(LabelingGui):
 
     def onSaveButton(self):
         logger.info("save object as?")
-        if not self.topLevelOperatorView.dataIsStorable():
+        if not self.topLevelOperatorView.CanObjectBeSaved.value:
             msgBox = QMessageBox(self)
             msgBox.setText("The data does not seem fit to be stored.")
             msgBox.setWindowTitle("Problem with Data")
@@ -411,7 +411,7 @@ class CarvingGui(LabelingGui):
             showSeg3DAction.setChecked(self._showSegmentationIn3D)
             showSeg3DAction.triggered.connect(self._toggleSegmentation3D)
 
-        if op.dataIsStorable():
+        if op.CanObjectBeSaved.value:
             menu.addAction("Save object").triggered.connect(self.onSaveButton)
         menu.addAction("Browse objects").triggered.connect(self.onShowObjectNames)
         menu.addAction("Segment").triggered.connect(self.onSegmentButton)

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -276,11 +276,7 @@ class CarvingGui(LabelingGui):
     def onSaveButton(self):
         logger.info("save object as?")
         if not self.topLevelOperatorView.CanObjectBeSaved.value:
-            msgBox = QMessageBox(self)
-            msgBox.setText("The data does not seem fit to be stored.")
-            msgBox.setWindowTitle("Problem with Data")
-            msgBox.setIcon(2)
-            msgBox.exec_()
+            QMessageBox.warning(self, "Problem with Data", "The data does not seem fit to be stored.")
             logger.error("object not saved due to faulty data.")
             return
 
@@ -296,8 +292,8 @@ class CarvingGui(LabelingGui):
         if is_name_changed and new_name in saved_object_names:
             QMessageBox.critical(
                 self,
-                "Save Object As",
-                f"An object with name '{new_name}' already exists.\nPlease choose a different name.",
+                "Unable to Save Object",
+                f"<p>An object with name {new_name!r} already exists.</p><p>Please choose a different name.</p>",
             )
             return
 
@@ -371,7 +367,7 @@ class CarvingGui(LabelingGui):
                 if self.render and self._renderMgr.ready:
                     self._update_rendering()
 
-            delAction = submenu.addAction("Delete %s" % name)
+            delAction = submenu.addAction(f"Delete {name}")
             delAction.triggered.connect(partial(onDelAction, name))
 
             if self.render:

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -28,7 +28,6 @@ import numpy
 
 # PyQt
 from PyQt5 import uic
-from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QMenu, QMessageBox, QFileDialog
 
@@ -40,14 +39,13 @@ from volumina.api import createDataSource, ArraySource
 from volumina.layer import ColortableLayer, GrayscaleLayer
 from volumina.utility import ShortcutManager, preferences
 
-from ilastik.widgets.labelListModel import LabelListModel
-
 from volumina.view3d.meshgenerator import MeshGeneratorDialog, mesh_to_obj, labeling_to_mesh
 from volumina.view3d.volumeRendering import RenderingManager
 
 # ilastik
 from ilastik.utility import bind
 from ilastik.applets.labeling.labelingGui import LabelingGui
+from ilastik.workflows.carving.opCarving import DEFAULT_OBJECT_NAME
 
 
 import logging
@@ -93,7 +91,7 @@ class CarvingGui(LabelingGui):
         )
 
         self.parentApplet = parentApplet
-        self.labelingDrawerUi.currentObjectLabel.setText("<not saved yet>")
+        self.labelingDrawerUi.currentObjectLabel.setText(DEFAULT_OBJECT_NAME)
 
         # Init special base class members
         self.minLabelNumber = 2
@@ -278,10 +276,8 @@ class CarvingGui(LabelingGui):
     def onSaveButton(self):
         logger.info("save object as?")
         if self.topLevelOperatorView.dataIsStorable():
-            prevName = ""
-            if self.topLevelOperatorView.hasCurrentObject():
-                prevName = self.topLevelOperatorView.getCurrentObjectName()
-            if prevName == "<not saved yet>":
+            prevName = self.topLevelOperatorView.getCurrentObjectName()
+            if prevName == DEFAULT_OBJECT_NAME:
                 prevName = ""
             name = self.saveAsDialog(name=prevName)
             if name is None:

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -235,17 +235,11 @@ class OpCarving(Operator):
             self.CanObjectBeSaved.setValue(False)
             return
 
-        has_segmentation = numpy.any(self._mst.hasSeg)
-        if has_segmentation:
-            # Segmentation existing implies that both types of seeds exist.
-            # Avoid the array calculations below.
-            self.CanObjectBeSaved.setValue(True)
-            return
-
         nodeSeeds = self._mst.gridSegmentor.getNodeSeeds()
         has_bg_seeds = numpy.any(nodeSeeds == Labels.BACKGROUND)
         has_fg_seeds = numpy.any(nodeSeeds == Labels.FOREGROUND)
-        self.CanObjectBeSaved.setValue(has_bg_seeds and has_fg_seeds)
+        has_segmentation = numpy.any(self._mst.hasSeg)
+        self.CanObjectBeSaved.setValue(has_bg_seeds and has_fg_seeds and has_segmentation)
 
     def setupOutputs(self):
         self.Segmentation.meta.assignFrom(self.InputData.meta)

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -107,7 +107,7 @@ class OpCarving(Operator):
 
     AllObjectNames = OutputSlot(rtype=List, stype=Opaque)
 
-    HasSegmentation = OutputSlot(stype="bool")
+    CanObjectBeSaved = OutputSlot(stype="bool")
 
     HintOverlay = OutputSlot()
 
@@ -149,7 +149,7 @@ class OpCarving(Operator):
             self._pmap = f["/data"][numpy.newaxis, :, :, :, numpy.newaxis]
 
         self._setCurrObjectName(DEFAULT_OBJECT_NAME)
-        self.HasSegmentation.setValue(False)
+        self.CanObjectBeSaved.setValue(False)
 
         # keep track of a set of object names that have changed since
         # the last serialization of this object to disk
@@ -330,7 +330,7 @@ class OpCarving(Operator):
         self._mst.setResulFgObj(fgNodes[0])
 
         self._setCurrObjectName(name)
-        self.HasSegmentation.setValue(True)
+        self.CanObjectBeSaved.setValue(True)
 
         # now that 'name' is no longer part of the set of finished objects, rebuild the done overlay
         self._buildDone()
@@ -440,7 +440,7 @@ class OpCarving(Operator):
         logger.info("save: len = {}".format(len(objects)))
         self.AllObjectNames.meta.shape = (len(objects),)
 
-        self.HasSegmentation.setValue(False)
+        self.CanObjectBeSaved.setValue(False)
 
     @Operator.forbidParallelExecute
     def save_object(self, name):
@@ -467,7 +467,7 @@ class OpCarving(Operator):
         self._mst.object_lut[name] = numpy.where(sVseg == 2)
 
         self._setCurrObjectName(DEFAULT_OBJECT_NAME)
-        self.HasSegmentation.setValue(False)
+        self.CanObjectBeSaved.setValue(False)
 
         objects = list(self._mst.object_names.keys())
         self.AllObjectNames.meta.shape = (len(objects),)
@@ -623,8 +623,8 @@ class OpCarving(Operator):
 
             self.Segmentation.setDirty(slice(None))
             self.DoneSegmentation.setDirty(slice(None))
-            hasSeg = numpy.any(self._mst.hasSeg)
-            self.HasSegmentation.setValue(hasSeg)
+            has_segmentation = numpy.any(self._mst.hasSeg)
+            self.CanObjectBeSaved.setValue(has_segmentation)
 
         elif slot == self.MST:
             self._opMstCache.Input.disconnect()

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -227,9 +227,9 @@ class OpCarving(Operator):
                     continue
                 assert (
                     name in self._mst.object_names
-                ), f"{name} not in self._mst.object_names, keys are {list(self._mst.object_names.keys())!r}"
+                ), f"{name} not in self._mst.object_names, keys are {list(self._mst.object_names)!r}"
                 self._done_seg_lut[objectSupervoxels] = self._mst.object_names[name]
-        logger.info("building the 'done' luts took {} seconds".format(timer.seconds()))
+        logger.info(f"building the 'done' luts took {timer.seconds()} seconds")
 
     def _updateCanObjectBeSaved(self):
         if self._mst is None:
@@ -267,8 +267,8 @@ class OpCarving(Operator):
         self.AllObjectNames.meta.dtype = object
 
     def getCurrentObjectName(self):
-        f"""
-        Returns current object name, which is {DEFAULT_OBJECT_NAME} until an object is loaded.
+        """
+        Returns current object name, which is DEFAULT_OBJECT_NAME until an object is loaded.
         """
         return self._currObjectName
 
@@ -592,7 +592,7 @@ class OpCarving(Operator):
         with Timer() as timer:
             logger.info("Writing seeds to label array")
             self.opLabelArray.LabelSinkInput[roi.toSlice()] = value
-            logger.info("Writing seeds to label array took {} seconds".format(timer.seconds()))
+            logger.info(f"Writing seeds to label array took {timer.seconds()} seconds")
 
         assert self._mst is not None
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -458,6 +458,9 @@ class OpCarving(Operator):
                 objNr = 1
 
         sVseg = self._mst.getSuperVoxelSeg()
+        if not any(sVseg > 0):
+            logger.info(f"   --> not saving due to missing segmentation")
+            return
 
         self._mst.object_names[name] = objNr
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -41,7 +41,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_LABEL_PREFIX = "Object "
-DEFAULT_OBJECT_NAME = "<not saved yet>"
 
 
 @unique
@@ -148,7 +147,7 @@ class OpCarving(Operator):
                 raise RuntimeError("Could not open pmap overlay '%s'" % pmapOverlayFile)
             self._pmap = f["/data"][numpy.newaxis, :, :, :, numpy.newaxis]
 
-        self._setCurrObjectName(DEFAULT_OBJECT_NAME)
+        self._setCurrObjectName("")
         self._updateCanObjectBeSaved()
 
         # keep track of a set of object names that have changed since
@@ -265,12 +264,6 @@ class OpCarving(Operator):
             self.AllObjectNames.meta.shape = (0,)
 
         self.AllObjectNames.meta.dtype = object
-
-    def getCurrentObjectName(self):
-        """
-        Returns current object name, which is DEFAULT_OBJECT_NAME until an object is loaded.
-        """
-        return self._currObjectName
 
     def doneObjectNamesForPosition(self, position3d):
         """
@@ -424,7 +417,7 @@ class OpCarving(Operator):
         if name in self._mst.object_names:
             del self._mst.object_names[name]
 
-        self._setCurrObjectName(DEFAULT_OBJECT_NAME)
+        self._setCurrObjectName("")
 
         # now that 'name' has been deleted, rebuild the done overlay
         self._buildDone()
@@ -474,7 +467,7 @@ class OpCarving(Operator):
 
         self._mst.object_lut[name] = numpy.where(sVseg == 2)
 
-        self._setCurrObjectName(DEFAULT_OBJECT_NAME)
+        self._setCurrObjectName("")
         self._updateCanObjectBeSaved()
 
         objects = list(self._mst.object_names.keys())

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -342,7 +342,7 @@ class OpCarving(Operator):
             logger.info("  --> no object with this name")
             return
 
-        self.saveCurrentObject()
+        self.save_object(self._currObjectName)
         self._clearLabels()
 
         fgVoxels, bgVoxels = self.restore_and_get_labels_for_object(name)
@@ -443,17 +443,11 @@ class OpCarving(Operator):
         self.HasSegmentation.setValue(False)
 
     @Operator.forbidParallelExecute
-    def saveCurrentObject(self):
-        logger.info(f"saving object {self._currObjectName}")
-        self.save_object(self._currObjectName)
-
-    @Operator.forbidParallelExecute
     def save_object(self, name):
         """
         Saves current object as name.
         """
-        seed = 2
-        logger.info("   --> Saving object %r from seed %r" % (name, seed))
+        logger.info(f"   --> Saving object {name!r}")
         if name in self._mst.object_names:
             objNr = self._mst.object_names[name]
         else:
@@ -464,7 +458,6 @@ class OpCarving(Operator):
                 objNr = 1
 
         sVseg = self._mst.getSuperVoxelSeg()
-        sVseed = self._mst.getSuperVoxelSeeds()
 
         self._mst.object_names[name] = objNr
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -506,9 +506,12 @@ class OpCarving(Operator):
         return fg, bg
 
     def saveObjectAs(self, name):
-        self.save_object(name)
-
         fgVoxels, bgVoxels = self.get_label_voxels()
+        if len(fgVoxels[0]) == 0 or len(bgVoxels[0]) == 0:
+            logger.info(f"Either foreground or background labels missing. Cannot save object {name}.")
+            return
+
+        self.save_object(name)
 
         self.attachVoxelLabelsToObject(name, fgVoxels=fgVoxels, bgVoxels=bgVoxels)
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -347,9 +347,6 @@ class OpCarving(Operator):
             logger.info("  --> no object with this name")
             return
 
-        if self.CanObjectBeSaved.value:
-            # The user was probably ready to save, so let's just do it
-            self.save_object(self._currObjectName)
         self._clearLabels()
 
         fgVoxels, bgVoxels = self.restore_and_get_labels_for_object(name)

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -413,15 +413,6 @@ class OpPreprocessing(Operator):
         self._dirty = False
         self.enableDownstream(True)
 
-        # copy over saved objects
-        if self.cachedResult[0] is not None:
-            mst.object_lut = self.cachedResult[0].object_lut
-            mst.object_names = self.cachedResult[0].object_names
-            mst.object_seeds_bg_voxels = self.cachedResult[0].object_seeds_bg_voxels
-            mst.object_seeds_fg_voxels = self.cachedResult[0].object_seeds_fg_voxels
-            mst.bg_priority = self.cachedResult[0].bg_priority
-            mst.no_bias_below = self.cachedResult[0].no_bias_below
-
         self.cachedResult = result
 
         result[0] = mst

--- a/ilastik/workflows/carving/opPreprocessing.py
+++ b/ilastik/workflows/carving/opPreprocessing.py
@@ -416,6 +416,11 @@ class OpPreprocessing(Operator):
         self.cachedResult = result
 
         result[0] = mst
+
+        # Signal downstream that a new MST has been created.
+        # Otherwise opCarving.propagateDirty does not get called to carry
+        # over existing user labels into the new MST.
+        self.PreprocessedData.setDirty(slice(None))
         return result
 
     def propagateDirty(self, slot, subindex, roi):
@@ -431,7 +436,6 @@ class OpPreprocessing(Operator):
 
         self._dirty = True
         self.enableDownstream(False)
-        self.PreprocessedData.setDirty(slice(None))
 
     def enableDownstream(self, ed):
         """set enable of carving applet to ed"""

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -124,24 +124,24 @@ class PreprocessingGui(QMainWindow):
         QMessageBox.critical(self, "error", str(exception))
 
     def handleRunButtonClicked(self):
-        if (
-            self.topLevelOperatorView.cachedResult[0] is not None
-            and self.topLevelOperatorView.cachedResult[0].object_names
-        ):
-            buttons = QMessageBox.Yes | QMessageBox.Cancel
-            n = len(self.topLevelOperatorView.cachedResult[0].object_names)
+        cached_result = self.topLevelOperatorView.cachedResult[0]
+        n_saved = len(cached_result.object_names) if cached_result is not None else 0
+        if n_saved:
             response = QMessageBox.warning(
                 self,
                 "Confirm Deleting Saved Objects",
-                f"This project already contains {n} saved segmented objects. The existing segmentations "
-                "become invalid if you change preprocessing settings, and will be deleted.\n\n"
-                "Please consider creating a copy of the project file for the different preprocessing instead.\n\n"
-                "Run preprocessing and delete all saved objects?",
-                buttons,
+                (
+                    f"<p>This project already contains {n_saved} saved segmented objects. The existing segmentations "
+                    "become invalid if you change preprocessing settings, and will be deleted.</p>"
+                    "<p>Please consider creating a copy of the project file for the different preprocessing instead.</p>"
+                    "<p>Run preprocessing and delete all saved objects?</p>"
+                ),
+                buttons=QMessageBox.Yes | QMessageBox.Cancel,
                 defaultButton=QMessageBox.Cancel,
             )
             if response == QMessageBox.Cancel:
                 return
+
         self.setWriteprotect()
         self.topLevelOperatorView.Filter.setValue(self.filterChoice)
         self.topLevelOperatorView.SizeRegularizer.setValue(self.drawer.sizeRegularizerSpin.value())

--- a/ilastik/workflows/carving/preprocessingGui.py
+++ b/ilastik/workflows/carving/preprocessingGui.py
@@ -29,10 +29,8 @@ logger = logging.getLogger(__name__)
 # PyQt
 from PyQt5 import uic
 from PyQt5.QtWidgets import QMainWindow, QMessageBox
-from PyQt5.QtGui import QIcon
 
 # ilastik
-from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.utility import bind, log_exception
 from ilastik.utility.gui import ThreadRouter, threadRouted
 from .preprocessingViewerGui import PreprocessingViewerGui
@@ -126,6 +124,24 @@ class PreprocessingGui(QMainWindow):
         QMessageBox.critical(self, "error", str(exception))
 
     def handleRunButtonClicked(self):
+        if (
+            self.topLevelOperatorView.cachedResult[0] is not None
+            and self.topLevelOperatorView.cachedResult[0].object_names
+        ):
+            buttons = QMessageBox.Yes | QMessageBox.Cancel
+            n = len(self.topLevelOperatorView.cachedResult[0].object_names)
+            response = QMessageBox.warning(
+                self,
+                "Confirm Deleting Saved Objects",
+                f"This project already contains {n} saved segmented objects. The existing segmentations "
+                "become invalid if you change preprocessing settings, and will be deleted.\n\n"
+                "Please consider creating a copy of the project file for the different preprocessing instead.\n\n"
+                "Run preprocessing and delete all saved objects?",
+                buttons,
+                defaultButton=QMessageBox.Cancel,
+            )
+            if response == QMessageBox.Cancel:
+                return
         self.setWriteprotect()
         self.topLevelOperatorView.Filter.setValue(self.filterChoice)
         self.topLevelOperatorView.SizeRegularizer.setValue(self.drawer.sizeRegularizerSpin.value())

--- a/ilastik/workflows/carving/watershed_segmentor.py
+++ b/ilastik/workflows/carving/watershed_segmentor.py
@@ -72,6 +72,7 @@ class WatershedSegmentor(object):
 
     def clearSegmentation(self):
         self.gridSegmentor.clearSegmentation()
+        self.hasSeg = False
 
     def addSeeds(self, roi, brushStroke):
         if isinstance(self.gridSegmentor, ilastiktools.GridSegmentor_3D_UInt32):
@@ -100,6 +101,7 @@ class WatershedSegmentor(object):
 
     def clearSeeds(self) -> None:
         self.gridSegmentor.clearSeeds()
+        self.hasSeg = False
 
     def setSeeds(self, fgSeeds, bgSeeds):
         self.gridSegmentor.setSeeds(fgSeeds, bgSeeds)
@@ -136,3 +138,4 @@ class WatershedSegmentor(object):
 
     def setResulFgObj(self, fgNodes):
         self.gridSegmentor.setResulFgObj(fgNodes)
+        self.hasSeg = True


### PR DESCRIPTION
Sorry this one became so big. The commits are probably easier to review individually than the PR as a whole.

The original aim was to delete existing saved objects when the user re-runs the preprocessing, and to warn the user before doing so (#2011).

It turned out there were some more issues around saving and loading objects, particularly with tracking whether the current state is ready to be saved as an object. This should be improved now, which should make it easier in the future if we go for keeping the labels of saved objects and only throw away their segmentation when changing preprocessing.

## Checklist

- [x] Format code and imports.
- [x] Rebase commits into a logical sequence.
