### PR TITLE
functionality to ignore multiple dirty propagations from same source

### DIFF
--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -631,21 +631,20 @@ class Operator(metaclass=OperatorMetaClass):
         # return self._debug_text
         return "setups: {}".format(self._setup_count)
 
-    def setAllDirty(self):
-        """set all outputs dirty and ignore subsequent dirty prop from same source
+    def propagateDirtyIfNewModTime(self):
+        """set all outputs dirty and ignore if _pending_dirty_mod_time is new
 
-        should never be called outside `propagateDirty`.
+        This ignores subsequent dirty prop from same source (=same _pending_dirty_mod_time)
+
+        Should only be called within `Operator.propagateDirty`.
+        See https://github.com/ilastik/ilastik/pull/2694
         """
+        assert self._pending_dirty_mod_time != -1
         if self._pending_dirty_mod_time <= self._previous_dirty_mod_time_buffer:
             return
 
         for slot in self.outputs.values():
             slot.setDirty((), _mod_time=self._pending_dirty_mod_time)
-
-
-#    @debug_text.setter
-#    def debug_text(self, text):
-#        self._debug_text = text
 
 
 def format_operator_stack(tb):

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -258,7 +258,7 @@ class Operator(metaclass=OperatorMetaClass):
         # keeps track of any setDirty calls on inputs slots
         self._previous_dirty_mod_time_buffer = -1
         # temporary variable during dirty notification to buffer the previous
-        # value. Used in `setAllDirty` in order to ignore multiple dirty
+        # value. Used in `propagateDirtyIfNewModTime` in order to ignore multiple dirty
         # notifications cause by the same upstream source
         self._pending_dirty_mod_time = -1
 

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -256,11 +256,11 @@ class Operator(metaclass=OperatorMetaClass):
         self._setup_count = 0
 
         # keeps track of any setDirty calls on inputs slots
-        self._last_dirty = -1
+        self._previous_dirty_mod_time_buffer = -1
         # temporary variable during dirty notification to buffer the previous
         # value. Used in `setAllDirty` in order to ignore multiple dirty
         # notifications cause by the same upstream source
-        self._previous_dirty = -1
+        self._pending_dirty_mod_time = -1
 
     @property
     def children(self):
@@ -636,11 +636,11 @@ class Operator(metaclass=OperatorMetaClass):
 
         should never be called outside `propagateDirty`.
         """
-        if self._last_dirty <= self._previous_dirty:
+        if self._pending_dirty_mod_time <= self._previous_dirty_mod_time_buffer:
             return
 
         for slot in self.outputs.values():
-            slot.setDirty(())
+            slot.setDirty((), _mod_time=self._pending_dirty_mod_time)
 
 
 #    @debug_text.setter

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -256,7 +256,7 @@ class Operator(metaclass=OperatorMetaClass):
         self._setup_count = 0
 
         # keeps track of any setDirty calls on inputs slots
-        self._previous_dirty_mod_time_buffer = -1
+        self._previous_dirty_mod_time = -1
         # temporary variable during dirty notification to buffer the previous
         # value. Used in `propagateDirtyIfNewModTime` in order to ignore multiple dirty
         # notifications cause by the same upstream source
