### PR TITLE
Change startup screen to the 3-column layout

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -105,8 +105,6 @@ try:
 except:
     _has_dvid_support = False
 
-ILASTIKFont = QFont("Helvetica", 12, QFont.Bold)
-
 logger = logging.getLogger(__name__)
 
 
@@ -625,10 +623,7 @@ class IlastikShell(QMainWindow):
         self.startscreen.CreateList.setWidget(self.startscreen.VL1.widget())
         self.startscreen.CreateList.setWidgetResizable(True)
 
-        self.startscreen.openRecentProject.setFont(ILASTIKFont)
-        self.startscreen.openProject.setFont(ILASTIKFont)
         self._replaceLogo(localDir)
-        self.startscreen.createNewProject.setFont(ILASTIKFont)
 
         self.openFileButtons = []
 

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -575,7 +575,7 @@ class IlastikShell(QMainWindow):
             for path, workflow in projects:
                 if not os.path.exists(path):
                     continue
-                b = FilePathButton(path, " ({})".format(workflow), parent=self.startscreen)
+                b = FilePathButton(path, workflow, parent=self.startscreen)
                 styleStartScreenButton(b, ilastikIcons.Open)
 
                 b.clicked.connect(partial(self.openFileAndCloseStartscreen, path))

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -584,8 +584,8 @@ class IlastikShell(QMainWindow):
 
                 # Insert the new button after all the other controls,
                 #  but before the vertical spacer at the end of the list.
-                insertion_index = self.startscreen.VL1.count() - 1
-                self.startscreen.VL1.insertWidget(insertion_index, b)
+                insertion_index = self.startscreen.VL2.count() - 1
+                self.startscreen.VL2.insertWidget(insertion_index, b)
                 self.openFileButtons.append(b)
 
     def _replaceLogo(self, localDir):

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -41,7 +41,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QMenu,
     QApplication,
-    QStackedWidget,
+    QPushButton,
     qApp,
     QFileDialog,
     QMessageBox,
@@ -286,12 +286,26 @@ class ProgressDisplayManager(QObject):
 # ===----------------------------------------------------------------------------------------------------------------===
 
 
-def styleStartScreenButton(button, icon):
-    assert isinstance(button, QToolButton)
-    button.setAutoRaise(True)
-    button.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-    button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+def styleStartScreenButton(button: QPushButton, icon: str) -> None:
     button.setIcon(QIcon(icon))
+    button.setFlat(True)
+    button.setStyleSheet(
+        r"""
+        * {
+            background-color: palette(window);
+            border: none;
+            border-radius: 1em;
+            padding: 0.5em 1em;
+            text-align: left;
+        }
+        *:hover {
+            background-color: palette(light);
+        }
+        *:pressed {
+            background-color: palette(dark);
+        }
+    """
+    )
 
 
 @ShellABC.register
@@ -581,10 +595,7 @@ class IlastikShell(QMainWindow):
 
                 b.clicked.connect(partial(self.openFileAndCloseStartscreen, path))
 
-                # Insert the new button after all the other controls,
-                #  but before the vertical spacer at the end of the list.
-                insertion_index = self.startscreen.VL2.count() - 1
-                self.startscreen.VL2.insertWidget(insertion_index, b)
+                self.startscreen.recentProjectsContainerLayout.addWidget(b)
                 self.openFileButtons.append(b)
 
     def _replaceLogo(self, localDir):
@@ -695,7 +706,7 @@ class IlastikShell(QMainWindow):
                     continue
 
                 wf_class, wf_name, wf_display_name = wfs[wf_name]
