### PR TITLE
Carving: Prevent running segmentation when fore- or background labels are missing

### DIFF
--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -219,6 +219,13 @@ class CarvingGui(LabelingGui):
 
     def onSegmentButton(self):
         logger.debug("segment button clicked")
+        if not self.topLevelOperatorView.CanRunSegmentation.value:
+            QMessageBox.critical(
+                self,
+                "Unable to Run Segmentation",
+                "Both foreground and background labels are required to run segmentation.",
+            )
+            return
         bkPriorityValue = self.labelingDrawerUi.backgroundPrioritySpin.value()
         self.topLevelOperatorView.BackgroundPriority.setValue(bkPriorityValue)
         biasValue = self.labelingDrawerUi.noBiasBelowSpin.value()


### PR DESCRIPTION
This closes #2656 

The watershed can't handle either fore- or background labels being missing currently. I don't see why it couldn't, but fixing that in ilastiktools is a different scale of work.

So instead we quick-fix by preventing the user from running segmentation if one of the label types is missing.