@@ -640,7 +640,7 @@ class Operator(metaclass=OperatorMetaClass):
         See https://github.com/ilastik/ilastik/pull/2694
         """
         assert self._pending_dirty_mod_time != -1
-        if self._pending_dirty_mod_time <= self._previous_dirty_mod_time_buffer:
+        if self._pending_dirty_mod_time <= self._previous_dirty_mod_time:
             return
 
         for slot in self.outputs.values():

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -240,7 +240,7 @@ class OpTrainPixelwiseClassifierBlocked(Operator):
                 )
 
     def propagateDirty(self, slot, subindex, roi):
-        self.setAllDirty()
+        self.propagateDirtyIfNewModTime()
 
 
 class OpTrainVectorwiseClassifierBlocked(Operator):

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -240,7 +240,7 @@ class OpTrainPixelwiseClassifierBlocked(Operator):
                 )
 
     def propagateDirty(self, slot, subindex, roi):
-        self.Classifier.setDirty()
+        self.setAllDirty()
 
 
 class OpTrainVectorwiseClassifierBlocked(Operator):

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -311,7 +311,7 @@ class OpMultiArrayStacker(Operator):
             # Any upstream change will cause the whole output to be set dirty
             # Often enough this would happen eventually (e.g. stacking the output
             # of different Filter operators, all connected to the same input).
-            self.setAllDirty()
+            self.propagateDirtyIfNewModTime()
 
         else:
             assert False, "Unknown input slot."

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -307,24 +307,11 @@ class OpMultiArrayStacker(Operator):
         if not self.Output.ready():
             # If we aren't even fully configured, there's no need to notify downstream slots about dirtiness
             return
-        if inputSlot == self.AxisFlag or inputSlot == self.AxisIndex:
-            self.Output.setDirty(slice(None))
-
-        elif inputSlot == self.Images:
-            imageIndex = subindex[0]
-            axisflag = self.AxisFlag.value
-            axisIndex = self.Output.meta.axistags.index(axisflag)
-
-            if len(roi.start) == len(self.Output.meta.shape):
-                # axis is already in the input
-                roi.start[axisIndex] += self.intervals[imageIndex][0]
-                roi.stop[axisIndex] += self.intervals[imageIndex][0]
-                self.Output.setDirty(roi)
-            else:
-                # insert axis into roi
-                newroi = copy.copy(roi)
-                newroi = newroi.insertDim(axisIndex, self.intervals[imageIndex][0], self.intervals[imageIndex][0] + 1)
-                self.Output.setDirty(newroi)
+        if inputSlot in (self.AxisFlag, self.AxisIndex, self.Images):
+            # Any upstream change will cause the whole output to be set dirty
+            # Often enough this would happen eventually (e.g. stacking the output
+            # of different Filter operators, all connected to the same input).
+            self.setAllDirty()
 
         else:
             assert False, "Unknown input slot."

--- a/lazyflow/operators/opCompressedUserLabelArray.py
+++ b/lazyflow/operators/opCompressedUserLabelArray.py
@@ -31,6 +31,8 @@ import collections
 import numpy
 import vigra
 
+import time
+
 # Lazyflow
 from lazyflow.graph import InputSlot, OutputSlot
 from lazyflow.roi import (
@@ -191,7 +193,7 @@ class OpCompressedUserLabelArray(OpUnmanagedCompressedCache):
 
         for block_roi in changed_block_rois:
             # FIXME: Shouldn't this dirty notification be handled in OpUnmanagedCompressedCache?
-            self.Output.setDirty(*block_roi)
+            self.Output.setDirty(*block_roi, reset_modtime=True)
 
     def execute(self, slot, subindex, roi, destination):
         if slot == self.Output:
@@ -450,7 +452,7 @@ class OpCompressedUserLabelArray(OpUnmanagedCompressedCache):
             max_label = max(max_label, cleaned_block_data.max())
 
             # We could wait to send out one big dirty notification (instead of one per block),
-            # But that might result in a lot of unecessarily dirty pixels in cases when the
+            # But that might result in a lot of unnecessarily dirty pixels in cases when the
             # new_pixels were mostly empty (such as when importing labels from disk).
             # That's bad for downstream operators like OpFeatureMatrixCache
             # So instead, we only send notifications for the blocks that were touched.
@@ -458,7 +460,7 @@ class OpCompressedUserLabelArray(OpUnmanagedCompressedCache):
             # During project import, this is slightly worse.
             # But during label import from disk, this is very important.a
             # FIXME: Shouldn't this notification be triggered from within OpUnmanagedCompressedCache?
-            self.Output.setDirty(*block_roi)
+            self.Output.setDirty(*block_roi, reset_modtime=True)
 
         return max_label  # Internal use: Return max label
 

--- a/lazyflow/operators/opCompressedUserLabelArray.py
+++ b/lazyflow/operators/opCompressedUserLabelArray.py
@@ -193,7 +193,7 @@ class OpCompressedUserLabelArray(OpUnmanagedCompressedCache):
 
         for block_roi in changed_block_rois:
             # FIXME: Shouldn't this dirty notification be handled in OpUnmanagedCompressedCache?
-            self.Output.setDirty(*block_roi, reset_modtime=True)
+            self.Output.setDirty(*block_roi)
 
     def execute(self, slot, subindex, roi, destination):
         if slot == self.Output:
@@ -460,7 +460,7 @@ class OpCompressedUserLabelArray(OpUnmanagedCompressedCache):
             # During project import, this is slightly worse.
             # But during label import from disk, this is very important.a
             # FIXME: Shouldn't this notification be triggered from within OpUnmanagedCompressedCache?
-            self.Output.setDirty(*block_roi, reset_modtime=True)
+            self.Output.setDirty(*block_roi)
 
         return max_label  # Internal use: Return max label
 

--- a/lazyflow/operators/opCompressedUserLabelArray.py
+++ b/lazyflow/operators/opCompressedUserLabelArray.py
@@ -31,8 +31,6 @@ import collections
 import numpy
 import vigra
 
-import time
-
 # Lazyflow
 from lazyflow.graph import InputSlot, OutputSlot
 from lazyflow.roi import (

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -932,7 +932,9 @@ class Slot(object):
                 try:
                     self.operator.propagateDirty(self.top_level_slot, self.subindex, roi)
                 finally:
-                    self.operator._previous_dirty_mod_time_buffer = self.operator._pending_dirty_mod_time
+                    self.operator._previous_dirty_mod_time_buffer = max(
+                        self.operator._previous_dirty_mod_time_buffer, self.operator._pending_dirty_mod_time
+                    )
                     self.operator._pending_dirty_mod_time = -1
 
     def __iter__(self):

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -932,8 +932,8 @@ class Slot(object):
                 try:
                     self.operator.propagateDirty(self.top_level_slot, self.subindex, roi)
                 finally:
-                    self.operator._previous_dirty_mod_time_buffer = max(
-                        self.operator._previous_dirty_mod_time_buffer, self.operator._pending_dirty_mod_time
+                    self.operator._previous_dirty_mod_time = max(
+                        self.operator._previous_dirty_mod_time, self.operator._pending_dirty_mod_time
                     )
                     self.operator._pending_dirty_mod_time = -1
 

--- a/tests/test_lazyflow/test_graph/test_dirty_modtime.py
+++ b/tests/test_lazyflow/test_graph/test_dirty_modtime.py
@@ -30,6 +30,21 @@ def test_op_mod_time(graph):
         assert op._pending_dirty_mod_time == -1
 
 
+def test_op_lower_mod_time_does_not_modify(graph):
+    """setDirty _mod_time modifies parent op correctly"""
+    op = MockOp(graph=graph)
+
+    assert op._pending_dirty_mod_time == -1
+
+    op.Input.setDirty((), _mod_time=42)
+    assert op._previous_dirty_mod_time_buffer == 42
+    assert op._pending_dirty_mod_time == -1
+
+    op.Input.setDirty((), _mod_time=41)
+    assert op._previous_dirty_mod_time_buffer == 42
+    assert op._pending_dirty_mod_time == -1
+
+
 def test_op_mod_time_chain(graph):
     """mod_time is propagated to all ops in the chain"""
     op1 = MockOp(graph=graph)

--- a/tests/test_lazyflow/test_graph/test_dirty_modtime.py
+++ b/tests/test_lazyflow/test_graph/test_dirty_modtime.py
@@ -22,11 +22,12 @@ def test_op_mod_time(graph):
     """setDirty _mod_time modifies parent op correctly"""
     op = MockOp(graph=graph)
 
-    assert op._last_dirty == -1
+    assert op._pending_dirty_mod_time == -1
 
     for mod_time in (1, 2, 13, 42):
         op.Input.setDirty((), _mod_time=mod_time)
-        assert op._last_dirty == mod_time
+        assert op._previous_dirty_mod_time_buffer == mod_time
+        assert op._pending_dirty_mod_time == -1
 
 
 def test_op_mod_time_chain(graph):
@@ -35,61 +36,38 @@ def test_op_mod_time_chain(graph):
     op2 = MockOp(graph=graph)
     op2.Input.connect(op1.Output)
 
-    assert op1._last_dirty == -1
-    assert op2._last_dirty == -1
+    assert op1._previous_dirty_mod_time_buffer == -1
+    assert op2._previous_dirty_mod_time_buffer == -1
 
     for mod_time in (1, 2, 13, 42):
         op1.Input.setDirty((), _mod_time=mod_time)
-        assert op1._last_dirty == mod_time
-        assert op2._last_dirty == mod_time
+        assert op1._previous_dirty_mod_time_buffer == mod_time
+        assert op2._previous_dirty_mod_time_buffer == mod_time
+        assert op1._pending_dirty_mod_time == -1
+        assert op2._pending_dirty_mod_time == -1
 
 
 def test_op_mod_time_source(graph):
-    """setDirty on Input should always modify OPs ._last_dirty"""
+    """setDirty on Input should always modify OPs ._previous_dirty_mod_time_buffer"""
     op = MockOp(graph=graph)
 
-    assert op._last_dirty == -1
+    assert op._previous_dirty_mod_time_buffer == -1
+    assert op._pending_dirty_mod_time == -1
 
     op.Input.setDirty(())
 
-    assert op._last_dirty > -1
-
-
-def test_op_reset_mod_time(graph):
-    """setDirty on Input should always modify OPs ._last_dirty"""
-    op = MockOp(graph=graph)
-
-    assert op._last_dirty == -1
-
-    op.Input.setDirty((), _mod_time=-2)
-
-    assert op._last_dirty == -2
-
-    op.Input.setDirty((), reset_modtime=True)
-
-    assert op._last_dirty > -2
+    assert op._previous_dirty_mod_time_buffer > -1
 
 
 def test_op_output_dirty(graph):
-    """setDirty on output should not modify OPs ._last_dirty"""
+    """setDirty on output should not modify OPs ._previous_dirty_mod_time_buffer"""
     op = MockOp(graph=graph)
 
-    assert op._last_dirty == -1
+    assert op._previous_dirty_mod_time_buffer == -1
 
     op.Output.setDirty(())
 
-    assert op._last_dirty == -1
-
-
-def test_op_output_dirty_reset(graph):
-    """setDirty on output should not modify OPs ._last_dirty"""
-    op = MockOp(graph=graph)
-
-    assert op._last_dirty == -1
-
-    op.Output.setDirty((), reset_modtime=True)
-
-    assert op._last_dirty == -1
+    assert op._previous_dirty_mod_time_buffer == -1
 
 
 class SourceOp(Operator):
@@ -141,7 +119,7 @@ def test_op_all_dirty(graph):
     op_source.Input.setDirty((), _mod_time=42)
 
     dirty_cb.assert_called_once()
-    assert op_all_dirty._last_dirty == 42
+    assert op_all_dirty._previous_dirty_mod_time_buffer == 42
 
 
 class MockOpLastDirty(Operator):
@@ -150,43 +128,43 @@ class MockOpLastDirty(Operator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._last_dirty = 13
+        self._previous_dirty_mod_time_buffer = 13
 
     def setupOutputs(self):
         self.Output.meta.assignFrom(self.Input.meta)
 
     def propagateDirty(self, slot, subindex, roi):
-        assert self._previous_dirty == 13
+        assert self._previous_dirty_mod_time_buffer == 13
         self.Output.setDirty(())
 
     def execute(self, slot, subindex, roi):
         pass
 
 
-def test_previous_dirty_set(graph):
+def test_previous_dirty_mod_time_buffer_set(graph):
     op = MockOpLastDirty(graph=graph)
-    assert op._previous_dirty == -1
-    assert op._last_dirty == 13
+    assert op._pending_dirty_mod_time == -1
+    assert op._previous_dirty_mod_time_buffer == 13
 
     op.Input.setDirty((), _mod_time=42)
-    assert op._previous_dirty == -1
-    assert op._last_dirty == 42
+    assert op._pending_dirty_mod_time == -1
+    assert op._previous_dirty_mod_time_buffer == 42
 
 
 class MockOpLastDirtyEx(MockOpLastDirty):
     def propagateDirty(self, slot, subindex, roi):
-        assert self._previous_dirty == 13
+        assert self._previous_dirty_mod_time_buffer == 13
         self.Output.setDirty(())
         raise ValueError()
 
 
-def test_previous_dirty_ex(graph):
+def test_previous_dirty_mod_time_buffer_ex(graph):
     op = MockOpLastDirtyEx(graph=graph)
-    assert op._previous_dirty == -1
-    assert op._last_dirty == 13
+    assert op._pending_dirty_mod_time == -1
+    assert op._previous_dirty_mod_time_buffer == 13
 
     with pytest.raises(ValueError):
         op.Input.setDirty((), _mod_time=42)
 
-    assert op._previous_dirty == -1
-    assert op._last_dirty == 42
+    assert op._pending_dirty_mod_time == -1
+    assert op._previous_dirty_mod_time_buffer == 42

--- a/tests/test_lazyflow/test_graph/test_dirty_modtime.py
+++ b/tests/test_lazyflow/test_graph/test_dirty_modtime.py
@@ -1,0 +1,192 @@
+from lazyflow.graph import Operator, InputSlot, OutputSlot
+
+from unittest import mock
+import pytest
+
+
+class MockOp(Operator):
+    Input = InputSlot(value=(10,))
+    Output = OutputSlot()
+
+    def setupOutputs(self):
+        self.Output.meta.assignFrom(self.Input.meta)
+
+    def propagateDirty(self, slot, subindex, roi):
+        self.Output.setDirty(())
+
+    def execute(self, slot, subindex, roi):
+        pass
+
+
+def test_op_mod_time(graph):
+    """setDirty _mod_time modifies parent op correctly"""
+    op = MockOp(graph=graph)
+
+    assert op._last_dirty == -1
+
+    for mod_time in (1, 2, 13, 42):
+        op.Input.setDirty((), _mod_time=mod_time)
+        assert op._last_dirty == mod_time
+
+
+def test_op_mod_time_chain(graph):
+    """mod_time is propagated to all ops in the chain"""
+    op1 = MockOp(graph=graph)
+    op2 = MockOp(graph=graph)
+    op2.Input.connect(op1.Output)
+
+    assert op1._last_dirty == -1
+    assert op2._last_dirty == -1
+
+    for mod_time in (1, 2, 13, 42):
+        op1.Input.setDirty((), _mod_time=mod_time)
+        assert op1._last_dirty == mod_time
+        assert op2._last_dirty == mod_time
+
+
+def test_op_mod_time_source(graph):
+    """setDirty on Input should always modify OPs ._last_dirty"""
+    op = MockOp(graph=graph)
+
+    assert op._last_dirty == -1
+
+    op.Input.setDirty(())
+
+    assert op._last_dirty > -1
+
+
+def test_op_reset_mod_time(graph):
+    """setDirty on Input should always modify OPs ._last_dirty"""
+    op = MockOp(graph=graph)
+
+    assert op._last_dirty == -1
+
+    op.Input.setDirty((), _mod_time=-2)
+
+    assert op._last_dirty == -2
+
+    op.Input.setDirty((), reset_modtime=True)
+
+    assert op._last_dirty > -2
+
+
+def test_op_output_dirty(graph):
+    """setDirty on output should not modify OPs ._last_dirty"""
+    op = MockOp(graph=graph)
+
+    assert op._last_dirty == -1
+
+    op.Output.setDirty(())
+
+    assert op._last_dirty == -1
+
+
+def test_op_output_dirty_reset(graph):
+    """setDirty on output should not modify OPs ._last_dirty"""
+    op = MockOp(graph=graph)
+
+    assert op._last_dirty == -1
+
+    op.Output.setDirty((), reset_modtime=True)
+
+    assert op._last_dirty == -1
+
+
+class SourceOp(Operator):
+    Input = InputSlot(value=(10,))
+
+    Output1 = OutputSlot()
+    Output2 = OutputSlot()
+
+    def setupOutputs(self):
+        self.Output1.meta.assignFrom(self.Input.meta)
+        self.Output2.meta.assignFrom(self.Input.meta)
+
+    def propagateDirty(self, slot, subindex, roi):
+        self.Output1.setDirty()
+        self.Output2.setDirty()
+
+    def execute(self, slot, subindex, roi):
+        pass
+
+
+class AllDirtyOp(Operator):
+    Input1 = InputSlot()
+    Input2 = InputSlot()
+
+    Output = OutputSlot()
+
+    def setupOutputs(self):
+        self.Output.meta.assignFrom(self.Input1.meta)
+
+    def propagateDirty(self, slot, subindex, roi):
+        self.setAllDirty()
+
+    def execute(self, slot, subindex, roi):
+        pass
+
+
+def test_op_all_dirty(graph):
+    """using setAllDirty prevents subsequent dirty-prop with same mod_time"""
+    op_source = SourceOp(graph=graph)
+
+    op_all_dirty = AllDirtyOp(graph=graph)
+
+    dirty_cb = mock.Mock()
+    op_all_dirty.Output.notifyDirty(dirty_cb)
+
+    op_all_dirty.Input1.connect(op_source.Output1)
+    op_all_dirty.Input2.connect(op_source.Output2)
+
+    op_source.Input.setDirty((), _mod_time=42)
+
+    dirty_cb.assert_called_once()
+    assert op_all_dirty._last_dirty == 42
+
+
+class MockOpLastDirty(Operator):
+    Input = InputSlot(value=(10,))
+    Output = OutputSlot()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._last_dirty = 13
+
+    def setupOutputs(self):
+        self.Output.meta.assignFrom(self.Input.meta)
+
+    def propagateDirty(self, slot, subindex, roi):
+        assert self._previous_dirty == 13
+        self.Output.setDirty(())
+
+    def execute(self, slot, subindex, roi):
+        pass
+
+
+def test_previous_dirty_set(graph):
+    op = MockOpLastDirty(graph=graph)
+    assert op._previous_dirty == -1
+    assert op._last_dirty == 13
+
+    op.Input.setDirty((), _mod_time=42)
+    assert op._previous_dirty == -1
+    assert op._last_dirty == 42
+
+
+class MockOpLastDirtyEx(MockOpLastDirty):
+    def propagateDirty(self, slot, subindex, roi):
+        assert self._previous_dirty == 13
+        self.Output.setDirty(())
+        raise ValueError()
+
+
+def test_previous_dirty_ex(graph):
+    op = MockOpLastDirtyEx(graph=graph)
+    assert op._previous_dirty == -1
+    assert op._last_dirty == 13
+
+    with pytest.raises(ValueError):
+        op.Input.setDirty((), _mod_time=42)
+
+    assert op._previous_dirty == -1
+    assert op._last_dirty == 42

--- a/tests/test_lazyflow/test_graph/test_dirty_modtime.py
+++ b/tests/test_lazyflow/test_graph/test_dirty_modtime.py
@@ -113,14 +113,14 @@ class AllDirtyOp(Operator):
         self.Output.meta.assignFrom(self.Input1.meta)
 
     def propagateDirty(self, slot, subindex, roi):
-        self.setAllDirty()
+        self.propagateDirtyIfNewModTime()
 
     def execute(self, slot, subindex, roi):
         pass
 
 
 def test_op_all_dirty(graph):
-    """using setAllDirty prevents subsequent dirty-prop with same mod_time"""
+    """using propagateDirtyIfNewModTime prevents subsequent dirty-prop with same mod_time"""
     op_source = SourceOp(graph=graph)
 
     op_all_dirty = AllDirtyOp(graph=graph)


### PR DESCRIPTION
Dirty propagation in ilastik goes depth-first. It is possible for dirtiness to propagate to the same target via multiple upstream paths. This commit adds the concept of a "modification time" (`mod_time` in the code) to encode sources of dirtiness.
Operators will keep track of the last `mod_time` they've seen (during dirty propagation) and can ignore it, if it is already known (see `Operator.setAllDirty`).

In more complicated graphs like in autocontext, this solves heavy delays when annotating.

<img width="1786" alt="image" src="https://user-images.githubusercontent.com/24434157/232036236-5e6f2f21-e4cf-41c2-a9a7-eeea2057c7f0.png">

To illustrate the problem, consider the above DAG, a "simplified" auto-context-like setup. In normal dirty prop, when setting the input dirty, the following sequence would occur:

```
                                    _____________________ BLOCK A ____
                                   |                                  |
Input --> Filter1 --> Stacker1 --> Filter4 --> Stacker2               |
                               --> Filter5 --> Stacker2               |
                               --> Filter6 --> Stacker2 ______________|
      --> Filter 2 --> Stacker1 --> BLOCK A
      --> Filter 3 --> Stacker1 --> BLOCK A
```

Here, via BlockA Stacker2 will in total emit 9 dirty signals.

With the changes from this PR, any change in Input1 will be labeled with `mod_time` - downstream operators can choose to ignore subsequent dirty propagation:

```
Input --> Filter1 --> Stacker1 --> BLOCK A
      --> Filter 2 --> Stacker1: no Dirty prop IGNORED
      --> Filter 3 --> Stacker1: no Dirty prop IGNORED
```
Here, via BlockA, Stacker2 will only propagate dirtiness once.

For reference, with a real world Autocontext project with 6 lanes, the latency for annoations in the first stage went down from 16 seconds to 0.25 seconds.

Despite being very defensive here with this new feature, I want to keep this PR in a single commit, to make it easily revertible (meaning I'll squash any changes, if necessary).

One of the side effects here is that `MultiArrayStacker` will _not_ emit any fine grained dirty signals anymore, and always set complete output roi dirty.

For more simple workflows this optimization doesn't make a big difference. It's really only apparent if there are multiple "merging" operators, like `OpMultiArrayStacker` and the classifier operators.

For operators that do not use `setAllDirty`, nothing changes in behavior (still, the `mod_time` is propagated through the whole graph).