-                button = QToolButton(
+                button = QPushButton(
                     self.startscreen,
                     objectName=f"NewProjectButton_{wf_class.__name__}",
                     text=wf_display_name,
@@ -709,7 +720,7 @@ class IlastikShell(QMainWindow):
 
             group_layout = QVBoxLayout()
             for button in buttons:
-                group_layout.addWidget(button)
+                group_layout.addWidget(button, stretch=0, alignment=Qt.AlignLeft)
 
             group_widget = QWidget()
             group_widget.setLayout(group_layout)

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -575,7 +575,8 @@ class IlastikShell(QMainWindow):
             for path, workflow in projects:
                 if not os.path.exists(path):
                     continue
-                b = FilePathButton(path, workflow, parent=self.startscreen)
+                # Add "Em Quad" space character to visually separate path from workflow name.
+                b = FilePathButton(path, f"\u2001{workflow}", parent=self.startscreen)
                 styleStartScreenButton(b, ilastikIcons.Open)
 
                 b.clicked.connect(partial(self.openFileAndCloseStartscreen, path))

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -285,27 +285,22 @@ class ProgressDisplayManager(QObject):
 # === IlastikShell                                                                                                   ===
 # ===----------------------------------------------------------------------------------------------------------------===
 
-
-def styleStartScreenButton(button: QPushButton, icon: str) -> None:
-    button.setIcon(QIcon(icon))
-    button.setFlat(True)
-    button.setStyleSheet(
-        r"""
-        * {
-            background-color: palette(window);
-            border: none;
-            border-radius: 1em;
-            padding: 0.5em 1em;
-            text-align: left;
-        }
-        *:hover {
-            background-color: palette(light);
-        }
-        *:pressed {
-            background-color: palette(dark);
-        }
-    """
-    )
+# Style for flat buttons with no borders that are highlighted when hovered or pressed.
+FLAT_BUTTON_STYLE = r"""
+    QAbstractButton {
+        background-color: palette(window);
+        border: none;
+        border-radius: 1em;
+        padding: 0.5em 1em;
+        text-align: left;
+    }
+    QAbstractButton:hover {
+        background-color: palette(light);
+    }
+    QAbstractButton:pressed {
+        background-color: palette(dark);
+    }
+"""
 
 
 @ShellABC.register
@@ -590,12 +585,13 @@ class IlastikShell(QMainWindow):
                 if not os.path.exists(path):
                     continue
                 # Add "Em Quad" space character to visually separate path from workflow name.
-                b = FilePathButton(path, f"\u2001{workflow}", parent=self.startscreen)
-                styleStartScreenButton(b, ilastikIcons.Open)
-
+                b = FilePathButton(
+                    path, subtext=f"\u2001{workflow}", icon=QIcon(ilastikIcons.Open), parent=self.startscreen
+                )
+                b.setStyleSheet(FLAT_BUTTON_STYLE)
                 b.clicked.connect(partial(self.openFileAndCloseStartscreen, path))
 
-                self.startscreen.recentProjectsContainerLayout.addWidget(b)
+                self.startscreen.recentProjectsContainerLayout.addWidget(b, stretch=1, alignment=Qt.AlignLeft)
                 self.openFileButtons.append(b)
 
     def _replaceLogo(self, localDir):
@@ -639,7 +635,8 @@ class IlastikShell(QMainWindow):
 
         self.openFileButtons = []
 
-        styleStartScreenButton(self.startscreen.browseFilesButton, ilastikIcons.OpenFolder)
+        self.startscreen.browseFilesButton.setIcon(QIcon(ilastikIcons.OpenFolder))
+        self.startscreen.browseFilesButton.setStyleSheet(FLAT_BUTTON_STYLE)
         self.startscreen.browseFilesButton.clicked.connect(self.onOpenProjectActionTriggered)
 
         self._populateWorkflows()
@@ -712,7 +709,8 @@ class IlastikShell(QMainWindow):
                     text=wf_display_name,
                     clicked=partial(self.loadWorkflow, wf_class),
                 )
-                styleStartScreenButton(button, ilastikIcons.GoNext)
+                button.setIcon(QIcon(ilastikIcons.GoNext))
+                button.setStyleSheet(FLAT_BUTTON_STYLE)
                 buttons.append(button)
 
             if not buttons:

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -720,7 +720,7 @@ class IlastikShell(QMainWindow):
 
             group_layout = QVBoxLayout()
             for button in buttons:
-                group_layout.addWidget(button, stretch=0, alignment=Qt.AlignLeft)
+                group_layout.addWidget(button)
 
             group_widget = QWidget()
             group_widget.setLayout(group_layout)

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -719,6 +719,7 @@ class IlastikShell(QMainWindow):
                 continue
 
             group_layout = QVBoxLayout()
+            group_layout.setSpacing(4)
             for button in buttons:
                 group_layout.addWidget(button)
 
@@ -727,7 +728,7 @@ class IlastikShell(QMainWindow):
 
             wfs_layout.addWidget(CollapsibleWidget(group_widget, f" {group}", expanded=wf_dict["expanded"]))
 
-        self.startscreen.VL1.insertLayout(1, wfs_layout)
+        self.startscreen.workflowsContainerLayout.addLayout(wfs_layout)
 
     def openFileAndCloseStartscreen(self, path):
         if self.projectManager is not None:

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -103,6 +103,48 @@
              <item>
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
+                <spacer name="verticalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>32</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="appNameLabel">
+                 <property name="text">
+                  <string>&lt;h1&gt;ilastik&lt;/h1&gt;</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>32</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
                 <widget class="QLabel" name="label">
                  <property name="maximumSize">
                   <size>
@@ -122,6 +164,9 @@
                  <property name="scaledContents">
                   <bool>true</bool>
                  </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
                 </widget>
                </item>
                <item>
@@ -129,13 +174,10 @@
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Minimum</enum>
-                 </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>20</width>
-                   <height>16</height>
+                   <width>0</width>
+                   <height>0</height>
                   </size>
                  </property>
                 </spacer>
@@ -154,12 +196,12 @@
                 </widget>
                </item>
                <item>
-                <spacer name="verticalSpacer_5">
+                <spacer name="verticalSpacer_9">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>
                  <property name="sizeType">
-                  <enum>QSizePolicy::Minimum</enum>
+                  <enum>QSizePolicy::Fixed</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
@@ -183,14 +225,17 @@
                 </widget>
                </item>
                <item>
-                <spacer name="verticalSpacer">
+                <spacer name="verticalSpacer_10">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>20</width>
-                   <height>40</height>
+                   <height>16</height>
                   </size>
                  </property>
                 </spacer>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -88,30 +88,26 @@
              <property name="spacing">
               <number>0</number>
              </property>
-             <property name="margin">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
               <number>0</number>
              </property>
              <item>
               <layout class="QVBoxLayout" name="verticalLayout_6">
                <item>
-                <spacer name="verticalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
                 <widget class="QLabel" name="label">
                  <property name="maximumSize">
                   <size>
-                   <width>288</width>
-                   <height>410</height>
+                   <width>174</width>
+                   <height>250</height>
                   </size>
                  </property>
                  <property name="lineWidth">
@@ -124,6 +120,64 @@
                   <pixmap>../../../ilastik-fist.png</pixmap>
                  </property>
                  <property name="scaledContents">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_8">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Minimum</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="websiteLinkLabel">
+                 <property name="text">
+                  <string notr="true">&lt;a href=&quot;https://www.ilastik.org&quot;&gt;www.ilastik.org&lt;/a&gt;</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="openExternalLinks">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Minimum</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="twitterLinkLabel">
+                 <property name="text">
+                  <string notr="true">&lt;a href=&quot;https://twitter.com/ilastik_team&quot;&gt;@ilastik_team&lt;/a&gt;</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="openExternalLinks">
                   <bool>true</bool>
                  </property>
                 </widget>
@@ -164,7 +218,7 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>672</width>
+                    <width>786</width>
                     <height>526</height>
                    </rect>
                   </property>
@@ -174,7 +228,7 @@
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <layout class="QHBoxLayout" name="horizontalLayout_7">
                    <item>
                     <layout class="QVBoxLayout" name="VL1">
                      <item>
@@ -195,9 +249,6 @@
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
                        </property>
-                       <property name="sizeType">
-                        <enum>QSizePolicy::Fixed</enum>
-                       </property>
                        <property name="sizeHint" stdset="0">
                         <size>
                          <width>20</width>
@@ -206,6 +257,10 @@
                        </property>
                       </spacer>
                      </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <layout class="QVBoxLayout" name="VL2">
                      <item>
                       <widget class="QLabel" name="openProject">
                        <property name="text">
@@ -304,7 +359,16 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -240,7 +240,7 @@
                         </sizepolicy>
                        </property>
                        <property name="text">
-                        <string>Create New Project</string>
+                        <string>&lt;h3&gt;Create New Project&lt;/h3&gt;</string>
                        </property>
                       </widget>
                      </item>
@@ -264,7 +264,7 @@
                      <item>
                       <widget class="QLabel" name="openProject">
                        <property name="text">
-                        <string>Open Project ...</string>
+                        <string>&lt;h3&gt;Open Project&lt;/h3&gt;</string>
                        </property>
                       </widget>
                      </item>
@@ -306,7 +306,7 @@
                         </sizepolicy>
                        </property>
                        <property name="text">
-                        <string>Open Recent Project</string>
+                        <string>&lt;h3&gt;Open Recent Project&lt;/h3&gt;</string>
                        </property>
                       </widget>
                      </item>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -290,6 +290,29 @@
                       </widget>
                      </item>
                      <item>
+                      <spacer name="verticalSpacer_11">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
+                       </property>
+                       <property name="sizeType">
+                        <enum>QSizePolicy::Fixed</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>0</width>
+                         <height>16</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <layout class="QVBoxLayout" name="workflowsContainerLayout">
+                       <property name="spacing">
+                        <number>4</number>
+                       </property>
+                      </layout>
+                     </item>
+                     <item>
                       <spacer name="verticalSpacer_3">
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
@@ -344,7 +367,11 @@
                       </widget>
                      </item>
                      <item>
-                      <layout class="QVBoxLayout" name="recentProjectsContainerLayout"/>
+                      <layout class="QVBoxLayout" name="recentProjectsContainerLayout">
+                       <property name="spacing">
+                        <number>4</number>
+                       </property>
+                      </layout>
                      </item>
                      <item>
                       <spacer name="verticalSpacer_6">

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -313,7 +313,7 @@
                        </property>
                       </widget>
                      </item>
-                     <item alignment="Qt::AlignLeft">
+                     <item>
                       <widget class="QPushButton" name="browseFilesButton">
                        <property name="text">
                         <string>Browse Files</string>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -174,10 +174,13 @@
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>0</width>
-                   <height>0</height>
+                   <height>32</height>
                   </size>
                  </property>
                 </spacer>
@@ -229,13 +232,10 @@
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
-                 </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>20</width>
-                   <height>16</height>
+                   <width>0</width>
+                   <height>0</height>
                   </size>
                  </property>
                 </spacer>
@@ -313,14 +313,8 @@
                        </property>
                       </widget>
                      </item>
-                     <item>
-                      <widget class="QToolButton" name="browseFilesButton">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
+                     <item alignment="Qt::AlignLeft">
+                      <widget class="QPushButton" name="browseFilesButton">
                        <property name="text">
                         <string>Browse Files</string>
                        </property>
@@ -344,16 +338,13 @@
                      </item>
                      <item>
                       <widget class="QLabel" name="openRecentProject">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
                        <property name="text">
                         <string>&lt;h3&gt;Open Recent Project&lt;/h3&gt;</string>
                        </property>
                       </widget>
+                     </item>
+                     <item>
+                      <layout class="QVBoxLayout" name="recentProjectsContainerLayout"/>
                      </item>
                      <item>
                       <spacer name="verticalSpacer_6">

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -273,7 +273,7 @@
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
                    <item>
                     <layout class="QVBoxLayout" name="VL1">
                      <item>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -228,6 +228,35 @@
                 </widget>
                </item>
                <item>
+                <spacer name="verticalSpacer_12">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="forumLinkLabel">
+                 <property name="text">
+                  <string>&lt;a href=&quot;https://forum.image.sc/tags/ilastik&quot;&gt;forum.sc&lt;/a&gt;</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="openExternalLinks">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <spacer name="verticalSpacer_10">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -246,7 +246,7 @@
                <item>
                 <widget class="QLabel" name="forumLinkLabel">
                  <property name="text">
-                  <string>&lt;a href=&quot;https://forum.image.sc/tags/ilastik&quot;&gt;forum.sc&lt;/a&gt;</string>
+                  <string>&lt;a href=&quot;https://forum.image.sc/tags/ilastik&quot;&gt;Get in Touch&lt;/a&gt;</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignCenter</set>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -365,7 +365,7 @@
                        </property>
                       </widget>
                      </item>
-                     <item>
+                     <item alignment="Qt::AlignLeft">
                       <widget class="QPushButton" name="browseFilesButton">
                        <property name="text">
                         <string>Browse Files</string>

--- a/ilastik/widgets/filePathButton.py
+++ b/ilastik/widgets/filePathButton.py
@@ -20,18 +20,18 @@ class FilePathButton(QToolButton):
         # Determine the shortest possible text we could display,
         #  and use it to set our minimum width
         drive = os.path.splitdrive(self._filepath)[0]
-        self.setText(drive + "/.../" + os.path.split(self._filepath)[1] + self._suffix)
+        self._setPathText(drive + "/.../" + os.path.split(self._filepath)[1])
         self.setMinimumWidth(self.minimumSizeHint().width())
         self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
 
         # By default, show the full path
-        self.setText(self._filepath + self._suffix)
+        self._setPathText(self._filepath)
         self.setToolTip(self.text())
 
     def resizeEvent(self, event):
         # Start with the full path
         short_filepath = self._filepath
-        self.setText(self._filepath + self._suffix)
+        self._setPathText(self._filepath)
         ideal_width = self.minimumSizeHint().width()
 
         # Keep removing intermediate directories until the text fits inside the new width
@@ -51,8 +51,13 @@ class FilePathButton(QToolButton):
 
             # Always include drive
             short_filepath = drive + os.path.join(dirpath, filename)
-            self.setText(short_filepath + self._suffix)
+            self._setPathText(short_filepath)
             ideal_width = self.minimumSizeHint().width()
+
+    def _setPathText(self, path: str) -> None:
+        # Buttons don't support HTML markup.
+        # U+2937: Arrow Pointing Downwards Then Curving Rightwards.
+        self.setText(f"{path}\n\u2937{self._suffix}" if self._suffix else path)
 
 
 if __name__ == "__main__":

--- a/ilastik/widgets/filePathButton.py
+++ b/ilastik/widgets/filePathButton.py
@@ -26,7 +26,7 @@ class FilePathButton(QToolButton):
 
         # By default, show the full path
         self._setPathText(self._filepath)
-        self.setToolTip(self.text())
+        self.setToolTip(self._filepath)
 
     def resizeEvent(self, event):
         # Start with the full path
@@ -56,8 +56,8 @@ class FilePathButton(QToolButton):
 
     def _setPathText(self, path: str) -> None:
         # Buttons don't support HTML markup.
-        # U+2937: Arrow Pointing Downwards Then Curving Rightwards.
-        self.setText(f"{path}\n\u2937{self._suffix}" if self._suffix else path)
+        # Add an "Em Quad" space character to visually separate path and suffix.
+        self.setText(f"{path}\n\u2001{self._suffix}" if self._suffix else path)
 
 
 if __name__ == "__main__":

--- a/ilastik/widgets/filePathButton.py
+++ b/ilastik/widgets/filePathButton.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import PurePath
-from typing import Optional, Tuple, Union
+from typing import Iterable, Optional, Union
 
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QIcon, QResizeEvent
@@ -19,64 +19,75 @@ class FilePathButton(QPushButton):
         icon: Optional[QIcon] = None,
         parent: Optional[QWidget] = None,
     ):
