### PR TITLE
fix tda export names

### DIFF
--- a/ilastik/applets/trainableDomainAdaptation/tdaDataExportApplet.py
+++ b/ilastik/applets/trainableDomainAdaptation/tdaDataExportApplet.py
@@ -1,0 +1,55 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from ilastik.applets.dataExport.dataExportApplet import DataExportApplet
+from ilastik.applets.neuralNetwork.opNNClassificationDataExport import OpNNClassificationDataExport
+from ilastik.applets.dataExport.dataExportSerializer import DataExportSerializer
+from ilastik.utility import OpMultiLaneWrapper
+
+
+class TdaDataExportApplet(DataExportApplet):
+    """
+    This a specialization of the generic data export applet that
+    provides a special viewer for Neural Network predictions.
+    """
+
+    def __init__(self, workflow, title, isBatch=False):
+        self._topLevelOperator = OpMultiLaneWrapper(
+            OpNNClassificationDataExport,
+            parent=workflow,
+            promotedSlotNames=set(["RawData", "Inputs", "RawDatasetInfo"]),
+        )
+
+        self._title = title
+        self._serializers = [DataExportSerializer(self._topLevelOperator, title)]
+        # Base class init
+        super().__init__(workflow, title, isBatch)
+
+    @property
+    def topLevelOperator(self):
+        return self._topLevelOperator
+
+    def getMultiLaneGui(self):
+        if self._gui is None:
+            # Gui is a special subclass of the generic gui
+            from .tdaDataExportGui import TdaDataExportGui
+
+            self._gui = TdaDataExportGui(self, self.topLevelOperator)
+        return self._gui

