### PR TITLE
Add Trainable Domain Adaptation workflow

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,6 +44,8 @@ outputs:
         - marching_cubes
         - ndstructs
         - nifty
+        # need to update our packages to be compatible with pandas 2 API
+        - pandas <2
         - psutil
         - pyopengl
         - pyqt 5.12.*

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -23,6 +23,8 @@ dependencies:
   - marching_cubes
   - ndstructs
   - nifty
+  # need to update our packages to be compatible with pandas 2 API
+  - pandas <2
   - psutil
   - pyopengl
   - pyqt 5.12.*

--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -179,7 +179,9 @@ class ModelStateControl(QWidget):
         super().__init__(parent)
         self.threadRouter = ThreadRouter(self)
         self._preDownloadChecks = set()
+        self._setup_ui()
 
+    def _setup_ui(self):
         layout = QVBoxLayout()
 
         self.modelSourceEdit = ModelSourceEdit(self)
@@ -192,7 +194,6 @@ class ModelStateControl(QWidget):
         bottom_layout.addWidget(self.modelControlButton)
         layout.addWidget(self.modelSourceEdit)
         layout.addLayout(bottom_layout)
-        self.setLayout(layout)
 
     def setTiktorchController(self, tiktorchController):
         self._tiktorchController = tiktorchController

--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -729,7 +729,7 @@ class NNClassGui(LabelingGui):
         else:
             self._viewerControlUi.checkShowPredictions.setCheckState(Qt.PartiallyChecked)
 
-    def cc(self, *args, **kwargs):
+    def cancel(self, *args, **kwargs):
         self.cancel_src.cancel()
 
     @threadRouted

--- a/ilastik/applets/neuralNetwork/opNNClassificationDataExport.py
+++ b/ilastik/applets/neuralNetwork/opNNClassificationDataExport.py
@@ -23,10 +23,6 @@ from ilastik.applets.dataExport.opDataExport import OpDataExport
 
 
 class OpNNClassificationDataExport(OpDataExport):
-    """
-    Subclass placeholder
-    """
-
     PmapColors = InputSlot()
     LabelNames = InputSlot()
 

--- a/ilastik/applets/trainableDomainAdaptation/__init__.py
+++ b/ilastik/applets/trainableDomainAdaptation/__init__.py
@@ -1,0 +1,1 @@
+from .trainableDomainAdaptationApplet import TrainableDomainAdaptationApplet

--- a/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
+++ b/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
@@ -79,11 +79,14 @@ class BioImageModelCombo(QComboBox):
             logger.error(f"Error fetching models from bioimage.io: {BIOIMAGEIO_COLLECTION_ERROR}")
             return
 
-        enhancer_models = [m for m in BIOIMAGEIO_COLLECTION["collection"] if "shallow2deep" in m["tags"]]
-
         self.addItem("choose model..", {})
-        for m in enhancer_models:
-            self.addItem(m["name"], m)
+        self.insertSeparator(1)
+
+        for model in BIOIMAGEIO_COLLECTION["collection"]:
+            if "shallow2deep" in model["tags"]:
+                self.addItem(model["name"], model)
+
+        self.insertSeparator(self.count())
         self.addItem("select file", BioImageModelCombo._SELECT_FILE)
 
 

--- a/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
+++ b/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
@@ -1,0 +1,122 @@
+import logging
+
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QComboBox, QHBoxLayout, QLabel, QToolButton, QVBoxLayout
+
+from ilastik.applets.neuralNetwork.modelStateControl import ModelStateControl, display_template
+from ilastik.utility.gui import ThreadRouter, silent_qobject
+
+logger = logging.getLogger(__file__)
+
+
+class BioImageModelCombo(QComboBox):
+    collections_url = "https://raw.githubusercontent.com/bioimage-io/collection-bioimage-io/gh-pages/collection.json"
+    _SELECT_FILE = object()
+    _REMOVE_FILE = object()
+
+    modelDeleted = pyqtSignal()
+    modelOpenFromFile = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setEditable(False)
+        self.refresh()
+        self.currentIndexChanged.connect(self.onIndexChange)
+
+    def getModelSource(self):
+        idx = self.currentIndex()
+        data = self.itemData(idx)
+        if data == BioImageModelCombo._SELECT_FILE:
+            return ""
+        if data:
+            return data["id"]
+
+    def clear(self):
+        super().clear()
+        self.setToolTip("")
+
+    def setEmptyState(self):
+        self.refresh()
+        self.setEnabled(True)
+
+    def setModelInfo(self, model_source, model_info, template=display_template):
+        # TODO (k-dominik)
+        pass
+
+    def onIndexChange(self, idx):
+        item_data = self.itemData(idx)
+        if item_data == BioImageModelCombo._REMOVE_FILE:
+            logger.debug("model remove requested")
+            self.modelDeleted.emit()
+        elif item_data == BioImageModelCombo._SELECT_FILE:
+            logger.debug("open model from file")
+            self.modelOpenFromFile.emit()
+
+    def setModelDataAvailableState(self, model_source, model_info):
+        idx = self.findText(model_info.name)
+        if idx == -1:
+            # from file
+            with silent_qobject(self) as silent_self:
+                silent_self.insertItem(1, model_info.name, model_info)
+        else:
+            self.setCurrentText(self.itemText(idx))
+        self.setItemText(0, "remove model")
+        self.setItemData(0, BioImageModelCombo._REMOVE_FILE)
+
+        self.setEnabled(True)
+
+    def setReadyState(self, model_source, model_info):
+        self.setModelDataAvailableState(model_source, model_info)
+        self.setEnabled(False)
+
+    def refresh(self):
+        # do this in the background, indicate busyness
+        from bioimageio.spec.shared import BIOIMAGEIO_COLLECTION, BIOIMAGEIO_COLLECTION_ERROR
+
+        self.clear()
+
+        if BIOIMAGEIO_COLLECTION is None:
+            logger.error(f"Error fetching models from bioimage.io: {BIOIMAGEIO_COLLECTION_ERROR}")
+            return
+
+        enhancer_models = [m for m in BIOIMAGEIO_COLLECTION["collection"] if "shallow2deep" in m["tags"]]
+
+        self.addItem("choose model..", {})
+        for m in enhancer_models:
+            self.addItem(m["name"], m)
+        self.addItem("select file", BioImageModelCombo._SELECT_FILE)
+
+
+class EnhancerModelStateControl(ModelStateControl):
+    uploadDone = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.modelSourceEdit.modelOpenFromFile.connect(self.onModelInfoRequested)
+
+    def _setup_ui(self):
+        self.threadRouter = ThreadRouter(self)
+        self._preDownloadChecks = set()
+
+        layout = QVBoxLayout()
+
+        self.modelSourceEdit = BioImageModelCombo(self)
+        self.statusLabel = QLabel(self)
+        self.statusLabel.setText("status...")
+        self.modelControlButton = QToolButton(self)
+        self.modelControlButton.setText("...")
+        self.modelControlButton.setToolTip("Click here to check model details, initialize, or un-initialize the model")
+        self.statusLabel.setVisible(False)
+
+        top_layout = QHBoxLayout()
+        top_layout.addWidget(self.modelSourceEdit)
+        top_layout.addWidget(self.modelControlButton)
+
+        bottom_layout = QHBoxLayout()
+        bottom_layout.addWidget(self.statusLabel)
+        bottom_layout.addStretch()
+
+        layout.addLayout(top_layout)
+        layout.addLayout(bottom_layout)
+        self.setLayout(layout)