-        """Create a new button with the specified path, other text, and icon.
+        """Create a new button with the specified path, subtext, and icon.
 
         If the path is too long, intermediate directories will be replaced by a placeholder.
 
-        The other text, if not empty, is displayed below the path.
+        The subtext, if not empty, is displayed below the path.
         """
         super().__init__(parent)
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-
         self._path = PurePath(path)
-        self.setToolTip(str(self._path))
-
-        self._suffix = f"\n{subtext}" if subtext else ""
-
-        # Icon should be set before the text in order to be accounted for in the size hint.
+        self._subtext = subtext
         if icon is not None:
             super().setIcon(icon)
-
         self._abbrevs = [(PurePath(), 0)]
-        self._update_abbrevs()
-
-    def minimumSizeHint(self) -> QSize:
-        return QSize(self._abbrevs[-1][1], super().sizeHint().height())
+        self._update()
 
     def sizeHint(self) -> QSize:
         return QSize(self._abbrevs[0][1], super().sizeHint().height())
 
+    def minimumSizeHint(self) -> QSize:
+        return QSize(self._abbrevs[-1][1], super().sizeHint().height())
+
     def setText(self, text: str) -> None:
         self._path = PurePath(text)
         self.setToolTip(str(self._path))
-        self._update_abbrevs()
+        self._update()
+
+    def setSubtext(self, subtext: str) -> None:
+        self._subtext = subtext
+        self._update()
 
     def setIcon(self, icon: QIcon) -> None:
         super().setIcon(icon)
-        self._update_abbrevs()
+        self._update()
 
     def setIconSize(self, size: QSize) -> None:
         super().setIconSize(size)
-        self._update_abbrevs()
+        self._update()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
-        self._update_current_text()
+        self._update(update_abbrevs=False)
 
-    def _update_abbrevs(self) -> None:
-        """Update abbreviations for the current widget state, then update the current text."""
-        self._abbrevs = [self._set_path(self._path)]
-        for i in range(2, len(self._path.parts)):
-            path = PurePath(self._path.parts[0], HORIZONTAL_ELLIPSIS, *self._path.parts[i:])
-            self._abbrevs.append(self._set_path(path))
-        self._update_current_text()
+    def _update(self, update_abbrevs: bool = True) -> None:
+        """Update widget text.
 
