### PR TITLE
mnt: wsdt package not used

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,6 @@ outputs:
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra 1.11.1=*_1033
-        - wsdt
         - xarray
         - z5py
       run_constrained:

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -37,7 +37,6 @@ dependencies:
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
   - vigra 1.11.1=*_1033
-  - wsdt
   - xarray
   - z5py
 

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -5,8 +5,6 @@
     "loggers": {
         "py.warnings": {  "level":"WARN" },
 
-        "wsdt": { "level": "DEBUG" },
-
         "__main__":                                                 { "level":"DEBUG" },
         "ilastik_main":                                             { "level":"INFO" },
         "thread_start":                                             { "level":"INFO" },


### PR DESCRIPTION
looks like this package isn't needed anymore in ilastik (functionality replaced by `vigra`/`elf`).