--- a/ilastik/applets/trainableDomainAdaptation/opTrainableDomainAdaptation.py
+++ b/ilastik/applets/trainableDomainAdaptation/opTrainableDomainAdaptation.py
@@ -1,0 +1,94 @@
+import logging
+
+from ilastik.utility import OpMultiLaneWrapper
+from lazyflow import stype
+from lazyflow.graph import InputSlot, OutputSlot
+from lazyflow.operators.generic import OpMultiChannelSelector
+
+from ilastik.applets.neuralNetwork.opNNclass import OpBlockShape as OpNNBlockShape
+from ilastik.applets.neuralNetwork.opNNclass import OpPredictionPipeline as OpNNPredictionPipeline
+from ilastik.applets.pixelClassification.opPixelClassification import OpPixelClassification
+
+logger = logging.getLogger(__name__)
+
+
+class OpTrainableDomainAdaptation(OpPixelClassification):
+    name = "OpTrainableDomainAdaptation"
+    category = "Top-level"
+    SelectedChannels = InputSlot(value=[])
+    OverlayImages = InputSlot(level=1, optional=True)
+    BIOModel = InputSlot(stype=stype.Opaque, nonlane=True)
+    # Contains cached model info
+    ModelSession = InputSlot()
+    ServerConfig = InputSlot(stype=stype.Opaque, nonlane=True)
+
+    NumNNClasses = InputSlot()
+    FreezeNNPredictions = InputSlot(stype="bool", value=False, nonlane=True)
+
+    NNClassifier = OutputSlot()
+    EnhancerNetworkInput = OutputSlot(level=1)
+
+    NNPredictionProbabilities = OutputSlot(
+        level=1
+    )  # Classification predictions (via feature cache for interactive speed)
+    NNPredictionProbabilityChannels = OutputSlot(level=2)  # Classification predictions, enumerated by channel
+    CachedNNPredictionProbabilities = OutputSlot(level=1)
+
+    def __init__(self, *args, connectionFactory, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._connectionFactory = connectionFactory
+
+        self.FreezeNNPredictions.setValue(True)
+        self.opSelectProbs = OpMultiLaneWrapper(
+            OpMultiChannelSelector, parent=self, broadcastingSlotNames=["SelectedChannels"]
+        )
+        self.opSelectProbs.SelectedChannels.connect(self.SelectedChannels)
+        self.opSelectProbs.Input.connect(self.opPredictionPipeline.CachedPredictionProbabilities)
+        self.EnhancerNetworkInput.connect(self.opSelectProbs.Output)
+
+        # NN related connections
+        self.opNNBlockShape = OpMultiLaneWrapper(OpNNBlockShape, parent=self)
+        self.opNNBlockShape.RawImage.connect(self.opSelectProbs.Output)
+        self.opNNBlockShape.ModelSession.connect(self.ModelSession)
+
+        self.opNNPredictionPipeline = OpMultiLaneWrapper(OpNNPredictionPipeline, parent=self)
+        self.opNNPredictionPipeline.RawImage.connect(self.opSelectProbs.Output)
+        self.opNNPredictionPipeline.Classifier.connect(self.ModelSession)
+        self.opNNPredictionPipeline.NumClasses.connect(self.NumNNClasses)
+        self.opNNPredictionPipeline.FreezePredictions.connect(self.FreezeNNPredictions)
+
+        self.NNPredictionProbabilities.connect(self.opNNPredictionPipeline.PredictionProbabilities)
+        self.CachedNNPredictionProbabilities.connect(self.opNNPredictionPipeline.CachedPredictionProbabilities)
+        self.NNPredictionProbabilityChannels.connect(self.opNNPredictionPipeline.PredictionProbabilityChannels)
+
+    def setupOutputs(self):
+        super().setupOutputs()
+        if self.opNNBlockShape.BlockShapeInference.ready():
+            self.opNNPredictionPipeline.BlockShape.connect(self.opNNBlockShape.BlockShapeInference)
+
+    def cleanUp(self):
+        try:
+            self.ModelSession.value.close()
+        except Exception as e:
+            logger.warning(e)
+
+        super().cleanUp()
+
+    def update_config(self, partial_config: dict):
+        self.ClassifierFactory.meta.hparams = partial_config
+
+        def _send_hparams(slot):
+            classifierFactory = self.ClassifierFactory[:].wait()[0]
+            classifierFactory.update_config(self.ClassifierFactory.meta.hparams)
+
+        if not self.ClassifierFactory.ready():
+            self.ClassifierFactory.notifyReady(_send_hparams)
+        else:
+            classifierFactory = self.ClassifierFactory[:].wait()[0]
+            classifierFactory.update_config(partial_config)
+
+    def propagateDirty(self, slot, subindex, roi):
+        # Nothing to do here: All outputs are directly connected to
+        #  internal operators that handle their own dirty propagation.
+        self.PredictionProbabilityChannels.setDirty(slice(None))
+        super().propagateDirty(slot, subindex, roi)

--- a/ilastik/applets/trainableDomainAdaptation/tiktorchController.py
+++ b/ilastik/applets/trainableDomainAdaptation/tiktorchController.py
@@ -1,0 +1,18 @@
+from ilastik.applets.neuralNetwork.tiktorchController import BIOModelData, TiktorchOperatorModel
+
+
+class TrainableDomaninAdaptationTiktorchOperatorModel(TiktorchOperatorModel):
+    def clear(self):
+        self._state = self.State.Empty
+        self._operator.BIOModel.setValue(None)
+        self._operator.ModelSession.setValue(None)
+        self._operator.NumNNClasses.setValue(None)
+
+    def setModel(self, bioModelData: BIOModelData):
+        self._operator.NumNNClasses.disconnect()
+        self._operator.BIOModel.setValue(bioModelData)
+
+    def setSession(self, session):
+        self._operator.NumNNClasses.disconnect()
+        self._operator.ModelSession.setValue(session)
+        self._operator.NumNNClasses.setValue(self.modelData.numClasses)

--- a/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationApplet.py
+++ b/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationApplet.py
@@ -1,0 +1,58 @@
+from ilastik.applets.neuralNetwork.tiktorchController import TiktorchController
+from ilastik.applets.pixelClassification import PixelClassificationApplet, PixelClassificationSerializer
+
+from .opTrainableDomainAdaptation import OpTrainableDomainAdaptation
+from .tiktorchController import TrainableDomaninAdaptationTiktorchOperatorModel
+from .trainableDomainAdaptationSerializer import TrainableDomainAdaptationSerializer
+
+
+class TrainableDomainAdaptationApplet(PixelClassificationApplet):
+    """
+    Implements the pixel classification "applet", which allows the ilastik shell to use it.
+    """
+
+    def __init__(self, workflow, projectFileGroupName, connectionFactory):
+        self._topLevelOperator = OpTrainableDomainAdaptation(parent=workflow, connectionFactory=connectionFactory)
+
+        def on_classifier_changed(slot, roi):
+            if (
+                self._topLevelOperator.classifier_cache.Output.ready()
+                and self._topLevelOperator.classifier_cache.fixAtCurrent.value is True
+                and self._topLevelOperator.classifier_cache.Output.value is None
+            ):
+                # When the classifier is deleted (e.g. because the number of features has changed,
+                #  then notify the workflow. (Export applet should be disabled.)
+                self.appletStateUpdateRequested()
+
+        self._topLevelOperator.classifier_cache.Output.notifyDirty(on_classifier_changed)
+
+        super(PixelClassificationApplet, self).__init__("Training")
+
+        # We provide two independent serializing objects:
+        #  one for the current scheme and one for importing old projects.
+        self._serializableItems = [
+            PixelClassificationSerializer(self._topLevelOperator, projectFileGroupName),
+            TrainableDomainAdaptationSerializer(self._topLevelOperator, projectFileGroupName),
+        ]
+
+        self._gui = None
+
+        # GUI needs access to the serializer to enable/disable prediction storage
+        self.predictionSerializer = self._serializableItems[0]
+
+        # FIXME: For now, we can directly connect the progress signal from the classifier training operator
+        #  directly to the applet's overall progress signal, because it's the only thing we report progress for at the moment.
+        # If we start reporting progress for multiple tasks that might occur simulatneously,
+        #  we'll need to aggregate the progress updates.
+        self._topLevelOperator.opTrain.progressSignal.subscribe(self.progressSignal)
+
+        self.tiktorchOpModel = TrainableDomaninAdaptationTiktorchOperatorModel(self.topLevelOperator)
+        self.tiktorchController = TiktorchController(self.tiktorchOpModel, connectionFactory)
+
+    @property
+    def singleLaneGuiClass(self):
+        from .trainableDomainAdaptationGui import (  # prevent imports of QT classes in headless mode
+            TrainableDomainAdaptationGui,
+        )
+
+        return TrainableDomainAdaptationGui

--- a/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationApplet.py
+++ b/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationApplet.py
@@ -51,8 +51,7 @@ class TrainableDomainAdaptationApplet(PixelClassificationApplet):
 
     @property
     def singleLaneGuiClass(self):
-        from .trainableDomainAdaptationGui import (  # prevent imports of QT classes in headless mode
-            TrainableDomainAdaptationGui,
-        )
+        # prevent imports of QT classes in headless mode
+        from .trainableDomainAdaptationGui import TrainableDomainAdaptationGui
 
         return TrainableDomainAdaptationGui

--- a/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationGui.py
+++ b/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationGui.py
@@ -1,0 +1,227 @@
+import logging
+from functools import partial
+
+import sip
+from PyQt5.QtCore import Qt, QTimer, pyqtSlot
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QAction, QColorDialog, QFileDialog, QHBoxLayout, QLabel, QMenu, QPushButton
+from volumina.api import AlphaModulatedLayer, LazyflowSource
+from volumina.colortables import default16_new
+
+from ilastik.applets.pixelClassification.pixelClassificationGui import PixelClassificationGui
+
+from ilastik.applets.pixelClassification.SuggestFeaturesDialog import SuggestFeaturesDialog
+from .modelStateControl import EnhancerModelStateControl
+
+logger = logging.getLogger(__name__)
+
+
+class TrainableDomainAdaptationGui(PixelClassificationGui):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._drawer = self._labelControlUi
+        self.liveNNPrediction = False
+        self.__cleanup_fns = []
+        self._init_channel_selector_ui()
+        self._init_nn_prediction_ui()
+
+        self.invalidatePredictionsTimer = QTimer()
+        self.invalidatePredictionsTimer.timeout.connect(self.updateNNPredictions)
+        self.tiktorchModel.registerListener(self._onModelStateChanged)
+
+        self.labelingDrawerUi.liveUpdateButton.toggled.connect(self.toggleLiveNNPrediction)
+
+    def _init_channel_selector_ui(self):
+        drawer = self._drawer
+
+        channel_selector = QPushButton()
+        self.channel_menu = QMenu(self)  # Must retain menus (in self) or else they get deleted.
+        channel_selector.setMenu(self.channel_menu)
+        channel_selector.clicked.connect(channel_selector.showMenu)
+
+        def populate_channel_menu(*args):
+            if sip.isdeleted(channel_selector):
+                return
+            self.channel_menu.clear()
+            self.channel_actions = []
+            label_names = self.topLevelOperatorView.LabelNames.value
+            for i, label_name in enumerate(label_names):
+                action = QAction(label_name, self.channel_menu)
+                action.setCheckable(True)
+                self.channel_menu.addAction(action)
+                self.channel_actions.append(action)
+                action.toggled.connect(self.onChannelSelectionClicked)
+
+        populate_channel_menu()
+        self.__cleanup_fns.append(self.topLevelOperatorView.LabelNames.notifyDirty(populate_channel_menu))
+
+        channel_selector.setToolTip("Select Channels for NN input")
+        channel_selection_layout = QHBoxLayout()
+        channel_selection_layout.addWidget(QLabel("Select Channels"))
+        channel_selection_layout.addWidget(channel_selector)
+        drawer.verticalLayout.addLayout(channel_selection_layout)
+        self._channel_selector = channel_selector
+
+        def _update_channel_selector_txt(_slot, _roi):
+            label_data = self.labelListData
+            selected_idx = self.topLevelOperatorView.SelectedChannels.value
+            selected_channels = ", ".join(label_data[i].name for i in selected_idx)
+            self._channel_selector.setText(selected_channels)
+
+        self.__cleanup_fns.append(self.topLevelOperatorView.LabelNames.notifyDirty(_update_channel_selector_txt))
+        self.__cleanup_fns.append(self.topLevelOperatorView.SelectedChannels.notifyDirty(_update_channel_selector_txt))
+        _update_channel_selector_txt(self.topLevelOperatorView.SelectedChannels, ())
+
+    @classmethod
+    def getModelToOpen(cls, parent_window, defaultDirectory):
+        """
+        opens a QFileDialog for importing files
+        """
+        return QFileDialog.getOpenFileName(parent_window, "Select Model", defaultDirectory, "Models (*.tmodel *.zip)")[
+            0
+        ]
+
+    def _init_nn_prediction_ui(self):
+        # add new stuff here
+        drawer = self._drawer
+
+        nn_ctrl_layout = QHBoxLayout()
+        self.addModel = EnhancerModelStateControl()
+
+        self.addModel.setTiktorchController(self.tiktorchController)
+        self.addModel.setTiktorchModel(self.tiktorchModel)
+
+        nn_ctrl_layout.addWidget(self.addModel)
+
+        drawer.verticalLayout.addLayout(nn_ctrl_layout)
+
+    def _onModelStateChanged(self, state):
+        self.updateAllLayers()
+
+    def updateNNPredictions(self):
+        logger.info("Invalidating predictions")
+        self.topLevelOperatorView.FreezePredictions.setValue(False)
+        self.topLevelOperatorView.classifier_cache.Output.setDirty()
+
+    def toggleLiveNNPrediction(self, checked):
+        logger.debug("toggle live prediction mode to %r", checked)
+        checked = checked if checked is not None else self.isLiveUpdateEnabled()
+        # If we're changing modes, enable/disable our controls and other applets accordingly
+        if checked:
+            self.updateNNPredictions()
+
+        self.topLevelOperatorView.FreezeNNPredictions.setValue(not checked)
+
+        # Auto-set the "show predictions" state according to what the user just clicked.
+        if checked:
+            self.handleShowNNPredictionsClicked()
+
+        # Notify the workflow that some applets may have changed state now.
+        # (For example, the downstream pixel classification applet can
+        #  be used now that there are features selected)
+        self.parentApplet.appletStateUpdateRequested()
+
+    def onChannelSelectionClicked(self, *args):
+        channel_selections = []
+        for ch in range(len(self.channel_actions)):
+            if self.channel_actions[ch].isChecked():
+                channel_selections.append(ch)
+
+        self.topLevelOperatorView.SelectedChannels.setValue(channel_selections)
+
+    def stopAndCleanUp(self):
+        for fn in self.__cleanup_fns:
+            fn()
+
+        # Base class
+        super().stopAndCleanUp()
+
+    def setupLayers(self):
+        layers = []
+        enhancer_slot = self.topLevelOperatorView.EnhancerNetworkInput
+
+        n_layers = len(self.labelListData)
+        # NeuralNetwork Predictions
+        if enhancer_slot is not None and enhancer_slot.ready():
+            for channel, predictionSlot in enumerate(self.topLevelOperatorView.NNPredictionProbabilityChannels):
+                if predictionSlot.ready():
+                    predictsrc = LazyflowSource(predictionSlot)
+                    predictionLayer = AlphaModulatedLayer(
+                        predictsrc, tintColor=QColor(default16_new[n_layers + channel + 1]), normalize=(0.0, 1.0)
+                    )
+                    predictionLayer.visible = self.labelingDrawerUi.liveUpdateButton.isChecked()
+                    predictionLayer.opacity = 0.5
+                    predictionLayer.visibleChanged.connect(self.updateShowPredictionCheckbox)
+
+                    predictionLayer.name = f"NN prediction Channel {channel}"
+
+                    def changePredLayerColor(ref_layer, _checked):
+                        new_color = QColorDialog.getColor(ref_layer.tintColor, self, "Select Layer Color")
+                        if new_color.isValid():
+                            ref_layer.tintColor = new_color
+
+                    predictionLayer.contexts.append(
+                        QAction("Change color", None, triggered=partial(changePredLayerColor, predictionLayer))
+                    )
+
+                    layers.append(predictionLayer)
+
+        # EnhancerInput
+        if enhancer_slot is not None and enhancer_slot.ready():
+            layer = self.createStandardLayerFromSlot(enhancer_slot, name="EnhancerInput")
+            layer.visible = False
+            layers.append(layer)
+
+        layers.extend(super().setupLayers())
+        return layers
+
+    def initSuggestFeaturesDialog(self):
+        thisOpFeatureSelection = (
+            self.topLevelOperatorView.parent.featureSelectionApplet.topLevelOperator.innerOperators[0]
+        )
+
+        return SuggestFeaturesDialog(thisOpFeatureSelection, self, self.labelListData, self)
+
+    @property
+    def tiktorchController(self):
+        return self.parentApplet.tiktorchController
+
+    @property
+    def tiktorchModel(self):
+        return self.parentApplet.tiktorchOpModel
+
+    def cc(self, *args, **kwargs):
+        self.cancel_src.cancel()
+
+    @pyqtSlot()
+    def updateShowNNPredictionCheckbox(self):
+        """
+        updates the showPrediction Checkbox when Predictions were added to the layers
+        """
+        predictLayerCount = 0
+        visibleCount = 0
+        for layer in self.layerstack:
+            if "NN prediction" in layer.name:
+                predictLayerCount += 1
+                if layer.visible:
+                    visibleCount += 1
+            elif "Prediction" in layer.name:
+                predictLayerCount += 1
+                if layer.visible:
+                    visibleCount += 1
+
+        if visibleCount == 0:
+            self.checkShowPredictions.setCheckState(Qt.Unchecked)
+        elif predictLayerCount == visibleCount:
+            self.checkShowPredictions.setCheckState(Qt.Checked)
+        else:
+            self.checkShowPredictions.setCheckState(Qt.PartiallyChecked)
+
+    @pyqtSlot()
+    def handleShowNNPredictionsClicked(self):
+        checked = self._viewerControlUi.checkShowPredictions.isChecked()
+        for layer in self.layerstack:
+            if "NN prediction" in layer.name:
+                layer.visible = checked
+            elif "Prediction" in layer.name:
+                layer.visible = checked

--- a/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationSerializer.py
+++ b/ilastik/applets/trainableDomainAdaptation/trainableDomainAdaptationSerializer.py
@@ -1,0 +1,15 @@
+from ilastik.applets.base.appletSerializer import AppletSerializer, SerialListSlot
+
+from ..neuralNetwork.nnClassSerializer import BioimageIOModelSlot
+
+
+class TrainableDomainAdaptationSerializer(AppletSerializer):
+    def __init__(self, topLevelOperator, projectFileGroupName):
+        self.VERSION = 1
+
+        slots = [
+            BioimageIOModelSlot(topLevelOperator.BIOModel),
+            SerialListSlot(topLevelOperator.SelectedChannels),
+        ]
+
+        super().__init__(projectFileGroupName, slots)

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -652,6 +652,7 @@ class IlastikShell(QMainWindow):
                     "AutocontextTwoStage",
                     "Neural Network Classification (Local)",
                     "Neural Network Classification (Remote)",
+                    "Trainable Domain Adaptation (Local) (beta)",
                     "Carving",
                     "Edge Training With Multicut",
                 ],

