### PR TITLE
Carving: Also clear object when clearing labels

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -430,10 +430,10 @@ class CarvingGui(LabelingGui):
 
     def _onClearAction(self):
         confirm = QMessageBox.warning(
-            self, "Really Clear?", "Clear all brushtrokes?", QMessageBox.Ok | QMessageBox.Cancel
+            self, "Really Clear?", "Clear all brushtrokes and start new object?", QMessageBox.Ok | QMessageBox.Cancel
         )
         if confirm == QMessageBox.Ok:
-            self.topLevelOperatorView.clearCurrentLabeling()
+            self.topLevelOperatorView.clearCurrentLabelsAndObject()
 
     def _clearLabelListGui(self):
         # Remove rows until we have the right number

--- a/ilastik/workflows/carving/carvingSerializer.py
+++ b/ilastik/workflows/carving/carvingSerializer.py
@@ -197,7 +197,7 @@ class CarvingSerializer(AppletSerializer):
                 ]
                 logger.info("restored seeds")
 
-            opCarving._buildDone()
+            opCarving._updateDoneSegmentation()
 
     def isDirty(self):
         for index, innerOp in enumerate(self._o.innerOperators):

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -287,8 +287,9 @@ class OpCarving(Operator):
         Clear labels currently drawn and loaded object if there is one
         """
         self._clearLabels()
-        self._setCurrObjectName("")
         self.Trigger.setDirty(slice(None))
+        self._setCurrObjectName("")
+        self._buildDone()
         self._updateCanObjectBeSaved()
 
     def restore_and_get_labels_for_object(self, name):

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -211,10 +211,11 @@ class OpCarving(Operator):
         self._currObjectName = n
         self.CurrentObjectName.setValue(n)
 
-    def _buildDone(self):
+    def _updateDoneSegmentation(self):
         """
         Builds the done segmentation anew, for example after saving an object or
         deleting an object.
+        Excludes the current object if one is loaded.
         """
         if self._mst is None:
             return
@@ -289,7 +290,7 @@ class OpCarving(Operator):
         self._clearLabels()
         self.Trigger.setDirty(slice(None))
         self._setCurrObjectName("")
-        self._buildDone()
+        self._updateDoneSegmentation()
         self._updateCanObjectBeSaved()
 
     def restore_and_get_labels_for_object(self, name):
@@ -322,8 +323,7 @@ class OpCarving(Operator):
         self._setCurrObjectName(name)
         self._updateCanObjectBeSaved()
 
-        # now that 'name' is no longer part of the set of finished objects, rebuild the done overlay
-        self._buildDone()
+        self._updateDoneSegmentation()
         return (fgVoxelsSeedPos, bgVoxelsSeedPos)
 
     def loadObject(self, name):
@@ -410,9 +410,7 @@ class OpCarving(Operator):
             del self._mst.object_names[name]
 
         self._setCurrObjectName("")
-
-        # now that 'name' has been deleted, rebuild the done overlay
-        self._buildDone()
+        self._updateDoneSegmentation()
 
     def deleteObject(self, name):
         logger.info(f"want to delete object with name = {name}")
@@ -486,8 +484,7 @@ class OpCarving(Operator):
         objects = list(self._mst.object_names.keys())
         self.AllObjectNames.meta.shape = (len(objects),)
 
-        # now that 'name' is no longer part of the set of finished objects, rebuild the done overlay
-        self._buildDone()
+        self._updateDoneSegmentation()
 
         self._dirtyObjects.add(name)
 

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -295,8 +295,8 @@ class OpCarving(Operator):
 
     def restore_and_get_labels_for_object(self, name):
         """
-        Loads a single object called name to be the currently edited object. Its
-        not part of the done segmentation anymore.
+        Loads a single object called name to be the currently edited object.
+        _updateDoneSegmentation takes care to exclude the loaded object from the DoneSegmentation view.
         """
         assert self._mst is not None
         logger.info("[OpCarving] load object %s (opCarving=%d, mst=%d)" % (name, id(self), id(self._mst)))
@@ -355,6 +355,7 @@ class OpCarving(Operator):
 
         # The entire segmentation layer needs to be refreshed now.
         self.Segmentation.setDirty()
+        self.DoneSegmentation.setDirty()
         self._updateCanObjectBeSaved()
 
     def set_labels_into_WriteSeeds_input(self, fgVoxels, bgVoxels):

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -469,11 +469,8 @@ class OpCarving(Operator):
         if name in self._mst.object_names:
             objNr = self._mst.object_names[name]
         else:
-            # find free objNr
-            if len(list(self._mst.object_names.values())) > 0:
-                objNr = numpy.max(numpy.array(list(self._mst.object_names.values()))) + 1
-            else:
-                objNr = 1
+            # Find next free object number.
+            objNr = max(self._mst.object_names.values(), default=0) + 1
 
         self._mst.object_names[name] = objNr
         self._mst.bg_priority[name] = self.BackgroundPriority.value

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -290,15 +290,14 @@ class OpCarving(Operator):
         self._mst.object_seeds_bg_voxels[name] = bgVoxels
 
     @Operator.forbidParallelExecute
-    def clearCurrentLabeling(self, trigger_recompute=True):
+    def clearCurrentLabelsAndObject(self):
         """
-        Clears the current labeling.
+        Clear labels currently drawn and loaded object if there is one
         """
         self._clearLabels()
-        self._mst.gridSegmentor.clearSeeds()
-        self._updateCanObjectBeSaved()
-
+        self._setCurrObjectName("")
         self.Trigger.setDirty(slice(None))
+        self._updateCanObjectBeSaved()
 
     def restore_and_get_labels_for_object(self, name):
         """
@@ -518,7 +517,10 @@ class OpCarving(Operator):
         self._mst.gridSegmentor.clearSeeds()
 
         self._mst.clearSegmentation()
-        self.clearCurrentLabeling()
+        self._clearLabels()
+        self._updateCanObjectBeSaved()
+
+        self.Trigger.setDirty(slice(None))
 
     def getMaxUncertaintyPos(self, label):
         # FIXME: currently working on

--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -484,8 +484,6 @@ class OpCarving(Operator):
         objects = list(self._mst.object_names.keys())
         self.AllObjectNames.meta.shape = (len(objects),)
 
-        self._updateDoneSegmentation()
-
         self._dirtyObjects.add(name)
 
         self._mst.clearSegmentation()


### PR DESCRIPTION
This allows the user to use the "clear" button to not only remove all currently drawn labels, but also to get "out" of a currently loaded object (see [previous comment](https://github.com/ilastik/ilastik/pull/2664#issuecomment-1410503826)).

I've also inlined a couple of extracted functions that were previously used by an alternative saving mechanism. There used to be "Save" and "Save As", but we got rid of the former a few years ago.
