### PR TITLE
increase timeout to launch tiktorch

### DIFF
--- a/ilastik/workflows/neuralNetwork/_localLauncher.py
+++ b/ilastik/workflows/neuralNetwork/_localLauncher.py
@@ -71,7 +71,7 @@ class LocalServerLauncher:
 
             self._process = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
             try:
-                wait(lambda: os.path.exists(conn_param_path), max_wait=20)
+                wait(lambda: os.path.exists(conn_param_path), max_wait=60)
             except RuntimeError:
                 self.stop()
 


### PR DESCRIPTION
Unfortunately it can take longer than 20 seconds...


cc: @btbest 