--- a/ilastik/workflows/__init__.py
+++ b/ilastik/workflows/__init__.py
@@ -135,11 +135,15 @@ if ilastik.config.cfg.getboolean("ilastik", "hbp", fallback=False):
 # network classification, check whether required modules are available:
 try:
     from . import neuralNetwork
+    from . import trainableDomainAdaptation
 
     WORKFLOW_CLASSES += [neuralNetwork.RemoteWorkflow]
     logger.debug(ilastik.config.runtime_cfg)
     if ilastik.config.runtime_cfg.tiktorch_executable:
-        WORKFLOW_CLASSES += [neuralNetwork.LocalWorkflow]
+        WORKFLOW_CLASSES += [
+            neuralNetwork.LocalWorkflow,
+            trainableDomainAdaptation.LocalTrainableDomainAdaptationWorkflow,
+        ]
 
 except ImportError as e:
     logger.warning("Failed to import NeuralNet workflow; check dependencies: " + str(e), exc_info=1)

--- a/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
+++ b/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
@@ -52,17 +52,12 @@ class _NNWorkflowBase(Workflow):
     DATA_ROLE_RAW = 0
     DATA_ROLE_OVERLAY = 1
     ROLE_NAMES = ["Raw Data", "Overlay"]
-    ROLE_NAMES = ["Raw Data", "Overlay"]
 
