### PR TITLE
fix elf ws now returns uint64

### DIFF
--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -105,6 +105,8 @@ def parallel_watershed(
             f"processing block {block_index} {block.outerBlock.begin}-{block.outerBlock.end} took {btimer.seconds()}"
         )
 
+        # elf started returning uint64 in 0.46. Casting is (still) fine, as vigra is still used to produce the watershed.
+        ws_outer = ws_outer.astype("uint32")
         ws_inner = vigra.analysis.labelMultiArray(ws_outer[inner_local_slicing])
 
         labels[inner_slicing] = ws_inner
@@ -223,7 +225,7 @@ class OpWsdt(Operator):
                 self.ApplyNonmaxSuppression.value,
             )
 
-        result[..., 0] = ws
+        result[..., 0] = ws.astype("uint32")
 
         self.watershed_completed()
 

--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -10,7 +10,7 @@ import vigra
 from lazyflow.utility import OrderedSignal
 from lazyflow.request import Request
 from lazyflow.graph import Operator, InputSlot, OutputSlot
-from lazyflow.roi import roiToSlice, sliceToRoi
+from lazyflow.roi import roiToSlice
 from lazyflow.operators import OpBlockedArrayCache, OpMetadataInjector
 from lazyflow.operators.generic import OpPixelOperator
 from lazyflow.utility.timer import Timer
@@ -105,7 +105,8 @@ def parallel_watershed(
             f"processing block {block_index} {block.outerBlock.begin}-{block.outerBlock.end} took {btimer.seconds()}"
         )
 
-        # elf started returning uint64 in 0.46. Casting is (still) fine, as vigra is still used to produce the watershed.
+        # elf started returning uint64 in 0.46. Casting here is not dangerous.
+        # Up to now vigra is still used to produce the watershed in elf internally.
         ws_outer = ws_outer.astype("uint32")
         ws_inner = vigra.analysis.labelMultiArray(ws_outer[inner_local_slicing])
 
@@ -225,6 +226,8 @@ class OpWsdt(Operator):
                 self.ApplyNonmaxSuppression.value,
             )
 
+        # elf started returning uint64 in 0.46. Casting here is not dangerous.
+        # Up to now vigra is still used to produce the watershed in elf internally.
         result[..., 0] = ws.astype("uint32")
 
         self.watershed_completed()

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_Consistency.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_Consistency.py
@@ -32,8 +32,6 @@ from lazyflow.utility import Pipeline
 
 from ilastik.applets.wsdt.opWsdt import OpCachedWsdt, parallel_watershed
 
-from elf.segmentation.watershed import distance_transform_watershed
-
 
 DATA_PATH = os.path.join(os.path.split(__file__)[0], "../../data/inputdata/3d2c_Probabilities.h5")
 DATASET_NAME = "exported_data"


### PR DESCRIPTION
since 0.46, elf watershed returns `uint64`. As we do some further processing with `vigra` we need to cast to `uint32` (`uint64` not supported by `vigra`).

xref: https://github.com/constantinpape/elf/issues/68

(also removed an unused import in the tests)
