### PR TITLE
make NN-related operators aware of tensor ids

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -59,7 +59,7 @@ outputs:
         - xarray
         - z5py
       run_constrained:
-        - tiktorch >=23.6.0
+        - tiktorch >=23.7.0
         - volumina >=1.3.10
 
     test:
@@ -103,7 +103,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.6.0*
+        - tiktorch 23.7.0*
         - inferno
         - torchvision
         - volumina
@@ -152,7 +152,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.6.0*
+        - tiktorch 23.7.0*
         - inferno
         - torchvision
         - cudatoolkit >=10.2

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -51,7 +51,7 @@ dependencies:
   - cpuonly
   # - pytorch 1.9.*=*cu*
   # - cudatoolkit 11.1.*
-  - tiktorch >=23.6.0
+  - tiktorch >=23.7.0
 
   # dev-only dependencies
   - conda-build

--- a/ilastik/config.py
+++ b/ilastik/config.py
@@ -24,7 +24,7 @@ import os
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import appdirs
 
@@ -83,7 +83,7 @@ filename: in
 
 @dataclass
 class RuntimeCfg:
-    tiktorch_executable: Optional[str] = None
+    tiktorch_executable: Optional[List[str]] = None
     preferred_cuda_device_id: Optional[str] = None
 
 

--- a/lazyflow/metaDict.py
+++ b/lazyflow/metaDict.py
@@ -23,6 +23,7 @@ from builtins import zip
 ###############################################################################
 # Python
 import copy
+from typing import Dict, List
 import warnings
 
 from collections import OrderedDict, defaultdict
@@ -145,7 +146,7 @@ class MetaDict(defaultdict):
         # _setupOutputs or setValue (or copied via _changed)
         self._ready = origready
 
-    def getTaggedShape(self):
+    def getTaggedShape(self) -> Dict[str, int]:
         """Convenience function for creating an OrderedDict of axistag
         keys and shape dimensions.
 
@@ -158,7 +159,7 @@ class MetaDict(defaultdict):
     def getShape5D(self):
         return Shape5D(**self.getTaggedShape())
 
-    def getAxisKeys(self):
+    def getAxisKeys(self) -> List[str]:
         assert self.axistags is not None
         return [tag.key for tag in self.axistags]
 

--- a/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
+++ b/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
@@ -27,6 +27,7 @@ def pb_session():
         outputShapes=[
             inference_pb2.OutputShape(
                 shapeType=1,
+                referenceTensor="input",
                 offset=inference_pb2.NamedFloats(
                     namedFloats=[
                         inference_pb2.NamedFloat(name="x", size=16),
@@ -50,20 +51,22 @@ def pb_session():
                 ),
             )
         ],
+        inputNames=["input"],
+        outputNames=["output"],
     )
 
 
 def test_get_halo_returns_values_specified_by_tags(pb_session):
     model_session = ModelSession(session=pb_session, factory=mock.Mock())
-    assert model_session.get_halos(axes="xy") == [(256, 128)]
-    assert model_session.get_halos(axes="yx") == [(128, 256)]
-    assert model_session.get_halos(axes="yxc") == [(128, 256, 1)]
+    assert model_session.get_halos(axes="xy") == {"output": (256, 128)}
+    assert model_session.get_halos(axes="yx") == {"output": (128, 256)}
+    assert model_session.get_halos(axes="yxc") == {"output": (128, 256, 1)}
 
 
 def test_get_halo_returns_0_if_value_is_unspecified(pb_session):
     model_session = ModelSession(session=pb_session, factory=mock.Mock())
-    assert model_session.get_halos(axes="xyz") == [(256, 128, 0)]
-    assert model_session.get_halos(axes="txyz") == [(0, 256, 128, 0)]
+    assert model_session.get_halos(axes="xyz") == {"output": (256, 128, 0)}
+    assert model_session.get_halos(axes="txyz") == {"output": (0, 256, 128, 0)}
 
 
 def test_get_output_shape(pb_session):
@@ -71,16 +74,16 @@ def test_get_output_shape(pb_session):
     model_session = ModelSession(session=pb_session, factory=mock.Mock())
 
     output_shape = model_session.get_output_shapes()
-    assert output_shape == [[{"x": 1056, "y": 320, "c": 8}]]
+    assert output_shape == {"output": [{"x": 1056, "y": 320, "c": 8}]}
 
 
 def test_get_input_shape(pb_session):
     model_session = ModelSession(session=pb_session, factory=mock.Mock())
 
-    assert model_session.get_input_shapes("xyc") == [[(1024, 512, 1)]]
-    assert model_session.get_input_shapes("cyx") == [[(1, 512, 1024)]]
-    assert model_session.get_input_shapes("c") == [[(1,)]]
-    assert model_session.get_input_shapes("tzyxc") == [[(1, 1, 512, 1024, 1)]]
+    assert model_session.get_input_shapes("xyc") == {"input": [(1024, 512, 1)]}
+    assert model_session.get_input_shapes("cyx") == {"input": [(1, 512, 1024)]}
+    assert model_session.get_input_shapes("c") == {"input": [(1,)]}
+    assert model_session.get_input_shapes("tzyxc") == {"input": [(1, 1, 512, 1024, 1)]}
 
 
 def test_known_classes(pb_session):


### PR DESCRIPTION
In preparation for NN-like workflows to handle models with multiple in- and outputs and support tensor names/ids [which are mandatory in the spec](https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/model_spec_latest.md#bioimageio-model-resource-description-file-specification-049). These changes still work only for single in- and output models. Will make this operator properly work with multiple inputs/outputs in follow up work with an example workflow.

Summary
* `OpNNclass` tensor id aware, but expects only a single in- and output
  tensor.
* `ModelSession`:
  * added convenience properties for in and output names.
  * getters for input and output shapes now return dicts with tensor ids
    as keys.
* added a few type annotations for peace of mind.

note: this requires [tiktorch 23.7.0](https://github.com/ilastik/tiktorch/pull/205)

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [x] remove temp tiktorch testing channel from ab1d49f5b2a86281ca7038de86e0e16ab98ab78d
- [x] move tiktorch `23.7.0` to main label on ilastik-forge
