### PR TITLE
Osx arm 64

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,6 @@ outputs:
         - future
         - greenlet
         - grpcio <1.42
-        - grpcio-tools <1.42
         - h5py
         - hytra >=1.1.5
         - ilastik-feature-selection
@@ -61,7 +60,7 @@ outputs:
         - xarray
         - z5py
       run_constrained:
-        - tiktorch >=23.2.0
+        - tiktorch >=23.6.0
         - volumina >=1.3.10
 
     test:
@@ -105,7 +104,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.2.0*
+        - tiktorch 23.6.0*
         - inferno
         - torchvision
         - volumina
@@ -154,7 +153,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.2.0*
+        - tiktorch 23.6.0*
         - inferno
         - torchvision
         - cudatoolkit >=10.2

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -51,7 +51,7 @@ dependencies:
   - cpuonly
   # - pytorch 1.9.*=*cu*
   # - cudatoolkit 11.1.*
-  - tiktorch >=23.2.0
+  - tiktorch >=23.6.0
 
   # dev-only dependencies
   - conda-build

--- a/ilastik_scripts/ilastik_startup.py
+++ b/ilastik_scripts/ilastik_startup.py
@@ -118,7 +118,8 @@ def fix_macos() -> None:
     if platform.system() != "Darwin":
         return
     mac_ver = tuple(map(int, platform.mac_ver()[0].split(".")))
-    if mac_ver < (10, 16):
+    python_ver = tuple(map(int, platform.python_version().split(".")))
+    if mac_ver < (10, 16) or python_ver > (3, 8, 11):
         return
 
     # https://bugreports.qt.io/browse/QTBUG-87014

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpBigTiffReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpBigTiffReader.py
@@ -26,7 +26,7 @@ import tempfile
 import unittest
 
 import numpy
-import pytiff
+import tifffile
 import vigra
 
 from lazyflow.graph import Graph
@@ -44,22 +44,11 @@ class TestOpBigTiffReader(unittest.TestCase):
         cls.test_file_name = f"{cls.tmp_data_folder}/bigtiff_testfile.tif"
 
         cls.data = numpy.random.randint(0, 255, (800, 1200)).astype("uint8")
-        try:
-            t = pytiff.Tiff(cls.test_file_name, file_mode="w", bigtiff=True)
-            t.write(cls.data)
-        finally:
-            t.close()
+        tifffile.imwrite(cls.test_file_name, cls.data, bigtiff=True, metadata={"axes": "YX"})
 
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls.tmp_data_folder)
-
-    def test_is_obsolete(self):
-        """Check if vigra can read it
-
-        if vigra can read those tiffs, obBigTiffReader is obsolete
-        """
-        self.assertRaises(RuntimeError, vigra.impex.readImage, self.test_file_name)
 
     def test_read_bigtiff(self):
         g = Graph()


### PR DESCRIPTION
Necessary changes to distribute arm-64-based build

Summary:

* `pytiff` is not available for with compatible dependencies - so I removed it and changed to reading bigtiff with `tifffile`. Note: I'm using memmap here, and it has weird closing behavior:
  > Flush the memmap instance to write the changes to the file. Currently there is no API to close the underlying mmap. It is tricky to ensure the resource is actually closed, since it may be shared between different memmap instances.
  
  Alternatively to using `del` and trusting gc, as now in the code, one could close the private `_mmap` object. See also [numpy issue #13510](https://github.com/numpy/numpy/issues/13510)
* the good old workaround for big sur is not needed on newer python versions - which also means that carving will have the 3D preview again on mac - yay.
* There was some duplicate code for device selection in the NN workflows, and since I was adding the `mps` device, I didn't want to do it twice.

- [x] Needs python 3.9 #2703 