-    @property
-    def ExportNames(self):
-        @enum.unique
-        class ExportNames(SlotNameEnum):
-            PROBABILITIES = enum.auto()
-            if tiktorchController.ALLOW_TRAINING:
-                LABELS = enum.auto()
-
-        return ExportNames
+    @enum.unique
+    class ExportNames(SlotNameEnum):
+        PROBABILITIES = enum.auto()
+        if tiktorchController.ALLOW_TRAINING:
+            LABELS = enum.auto()
 
     @property
     def applets(self):

--- a/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
+++ b/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
@@ -19,6 +19,7 @@
 #          http://ilastik.org/license.html
 ###############################################################################
 import argparse
+import enum
 import itertools
 import logging
 
@@ -32,6 +33,7 @@ from ilastik.config import runtime_cfg
 from ilastik.workflow import Workflow
 from lazyflow.cancel_token import CancellationTokenSource
 from lazyflow.graph import Graph
+from ilastik.utility import SlotNameEnum
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,17 @@ class _NNWorkflowBase(Workflow):
     DATA_ROLE_RAW = 0
     DATA_ROLE_OVERLAY = 1
     ROLE_NAMES = ["Raw Data", "Overlay"]
-    EXPORT_NAMES = ["Probabilities", "Labels"] if tiktorchController.ALLOW_TRAINING else ["Probabilities"]
+    ROLE_NAMES = ["Raw Data", "Overlay"]
+
+    @property
+    def ExportNames(self):
+        @enum.unique
+        class ExportNames(SlotNameEnum):
+            PROBABILITIES = enum.auto()
+            if tiktorchController.ALLOW_TRAINING:
+                LABELS = enum.auto()
+
+        return ExportNames
 
     @property
     def applets(self):