--- a/ilastik/applets/trainableDomainAdaptation/tdaDataExportGui.py
+++ b/ilastik/applets/trainableDomainAdaptation/tdaDataExportGui.py
@@ -1,0 +1,94 @@
+##############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+
+from lazyflow.operators.generic import OpMultiArraySlicer2
+from volumina.api import LazyflowSource, AlphaModulatedLayer, ColortableLayer
+from ilastik.utility import bind
+from ilastik.applets.dataExport.dataExportGui import DataExportGui, DataExportLayerViewerGui
+from ilastik.applets.neuralNetwork.nnClassificationDataExportGui import (
+    NNClassificationDataExportGui,
+    NNClassificationResultsViewer,
+)
+from ilastik.workflows.trainableDomainAdaptation import LocalTrainableDomainAdaptationWorkflow
+
+from PyQt5.QtGui import QColor
+
+
+class TdaDataExportGui(NNClassificationDataExportGui):
+    """
+    A subclass of the generic data export gui that creates custom layer viewers.
+    """
+
+    def createLayerViewer(self, opLane):
+        return TdaResultsViewer(self.parentApplet, opLane)
+
+
+class TdaResultsViewer(NNClassificationResultsViewer):
+    """
+    SubClass for the DataExport viewerGui to show the layers correctly
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(NNClassificationResultsViewer, self).__init__(*args, **kwargs)
+        self.topLevelOperatorView.PmapColors.notifyDirty(bind(self.updateAllLayers))
+        self.topLevelOperatorView.LabelNames.notifyDirty(bind(self.updateAllLayers))
+
+    def setupLayers(self):
+        layers = []
+        opLane = self.topLevelOperatorView
+
+        # This code depends on a specific order for the export slots.
+        # If those change, update this function!
+        selection_names = opLane.SelectionNames.value
+
+        export_names = LocalTrainableDomainAdaptationWorkflow.ExportNames
+
+        # see comment above
+        for name, expected in zip(selection_names[0:1], export_names.asDisplayNameList()):
+            assert name.startswith(expected), "The Selection Names don't match the expected selection names."
+
+        selection = selection_names[opLane.InputSelection.value]
+
+        if selection.startswith(export_names.NN_PROBABILITIES.displayName) or selection.startswith(
+            export_names.PROBABILITIES.displayName
+        ):
+            exportedLayers = self._initPredictionLayers(opLane.ImageToExport)
+            for i, layer in enumerate(exportedLayers):
+                layer.visible = False
+                layer.name = f"{selection} {i} - Exported"
+            layers += exportedLayers
+        elif selection.startswith("Labels"):
+            previewLayer = self._initColortablelayer(opLane.ImageToExport)
+            if previewLayer:
+                previewLayer.visible = False
+                previewLayer.name = selection + " - Preview"
+                layers.append(previewLayer)
+
+        # If available, also show the raw data layer
+        rawSlot = opLane.FormattedRawData
+        if rawSlot.ready():
+            rawLayer = self.createStandardLayerFromSlot(rawSlot)
+            rawLayer.name = "Raw Data"
+            rawLayer.visible = True
+            rawLayer.opacity = 1.0
+            layers.append(rawLayer)
+
+        return layers

--- a/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
+++ b/ilastik/workflows/neuralNetwork/_nnWorkflowBase.py
@@ -97,24 +97,11 @@ class _NNWorkflowBase(Workflow):
         connection_string = None or self.parsed_args.connection_string
         self._createClassifierApplet(headless=self._headless, conn_str=connection_string)
 
-        self.dataExportApplet = NNClassificationDataExportApplet(self, "Data Export")
-
-        # Configure global DataExport settings
-        opDataSelection = self.dataSelectionApplet.topLevelOperator
-        opClassify = self.nnClassificationApplet.topLevelOperator
-        opDataExport = self.dataExportApplet.topLevelOperator
-        opDataExport.WorkingDirectory.connect(opDataSelection.WorkingDirectory)
-        opDataExport.SelectionNames.setValue(self.ExportNames.asDisplayNameList())
-        opDataExport.PmapColors.connect(opClassify.PmapColors)
-
-        opDataExport.LabelNames.connect(opClassify.LabelNames)
+        self._createDataExportApplet()
 
         self.batchProcessingApplet = BatchProcessingApplet(
             self, "Batch Processing", self.dataSelectionApplet, self.dataExportApplet
         )
-
-        # Expose for shell
-        self._applets.append(self.dataExportApplet)
         self._applets.append(self.batchProcessingApplet)
 
         if unused_args:
@@ -131,6 +118,22 @@ class _NNWorkflowBase(Workflow):
     def _createClassifierApplet(self):
         # Override in child class
         raise NotImplemented
+
+    def _createDataExportApplet(self):
+        # Override in child class if necessary
+        self.dataExportApplet = NNClassificationDataExportApplet(self, "Data Export")
+
+        # Configure global DataExport settings
+        opDataSelection = self.dataSelectionApplet.topLevelOperator
+        opClassify = self.nnClassificationApplet.topLevelOperator
+        opDataExport = self.dataExportApplet.topLevelOperator
+        opDataExport.WorkingDirectory.connect(opDataSelection.WorkingDirectory)
+        opDataExport.SelectionNames.setValue(self.ExportNames.asDisplayNameList())
+        opDataExport.PmapColors.connect(opClassify.PmapColors)
+
+        opDataExport.LabelNames.connect(opClassify.LabelNames)
+
+        self._applets.append(self.dataExportApplet)
 
     def _createInputAndConfigApplets(self):
         data_instructions = "Select your input data using the 'Raw Data' tab shown on the right"

--- a/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
+++ b/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
@@ -24,6 +24,7 @@ import logging
 from ilastik.applets.featureSelection import FeatureSelectionApplet
 from ilastik.applets.serverConfiguration.types import Device, ServerConfig
 from ilastik.applets.trainableDomainAdaptation import TrainableDomainAdaptationApplet
+from ilastik.applets.trainableDomainAdaptation.tdaDataExportApplet import TdaDataExportApplet
 from ilastik.config import runtime_cfg
 from ilastik.utility import SlotNameEnum
 from ilastik.workflows.neuralNetwork._localLauncher import LocalServerLauncher
@@ -111,6 +112,20 @@ class LocalTrainableDomainAdaptationWorkflow(_NNWorkflowBase):
 
         self.nnClassificationApplet = tda_appplet
         self._applets.append(self.nnClassificationApplet)
+
+    def _createDataExportApplet(self):
+        self.dataExportApplet = TdaDataExportApplet(self, "Data Export")
+
+        # Configure global DataExport settings
+        opDataSelection = self.dataSelectionApplet.topLevelOperator
+        opClassify = self.nnClassificationApplet.topLevelOperator
+        opDataExport = self.dataExportApplet.topLevelOperator
+        opDataExport.WorkingDirectory.connect(opDataSelection.WorkingDirectory)
+        opDataExport.SelectionNames.setValue(self.ExportNames.asDisplayNameList())
+        opDataExport.PmapColors.connect(opClassify.PmapColors)
+        opDataExport.LabelNames.connect(opClassify.LabelNames)
+
+        self._applets.append(self.dataExportApplet)
 
     def connectLane(self, laneIndex):
         """


### PR DESCRIPTION
trainable domain adaptation has different export layers than _NNClassificationWorkflow - hence, factored out the `_createDataExportApplet` method to be able to override it in child classes.
