### PR TITLE
Autosave before batch

### DIFF
--- a/ilastik/applets/base/applet.py
+++ b/ilastik/applets/base/applet.py
@@ -18,9 +18,10 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from lazyflow.utility.orderedSignal import OrderedSignal
 from abc import ABCMeta, abstractproperty, abstractmethod
+from enum import Enum, auto
 from future.utils import with_metaclass
+from lazyflow.utility.orderedSignal import OrderedSignal
 
 
 class Applet(with_metaclass(ABCMeta, object)):
@@ -135,11 +136,17 @@ class DatasetConstraintError(Exception):
         return "Constraint of '{}' applet was violated: {}".format(self.appletName, self.message)
 
 
-class ShellRequest(object):
+class ShellRequest(Enum):
     """
     This class enumerates the actions that applets can ask the shell to perform via :py:attr:`Applet.shellRequestSignal`.
     At the moment, there is only one supported action.
     """
 
     #: Request that the shell perform a "save project" action.
-    RequestSave = 0
+    RequestSave = auto()
+    # Requests for dirty tracking mainly useful in the context of batch processing
+    # where we don't want to persist graph changes
+    # Set all applets to ignore dirty changes
+    RequestDisableDirtyTracking = auto()
+    # Set all applets to track dirty tracking
+    RequestEnableDirtyTracking = auto()

--- a/ilastik/applets/base/applet.py
+++ b/ilastik/applets/base/applet.py
@@ -139,7 +139,6 @@ class DatasetConstraintError(Exception):
 class ShellRequest(Enum):
     """
     This class enumerates the actions that applets can ask the shell to perform via :py:attr:`Applet.shellRequestSignal`.
-    At the moment, there is only one supported action.
     """
 
     #: Request that the shell perform a "save project" action.

--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -43,6 +43,7 @@ from ilastik.utility import log_exception
 from ilastik.utility.gui import ThreadRouter, threadRouted
 from ilastik.widgets.ImageFileDialog import ImageFileDialog
 from lazyflow.request import Request
+from ilastik.applets.base.applet import ShellRequest
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +189,8 @@ class BatchProcessingGui(QTabWidget):
             "using the controls on the right.\n"
             "The results will be exported according "
             "to the same settings you chose in the "
-            "interactive export page above."
+            "interactive export page above.\n\n"
+            "Note: the project will be saved prior to running batch processing."
         )
         instructions_label.setWordWrap(True)
         instructions_label.setAlignment(Qt.AlignCenter)
@@ -313,6 +315,7 @@ class BatchProcessingGui(QTabWidget):
         role_inputs = {role_name: self._data_role_widgets[role_name].filepaths for role_name in role_names}
         if all(len(role_inp) == 0 for role_inp in role_inputs.values()):
             return
+        self.parentApplet.shellRequestSignal(ShellRequest.RequestSave)
 
         # Run the export in a separate thread
         lane_configs = self.parentApplet.dataSelectionApplet.create_lane_configs(role_inputs=role_inputs)

--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -331,15 +331,20 @@ class BatchProcessingGui(QTabWidget):
         self.cancel_button.setVisible(True)
         self.run_button.setEnabled(False)
 
+        # Disable dirty tracking during batch - lanes will be added and removed.
+        # This would set the project dirty/changed, without reason.
+        self.parentApplet.shellRequestSignal(ShellRequest.RequestDisableDirtyTracking)
         # Start the export
         export_req.submit()
 
     def handle_batch_processing_complete(self):
         """
         Called after batch processing completes, no matter how it finished (failed, cancelled, whatever).
-        Can be overridden in subclasses.
+
+        Re-enables dirty tracking.
+        Subclasses must call super().handle_batch_processing_complete()
         """
-        pass
+        self.parentApplet.shellRequestSignal(ShellRequest.RequestEnableDirtyTracking)
 
     def cancel_batch_processing(self):
         assert self.export_req, "No export is running, how were you able to press 'cancel'?"

--- a/ilastik/applets/counting/countingBatchProcessingGui.py
+++ b/ilastik/applets/counting/countingBatchProcessingGui.py
@@ -37,6 +37,7 @@ class CountingBatchProcessingGui(BatchProcessingGui):
         """
         Overridden from base class.
         """
+        super().handle_batch_processing_complete()
         if self.csv_export_file:
             self.csv_export_file.close()
             self.csv_export_file = None

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1358,6 +1358,10 @@ class IlastikShell(QMainWindow):
         if requestAction == ShellRequest.RequestSave:
             # Call the handler directly to ensure this is a synchronous call (not queued to the GUI thread)
             self.projectManager.saveProject()
+        elif requestAction == ShellRequest.RequestDisableDirtyTracking:
+            self.projectManager.ignoreDirty(True)
+        elif requestAction == ShellRequest.RequestEnableDirtyTracking:
+            self.projectManager.ignoreDirty(False)
 
     def __len__(self):
         return len(self._applets)

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -249,6 +249,11 @@ class ProjectManager(object):
             log_exception(logger)
             raise e
 
+    def ignoreDirty(self, ignore: bool):
+        for applet in self._applets:
+            for serializer in applet.dataSerializers:
+                serializer.ignoreDirty = ignore
+
     def getDirtyAppletNames(self):
         """
         Check the serializers for every applet in the workflow.


### PR DESCRIPTION
This PR adds autosave before doing batch processing on clicking of the _Process all files_ button. Furthermore, __dirty tracking is disabled__ for the duration of the batch processing. This results in a "clean" graph after batch. Otherwise it will get inevitably dirty because lanes are added/removed...

- [X] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