-    def _update_current_text(self) -> None:
-        """Update the current text to the shortest possible one that fits into the button."""
-        path = next((abbrev for abbrev, width in self._abbrevs if width <= self.width()), self._abbrevs[-1][0])
-        self._set_path(path)
+        If abbreviations and their corresponding widths don't need to be recomputed,
+        set ``update_abbrevs`` to ``False``.
+        """
+        if update_abbrevs:
+            self._abbrevs.clear()
+            for abbrev in abbreviated_paths(self._path):
+                # super().sizeHint() computes the proper size of the button
+                # for this abbreviation.
+                self._set_path(abbrev)
+                self._abbrevs.append((abbrev, super().sizeHint().width()))
+        self._set_path(next((p for p, w in self._abbrevs if w <= self.width()), self._abbrevs[-1][0]))
 
-    def _set_path(self, path: PurePath) -> Tuple[str, int]:
-        """Set button text from path; return the path's text, and the ideal width of this widget."""
-        text = str(path)
-        super().setText(f"{text}{self._suffix}")
-        return text, super().sizeHint().width()
+    def _set_path(self, path: PurePath) -> None:
+        """Set the current text as the specified path and (possibly) subtext on a new line."""
+        super().setText(f"{path}\n{self._subtext}" if self._subtext else str(path))
+
+
+def abbreviated_paths(path: PurePath, placeholder: str = HORIZONTAL_ELLIPSIS) -> Iterable[PurePath]:
+    """Yield the original path, and then it's consecutive abbreviations.
+
+    In an abbreviated path, one or more intermediate directories in that path
+    are replaced by a placeholder.
+
+    Directories are abbreviated starting from root, but the root itself
+    and the final path component are never abbreviated.
+    """
+    yield path
+    yield from (PurePath(path.parts[0], placeholder, *path.parts[i:]) for i in range(2, len(path.parts)))