@@ -97,7 +109,7 @@ class _NNWorkflowBase(Workflow):
         opClassify = self.nnClassificationApplet.topLevelOperator
         opDataExport = self.dataExportApplet.topLevelOperator
         opDataExport.WorkingDirectory.connect(opDataSelection.WorkingDirectory)
-        opDataExport.SelectionNames.setValue(self.EXPORT_NAMES)
+        opDataExport.SelectionNames.setValue(self.ExportNames.asDisplayNameList())
         opDataExport.PmapColors.connect(opClassify.PmapColors)
 
         opDataExport.LabelNames.connect(opClassify.LabelNames)
@@ -153,11 +165,11 @@ class _NNWorkflowBase(Workflow):
         # Data Export connections
         opDataExport.RawData.connect(opData.ImageGroup[self.DATA_ROLE_RAW])
         opDataExport.RawDatasetInfo.connect(opData.DatasetGroup[self.DATA_ROLE_RAW])
-        opDataExport.Inputs.resize(len(self.EXPORT_NAMES))
-        opDataExport.Inputs[0].connect(opNNclassify.PredictionProbabilities)
+        opDataExport.Inputs.resize(len(self.ExportNames))
+        opDataExport.Inputs[self.ExportNames.PROBABILITIES].connect(opNNclassify.PredictionProbabilities)
 
         if tiktorchController.ALLOW_TRAINING:
