### PR TITLE
Better default value for maxNearestNeighbors

### DIFF
--- a/ilastik/applets/tracking/conservation/drawer.ui
+++ b/ilastik/applets/tracking/conservation/drawer.ui
@@ -382,6 +382,9 @@
          <property name="maximum">
           <number>5</number>
          </property>
+         <property name="value">
+          <number>3</number>
+         </property>
         </widget>
        </item>
        <item row="7" column="0">

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -434,7 +434,7 @@ class OpConservationTracking(Operator):
         disappearance_cost=500,
         motionModelWeight=10.0,
         force_build_hypotheses_graph=False,
-        max_nearest_neighbors=1,
+        max_nearest_neighbors=3,
         numFramesPerSplit=0,
         withBatchProcessing=False,
         solverName="Flow-based",


### PR DESCRIPTION
because default values matter!

in most cases, the maxNearestNeighbors value should be larger than 1, to allow for greater flexibility in the tracking solution.

New default is 3 (discussed with @akreshuk)