--- a/ilastik/widgets/filePathButton.py
+++ b/ilastik/widgets/filePathButton.py
@@ -1,9 +1,10 @@
 import os
 from pathlib import PurePath
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
-from PyQt5.QtGui import QResizeEvent
-from PyQt5.QtWidgets import QPushButton, QWidget
+from PyQt5.QtCore import QSize
+from PyQt5.QtGui import QIcon, QResizeEvent
+from PyQt5.QtWidgets import QPushButton, QSizePolicy, QWidget
 
 HORIZONTAL_ELLIPSIS = "\u2026"
 
@@ -11,33 +12,71 @@ HORIZONTAL_ELLIPSIS = "\u2026"
 class FilePathButton(QPushButton):
     """Button that displays a possibly abbreviated filepath."""
 
-    def __init__(self, path: Union[str, os.PathLike], other: str = "", parent: Optional[QWidget] = None):
-        """Create a new button with the specified path and (possibly) other text.
+    def __init__(
+        self,
+        path: Union[str, os.PathLike],
+        subtext: str = "",
+        icon: Optional[QIcon] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        """Create a new button with the specified path, other text, and icon.
 
-        If path is too long, intermediate directories will be replaced by a placeholder.
+        If the path is too long, intermediate directories will be replaced by a placeholder.
 
         The other text, if not empty, is displayed below the path.
         """
         super().__init__(parent)
-        self._suffix = f"\n{other}" if other else ""
+        self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
-        path = PurePath(path)
-        self._abbrevs = [
-            str(path),
-            *[str(PurePath(path.parts[0], HORIZONTAL_ELLIPSIS, *path.parts[i:])) for i in range(2, len(path.parts))],
-        ]
+        self._path = PurePath(path)
+        self.setToolTip(str(self._path))
 
-        self._updateText(self._abbrevs[-1])
-        self.setMinimumWidth(self.sizeHint().width())
+        self._suffix = f"\n{subtext}" if subtext else ""
 
-        self._updateText(self._abbrevs[0])
-        self.setToolTip(self._abbrevs[0])
+        # Icon should be set before the text in order to be accounted for in the size hint.
+        if icon is not None:
+            super().setIcon(icon)
+
+        self._abbrevs = [(PurePath(), 0)]
+        self._update_abbrevs()
+
+    def minimumSizeHint(self) -> QSize:
+        return QSize(self._abbrevs[-1][1], super().sizeHint().height())
+
+    def sizeHint(self) -> QSize:
+        return QSize(self._abbrevs[0][1], super().sizeHint().height())
+
+    def setText(self, text: str) -> None:
+        self._path = PurePath(text)
+        self.setToolTip(str(self._path))
+        self._update_abbrevs()
+
+    def setIcon(self, icon: QIcon) -> None:
+        super().setIcon(icon)
+        self._update_abbrevs()
+
+    def setIconSize(self, size: QSize) -> None:
+        super().setIconSize(size)
+        self._update_abbrevs()
 
     def resizeEvent(self, event: QResizeEvent) -> None:
-        for abbrev in self._abbrevs:
-            self._updateText(abbrev)
-            if self.sizeHint().width() <= event.size().width():
-                break
+        self._update_current_text()
 
-    def _updateText(self, text: str) -> None:
-        self.setText(f"{text}{self._suffix}")
+    def _update_abbrevs(self) -> None:
+        """Update abbreviations for the current widget state, then update the current text."""
+        self._abbrevs = [self._set_path(self._path)]
+        for i in range(2, len(self._path.parts)):
+            path = PurePath(self._path.parts[0], HORIZONTAL_ELLIPSIS, *self._path.parts[i:])
+            self._abbrevs.append(self._set_path(path))
+        self._update_current_text()
+
+    def _update_current_text(self) -> None:
+        """Update the current text to the shortest possible one that fits into the button."""
+        path = next((abbrev for abbrev, width in self._abbrevs if width <= self.width()), self._abbrevs[-1][0])
+        self._set_path(path)
+
+    def _set_path(self, path: PurePath) -> Tuple[str, int]:
+        """Set button text from path; return the path's text, and the ideal width of this widget."""
+        text = str(path)
+        super().setText(f"{text}{self._suffix}")
+        return text, super().sizeHint().width()


### PR DESCRIPTION
Because v1.4.0 is imminent, don't change too much, just move _Open Project_ and _Open Recent Project_ buttons, make the logo smaller, and add some external links.

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/1649961/217219555-6824ae75-64f8-4b94-994e-c4d6226f4698.png">