-            opDataExport.Inputs[1].connect(opNNclassify.LabelImages)
+            opDataExport.Inputs[self.ExportNames.LABELS].connect(opNNclassify.LabelImages)
 
     def handleAppletStateUpdateRequested(self, upstream_ready=True):
         """

--- a/ilastik/workflows/trainableDomainAdaptation/__init__.py
+++ b/ilastik/workflows/trainableDomainAdaptation/__init__.py
@@ -1,0 +1,1 @@
+from ._localTrainableDomainAdaptationWorkflow import LocalTrainableDomainAdaptationWorkflow

--- a/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
+++ b/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
@@ -1,0 +1,205 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+import enum
+import logging
+
+from ilastik.applets.featureSelection import FeatureSelectionApplet
+from ilastik.applets.serverConfiguration.types import Device, ServerConfig
+from ilastik.applets.trainableDomainAdaptation import TrainableDomainAdaptationApplet
+from ilastik.config import runtime_cfg
+from ilastik.utility import SlotNameEnum
+from ilastik.workflows.neuralNetwork._localLauncher import LocalServerLauncher
+from ilastik.workflows.neuralNetwork._nnWorkflowBase import _NNWorkflowBase
+from lazyflow.operators import tiktorch
+
+# TODO (k-dominik): check if tinyvector is of any benefit here
+from lazyflow.roi import TinyVector
+
+logger = logging.getLogger(__name__)
+
+
+class LocalTrainableDomainAdaptationWorkflow(_NNWorkflowBase):
+    """
+    This class provides workflow for a local tiktorch executable.
+    It can be specified via "--tiktorch_executable" command line parameter.
+    Furthermore, the ilastik app will try to find a tiktorch version
+    (usually the case when bundled for distribution) if the parameter is not
+    supplied. If it cannot be found, workflow is not available.
+    """
+
+    auto_register = True
+    workflowName = "Trainable Domain Adaptation (Local) (beta)"
+    workflowDescription = "Allows to apply bioimage.io shallow2deep models on your data using bundled tiktorch"
+
+    @property
+    def ExportNames(self):
+        @enum.unique
+        class ExportNames(SlotNameEnum):
+            PROBABILITIES = enum.auto()
+            LABELS = enum.auto()
+            # TODOS: add NN output, too
+
+        return ExportNames
+
+    def __init__(self, shell, headless, workflow_cmdline_args, project_creation_args, *args, **kwargs):
+        tiktorch_exe_path = runtime_cfg.tiktorch_executable
+        if not tiktorch_exe_path:
+            raise RuntimeError("No tiktorch-executable specified")
+
+        self._launcher = LocalServerLauncher(tiktorch_exe_path)
+        super().__init__(shell, headless, workflow_cmdline_args, project_creation_args, *args, **kwargs)
+
+    def _createFeatureSelectionApplet(self):
+        return FeatureSelectionApplet(self, "Feature Selection", "FeatureSelections")
+
+    def _create_local_connection(self):
+        conn_str = self._launcher.start()
+        return conn_str
+
+    def _createClassifierApplet(self, headless=False, conn_str=None):
+        if not headless or not conn_str:
+            conn_str = self._create_local_connection()
+
+        self.featureSelectionApplet = self._createFeatureSelectionApplet()
+        self.applets.append(self.featureSelectionApplet)
+        srv_config = ServerConfig(id="auto", address=conn_str, devices=[Device(id="cpu", name="cpu", enabled=True)])
+        connFactory = tiktorch.TiktorchConnectionFactory()
+        conn = connFactory.ensure_connection(srv_config)
+
+        devices = conn.get_devices()
+        preferred_cuda_device_id = runtime_cfg.preferred_cuda_device_id
+        device_ids = [dev[0] for dev in devices]
+        cuda_devices = tuple(d for d in device_ids if d.startswith("cuda"))
+
+        if preferred_cuda_device_id not in device_ids:
+            if preferred_cuda_device_id:
+                logger.warning(f"Could nor find preferred cuda device {preferred_cuda_device_id}")
+            try:
+                preferred_cuda_device_id = cuda_devices[0]
+            except IndexError:
+                preferred_cuda_device_id = "cpu"
+
+            logger.info(f"Using default device for Neural Network Workflow {preferred_cuda_device_id}")
+        else:
+            logger.info(f"Using specified device for Neural Network Workflow {preferred_cuda_device_id}")
+
+        device_name = devices[device_ids.index(preferred_cuda_device_id)][1]
+
+        srv_config = srv_config.evolve(devices=[Device(id=preferred_cuda_device_id, name=device_name, enabled=True)])
+
+        tda_appplet = TrainableDomainAdaptationApplet(self, "TrainableDomainAdaptation", connectionFactory=connFactory)
+        opNNclassify = tda_appplet.topLevelOperator
+        opNNclassify.ServerConfig.setValue(srv_config)
+
+        self.nnClassificationApplet = tda_appplet
+        self._applets.append(self.nnClassificationApplet)
+
+    def connectLane(self, laneIndex):
+        """
+        connects the operators for different lanes, each lane has a laneIndex starting at 0
+        """
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(laneIndex)
+        opNNclassify = self.nnClassificationApplet.topLevelOperator.getLane(laneIndex)
+        opDataExport = self.dataExportApplet.topLevelOperator.getLane(laneIndex)
+        opFeatures = self.featureSelectionApplet.topLevelOperator.getLane(laneIndex)
+
+        opFeatures.InputImage.connect(opData.Image)
+        # Feature Images -> Classification Op (for training, prediction)
+        opNNclassify.FeatureImages.connect(opFeatures.OutputImage)
+        opNNclassify.CachedFeatureImages.connect(opFeatures.CachedOutputImage)
+        # Input Image ->  Classification Op (for display)
+        opNNclassify.InputImages.connect(opData.Image)
+        opNNclassify.OverlayImages.connect(opData.ImageGroup[self.DATA_ROLE_OVERLAY])
+        # Data Export connections
+        opDataExport.RawData.connect(opData.ImageGroup[self.DATA_ROLE_RAW])
+        opDataExport.RawDatasetInfo.connect(opData.DatasetGroup[self.DATA_ROLE_RAW])
+        opDataExport.Inputs.resize(len(self.ExportNames))
+        opDataExport.Inputs[self.ExportNames.PROBABILITIES].connect(opNNclassify.PredictionProbabilities)
+        opDataExport.Inputs[self.ExportNames.LABELS].connect(opNNclassify.LabelImages)
+        # TODO: add NN output, too
+
+    def cleanUp(self):
+        super().cleanUp()
+        self.nnClassificationApplet.tiktorchController.closeSession()
+        self._launcher.stop()
+
+    def handleAppletStateUpdateRequested(self, upstream_ready=True):
+        """
+        Overridden from NN Workflow base class
+        Called when an applet has fired the :py:attr:`Applet.appletStateUpdateRequested`
+        """
+        # If no data, nothing else is ready.
+        opDataSelection = self.dataSelectionApplet.topLevelOperator
+        input_ready = len(opDataSelection.ImageGroup) > 0 and not self.dataSelectionApplet.busy
+
+        opFeatureSelection = self.featureSelectionApplet.topLevelOperator
+        featureOutput = opFeatureSelection.OutputImage
+        features_ready = (
+            input_ready
+            and len(featureOutput) > 0
+            and featureOutput[0].ready()
+            and (TinyVector(featureOutput[0].meta.shape) > 0).all()
+        )
+        opNNClassification = self.nnClassificationApplet.topLevelOperator
+
+        opDataExport = self.dataExportApplet.topLevelOperator
+
+        predictions_ready = input_ready and len(opDataExport.Inputs) > 0
+
+        # Problems can occur if the features or input data are changed during live update mode.
+        # Don't let the user do that.
+        live_update_active = not opNNClassification.FreezePredictions.value
+
+        # The user isn't allowed to touch anything while batch processing is running.
+        batch_processing_busy = self.batchProcessingApplet.busy
+
+        self._shell.setAppletEnabled(
+            self.dataSelectionApplet, not (batch_processing_busy or live_update_active) and upstream_ready
+        )
+        self._shell.setAppletEnabled(
+            self.featureSelectionApplet,
+            not (batch_processing_busy or live_update_active) and input_ready and upstream_ready,
+        )
+
+        self._shell.setAppletEnabled(
+            self.nnClassificationApplet,
+            (input_ready and features_ready) and not batch_processing_busy and upstream_ready,
+        )
+
+        # TODO (k-dominik): Batch and Export rely on the model being loaded!
+        self._shell.setAppletEnabled(
+            self.dataExportApplet,
+            predictions_ready and not batch_processing_busy and not live_update_active and upstream_ready,
+        )
+        if self.batchProcessingApplet is not None:
+            self._shell.setAppletEnabled(
+                self.batchProcessingApplet, predictions_ready and not batch_processing_busy and upstream_ready
+            )
+
+        # Lastly, check for certain "busy" conditions, during which we
+        #  should prevent the shell from closing the project.
+        busy = False
+        busy |= self.dataSelectionApplet.busy
+        busy |= self.featureSelectionApplet.busy
+        busy |= self.nnClassificationApplet.busy
+        busy |= self.dataExportApplet.busy
+        busy |= self.batchProcessingApplet.busy
+        self._shell.enableProjectChanges(not busy)

--- a/lazyflow/operators/__init__.py
+++ b/lazyflow/operators/__init__.py
@@ -48,6 +48,7 @@ from .generic import (
     OpMultiArrayMerger,
     OpMultiArraySlicer2,
     OpMultiArrayStacker,
+    OpMultiChannelSelector,
     OpMultiInputConcatenater,
     OpPixelOperator,
     OpSelectSubslot,

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -849,3 +849,51 @@ class OpSelectSubslot(Operator):
 
     def propagateDirty(self, slot, subindex, roi):
         pass
+
+
+class OpMultiChannelSelector(Operator):
+    """Select a subset of channels from a multichannel image
+
+    Channels are stacked in the same order as provided in SelectedChannels
+    input slot.
+    """
+
+    Input = InputSlot()
+    SelectedChannels = InputSlot(value=[0])
+
+    Output = OutputSlot()
+
+    def setupOutputs(self):
+        if self.Input.meta.getAxisKeys()[-1] != "c":
+            raise ValueError("Channel axis must be last for the input")
+
+        if len(self.SelectedChannels.value) == 0:
+            self.Output.meta.NOTREADY = True
+            return
+
+        max_channel = self.Input.meta.getTaggedShape()["c"]
+        if any(x >= max_channel for x in self.SelectedChannels.value):
+            raise ValueError(f"Input has only {max_channel} channels, channel-selector {self.SelectedChannels.value}")
+
+        self.Output.meta.assignFrom(self.Input.meta)
+        self.Output.meta.shape = self.Input.meta.shape[:-1] + (len(self.SelectedChannels.value),)
+
+    def execute(self, slot, subindex, roi, result):
+        channel_indexes = self.SelectedChannels.value
+
+        # make sure to request the minimum (consecutive) channels
+        input_roi = roi.copy()
+        input_roi.start[-1] = min(channel_indexes)
+        input_roi.stop[-1] = max(channel_indexes) + 1
+
+        if len(channel_indexes) == 1:
+            # Fetch in-place
+            self.Input(input_roi.start, input_roi.stop).writeInto(result).wait()
+
+        else:
+            fetched_data = self.Input(input_roi.start, input_roi.stop).wait()
+            channel_indexes = [x - channel_indexes[0] for x in channel_indexes]
+            result[...] = fetched_data[..., tuple(channel_indexes)]
+
+    def propagateDirty(self, slot, subindex, roi):
+        self.propagateDirtyIfNewModTime()

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from builtins import zip
 from builtins import map
 from builtins import range
@@ -876,7 +874,7 @@ class OpMultiChannelSelector(Operator):
             raise ValueError(f"Input has only {max_channel} channels, channel-selector {self.SelectedChannels.value}")
 
         self.Output.meta.assignFrom(self.Input.meta)
-        self.Output.meta.shape = self.Input.meta.shape[:-1] + (len(self.SelectedChannels.value),)
+        self.Output.meta.shape = (*self.Input.meta.shape[:-1], len(self.SelectedChannels.value))
 
     def execute(self, slot, subindex, roi, result):
         channel_indexes = self.SelectedChannels.value
@@ -892,8 +890,8 @@ class OpMultiChannelSelector(Operator):
 
         else:
             fetched_data = self.Input(input_roi.start, input_roi.stop).wait()
-            channel_indexes = [x - channel_indexes[0] for x in channel_indexes]
-            result[...] = fetched_data[..., tuple(channel_indexes)]
+            channel_indexes = tuple(x - channel_indexes[0] for x in channel_indexes)
+            result[...] = fetched_data[..., channel_indexes]
 
     def propagateDirty(self, slot, subindex, roi):
         self.propagateDirtyIfNewModTime()

--- a/tests/test_lazyflow/test_operators/testOpMultiChannelSelector.py
+++ b/tests/test_lazyflow/test_operators/testOpMultiChannelSelector.py
@@ -1,0 +1,109 @@
+from lazyflow.operators import OpMultiChannelSelector
+import numpy
+import vigra
+
+import pytest
+
+
+@pytest.fixture
+def random_data_5c():
+    data = numpy.random.randint(0, 256, (10, 5, 5), dtype="uint8")
+    return vigra.taggedView(data, "yxc")
+
+
+def test_raises_channel_not_last(graph):
+    data = numpy.random.randint(0, 256, (10, 5, 1), dtype="uint8")
+    vdata = vigra.taggedView(data, "yxz")
+    op = OpMultiChannelSelector(graph=graph)
+    with pytest.raises(ValueError):
+        op.Input.setValue(vdata)
+
+
+def test_raises_selected_channel_not_in_data(graph):
+    data = numpy.random.randint(0, 256, (10, 5, 1), dtype="uint8")
+    vdata = vigra.taggedView(data, "yxc")
+
+    op = OpMultiChannelSelector(graph=graph)
+    op.Input.setValue(vdata)
+    with pytest.raises(ValueError):
+        op.SelectedChannels.setValue([1])
+
+
+def test_trivial_operation(graph):
+    data = numpy.random.randint(0, 256, (10, 5, 1), dtype="uint8")
+    vdata = vigra.taggedView(data, "yxc")
+
+    op = OpMultiChannelSelector(graph=graph)
+    op.Input.setValue(vdata)
+    op.SelectedChannels.setValue([0])
+
+    output = op.Output[()].wait()
+
+    numpy.testing.assert_array_equal(output, data)
+
+
+@pytest.mark.parametrize(
+    "selected_channel",
+    [
+        0,
+        1,
+        2,
+        3,
+        4,
+    ],
+)
+def test_get_single_channel(graph, selected_channel, random_data_5c):
+
+    op = OpMultiChannelSelector(graph=graph)
+    op.Input.setValue(random_data_5c)
+    op.SelectedChannels.setValue([selected_channel])
+
+    output = op.Output[()].wait()
+
+    numpy.testing.assert_array_equal(output, random_data_5c[..., (selected_channel,)])
+
+
+def test_selected_channel_change(graph, random_data_5c):
+    selected_channels = range(1, 5)
+
+    is_dirty = False
+
+    def set_dirty(*args, **kwargs):
+        nonlocal is_dirty
+        assert not is_dirty
+        is_dirty = True
+
+    op = OpMultiChannelSelector(graph=graph)
+    op.Input.setValue(random_data_5c)
+    # no change expected as its the default value
+    op.SelectedChannels.setValue([0])
+
+    assert not is_dirty
+
+    for selected_channel in selected_channels:
+        is_dirty = True
+        op.SelectedChannels.setValue([selected_channel])
+        assert is_dirty
+
+        output = op.Output[()].wait()
+        numpy.testing.assert_array_equal(output, random_data_5c[..., (selected_channel,)])
+
+
+@pytest.mark.parametrize(
+    "selected_channels",
+    [
+        (0, 1, 2, 3, 4),
+        (1, 2),
+        (2, 4),
+        (5, 2),
+        (3, 2, 4),
+    ],
+)
+def test_select_multi_channels(graph, selected_channels, random_data_5c):
+    selected_channels = (2, 4)
+    op = OpMultiChannelSelector(graph=graph)
+    op.SelectedChannels.setValue(selected_channels)
+    op.Input.setValue(random_data_5c)
+
+    output = op.Output[()].wait()
+    numpy.testing.assert_array_equal(output, random_data_5c[..., selected_channels])

--- a/tests/test_lazyflow/test_operators/testOpMultiChannelSelector.py
+++ b/tests/test_lazyflow/test_operators/testOpMultiChannelSelector.py
@@ -53,7 +53,6 @@ def test_trivial_operation(graph):
     ],
 )
 def test_get_single_channel(graph, selected_channel, random_data_5c):
-
     op = OpMultiChannelSelector(graph=graph)
     op.Input.setValue(random_data_5c)
     op.SelectedChannels.setValue([selected_channel])


### PR DESCRIPTION
aka shallow2deep

Not a lot of ways to make this PR more digestible - it is a whole new workflow after all. The only _added_ applet would be `ilastik.applets.trainableDomainAdaptation`.

Lets you

1. Annotate an image, Pixel Classification style

<img width="1441" alt="image" src="https://user-images.githubusercontent.com/24434157/236439340-1ec3e048-c343-42f7-9589-20d127030c1c.png">

2. Using one of the shallow2deep networks from the BioImage Model Zoo get enhanced predictions. the idea is, of course,  to do this in an interactive loop.

<img width="1441" alt="image" src="https://user-images.githubusercontent.com/24434157/236439715-a4dbaa07-0e31-42f3-921c-02027ee8de71.png">


The implementation relies a lot on the functionality (tried and tested) of the Pixel Classification Workflow, and the Neural Network Classification Workflow.

Ref: [From Shallow to Deep: Exploiting Feature-Based Classifiers for Domain Adaptation in Semantic Segmentation](https://www.frontiersin.org/articles/10.3389/fcomp.2022.805166/full) | [preprint](https://www.biorxiv.org/content/10.1101/2021.11.09.467925v1)