### PR TITLE
License data copied to ilastik root folder during release process

### DIFF
--- a/ilastik/shell/gui/licenseDialog.py
+++ b/ilastik/shell/gui/licenseDialog.py
@@ -80,13 +80,13 @@ class LicenseDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
 
-        ilastik_path = Path(ilastik.__file__).parent.parent
+        ilastik_path = Path(ilastik.__file__).parent
 
-        # environment variable set in release binary
-        license_path = Path(os.environ.get("ILASTIK_LICENSE_PATH", ilastik_path / "LICENSE"))
-        license_3rd_party_path = Path(os.environ.get("ILASTIK_LICENSE_3RD_PARTY_PATH", "NOTFOUND"))
+        # files copied during release process
+        license_path = ilastik_path / "LICENSE.txt"
+        license_3rd_party_path = ilastik_path / "THIRDPARTY_LICENSES.txt"
 
-        logo_path = ilastik_path / "ilastik" / "ilastik-fist.png"
+        logo_path = ilastik_path / "ilastik-fist.png"
 
         logo_image = QPixmap(str(logo_path)).scaled(125, 200, Qt.KeepAspectRatio, Qt.SmoothTransformation)
         logo = QLabel()

--- a/tests/test_ilastik/test_shell/test_license_dialog.py
+++ b/tests/test_ilastik/test_shell/test_license_dialog.py
@@ -28,10 +28,10 @@ def test_license_dlg_construct(qtbot):
 
 
 def test_license_dlg_default_license(qtbot, tmp_path):
-    with mock.patch("ilastik.__file__", new=str(tmp_path / "ilastik" / "__init__.py")):
+    with mock.patch("ilastik.__file__", new=str(tmp_path / "__init__.py")):
         dlg = get_dlg(qtbot)
 
-    license_path = tmp_path / "LICENSE"
+    license_path = tmp_path / "LICENSE.txt"
     license_path.touch()
     mock_open = mock.Mock()
     mock_error_msg = mock.Mock()
@@ -43,16 +43,17 @@ def test_license_dlg_default_license(qtbot, tmp_path):
     mock_error_msg.assert_not_called()
 
 
-def test_license_dlg_license(qtbot, mock_license):
-    license_path, license_text = mock_license
-    with mock.patch.dict(os.environ, {"ILASTIK_LICENSE_PATH": str(license_path)}):
+def test_license_dlg_default_3rdp_license(qtbot, tmp_path):
+    with mock.patch("ilastik.__file__", new=str(tmp_path / "__init__.py")):
         dlg = get_dlg(qtbot)
 
+    license_path = tmp_path / "THIRDPARTY_LICENSES.txt"
+    license_path.touch()
     mock_open = mock.Mock()
     mock_error_msg = mock.Mock()
     with mock.patch("webbrowser.open", mock_open):
         with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", mock_error_msg):
-            qtbot.mouseClick(dlg._show_details_btn, Qt.MouseButton.LeftButton)
+            qtbot.mouseClick(dlg._show_3rd_party_btn, Qt.MouseButton.LeftButton)
 
     mock_open.assert_called_once_with(license_path.as_uri())
     mock_error_msg.assert_not_called()
@@ -72,25 +73,10 @@ def test_license_dlg_license_notfound(qtbot):
     mock_error_msg.assert_called_once_with(dlg, "License file not found!", LicenseDialog.LICENSE_ERROR)
 
 
-def test_license_dlg_3rdp_license(qtbot, mock_license):
-    license_path, license_text = mock_license
-    with mock.patch.dict(os.environ, {"ILASTIK_LICENSE_3RD_PARTY_PATH": str(license_path)}):
-        dlg = get_dlg(qtbot)
-
-    mock_open = mock.Mock()
-    mock_error_msg = mock.Mock()
-    with mock.patch("webbrowser.open", mock_open):
-        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", mock_error_msg):
-            qtbot.mouseClick(dlg._show_3rd_party_btn, Qt.MouseButton.LeftButton)
-
-    mock_open.assert_called_once_with(license_path.as_uri())
-    mock_error_msg.assert_not_called()
-
-
 def test_license_dlg_3rdp_license_notfound(qtbot, mock_license):
     license_path, license_text = mock_license
-    with mock.patch.dict(os.environ, {"ILASTIK_LICENSE_3RD_PARTY_PATH": "_some_bogus_nonexistant_path_42_"}):
-        dlg = get_dlg(qtbot)
+
+    dlg = get_dlg(qtbot)
 
     mock_open = mock.Mock()
     mock_error_msg = mock.Mock()


### PR DESCRIPTION
setting env variables reliably on app startup tended to be error prone. now we copy license files statically into the ilastik root

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
