### PR TITLE
Undo elf fix

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - h5py
         - hytra >=1.1.5
         - ilastik-feature-selection
-        - ilastikrag
+        - ilastikrag >=0.1.4
         - ilastiktools
         - jsonschema
         - mamutexport
@@ -45,11 +45,12 @@ outputs:
         - ndstructs
         - nifty
         # need to update our packages to be compatible with pandas 2 API
-        - pandas <2
+        - pandas
         - psutil
         - pyopengl
         - pyqt 5.15.*
-        - python-elf
+        # previous versions would set thread limits globally with side effects
+        - python-elf >=0.4.8
         - scikit-image
         - scikit-learn
         - tifffile

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -17,20 +17,20 @@ dependencies:
   - h5py
   - hytra
   - ilastik-feature-selection
-  - ilastikrag
+  - ilastikrag >=0.1.4
   - ilastiktools
   - jsonschema
   - mamutexport
   - marching_cubes
   - ndstructs
   - nifty
-  # need to update our packages to be compatible with pandas 2 API
-  - pandas <2
+  - pandas
   - psutil
   - pyopengl
   - pyqt 5.15.*
   - pyqtgraph
-  - python-elf
+  # previous versions would set thread limits globally with side effects
+  - python-elf >= 0.4.8
   - qimage2ndarray
   - scikit-image
   - scikit-learn

--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -56,7 +56,6 @@ def parallel_watershed(
 
     """
 
-    logger.info(f"blockwise watershed with {max_workers} threads.")
     shape = data.shape
     ndim = len(shape)
 
@@ -67,11 +66,13 @@ def parallel_watershed(
     block_shape = (base_block,) * ndim if block_shape is None else block_shape
     # nifty requires the halo shape to be of type list
     halo = [10] * ndim if halo is None else halo
-    blocking = get_blocking(data, block_shape, roi=None)
 
     if max_workers is None:
         max_workers = max(1, Request.global_thread_pool.num_workers)
 
+    logger.info(f"blockwise watershed with {max_workers} threads.")
+
+    blocking = get_blocking(data, block_shape, roi=None, n_threads=max_workers)
     n_blocks = blocking.numberOfBlocks
 
     labels = np.zeros_like(data, dtype=np.uint32)

--- a/ilastik/workflows/neuralNetwork/_localLauncher.py
+++ b/ilastik/workflows/neuralNetwork/_localLauncher.py
@@ -69,19 +69,7 @@ class LocalServerLauncher:
             conn_param_path = os.path.join(conn_dir, "conn.json")
             cmd = self._executable_path + ["--port", "0", "--addr", "127.0.0.1", "--connection-file", conn_param_path]
 
-            env = os.environ.copy()
-            # HACK: unset environment variables that could be detrimental to neural
-            # network performance. Those in particular set by the elf library.
-            for k in [
-                "OMP_NUM_THREADS",
-                "OPENBLAS_NUM_THREADS",
-                "MKL_NUM_THREADS",
-                "VECLIB_NUM_THREADS",
-                "NUMEXPR_NUM_THREADS",
-            ]:
-                if k in env:
-                    del env[k]
-            self._process = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, env=env)
+            self._process = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
             try:
                 wait(lambda: os.path.exists(conn_param_path), max_wait=60)
             except RuntimeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@ from concurrent import futures
 # https://bugreports.qt.io/browse/QTBUG-87014
 if platform.system().lower() == "darwin":
     mac_ver = tuple(map(int, platform.mac_ver()[0].split(".")))
-    if mac_ver >= (10, 6):
+    python_ver = tuple(map(int, platform.python_version().split(".")))
+    if mac_ver >= (10, 16) and python_ver <= (3, 8, 11):
         os.environ["QT_MAC_WANTS_LAYER"] = "1"
         os.environ["VOLUMINA_SHOW_3D_WIDGET"] = "0"
 

--- a/tests/test_ilastik/helpers/wait.py
+++ b/tests/test_ilastik/helpers/wait.py
@@ -1,0 +1,112 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+import contextlib
+import threading
+import time
+from typing import Optional
+
+from PyQt5.QtCore import QEventLoop, Qt, QTimer
+from PyQt5.QtWidgets import QApplication
+
+
+def wait_until(f, timeout=10):
+    result = f()
+    while not result and timeout:
+        timeout -= 1
+        time.sleep(1)
+        result = f()
+    if not result:
+        raise Exception(f"TIMEOUT! waiting for {f}")
+    return result
+
+
+@contextlib.contextmanager
+def wait_signal(signal, timeout=1000):
+    """
+    Context manager
+    on exit would wait for signal to fire before continuing
+    :param timeout: timeout in ms
+    :param signal:
+    """
+    evtLoop = QEventLoop()
+    # QueuedConnection so we don't receive signal before entering the loop
+    signal.connect(evtLoop.quit, Qt.QueuedConnection)
+
+    yield
+
+    _exec_with_timeout(evtLoop, timeout, signal)
+
+
+@contextlib.contextmanager
+def wait_slot_ready(slot, timeout=1000):
+    """
+    Wait for slot to become ready
+    :param timeout: timeout in ms
+    :param slot: lazyflow slot
+    :return:
+    """
+    evtLoop = QEventLoop()
+
+    def _register():
+        if slot.ready():
+            evtLoop.quit()
+        else:
+            slot.notifyReady(lambda *a, **kw: evtLoop.quit())
+
+    # Use QTimer to avoid event firing before waiting has started
+    QTimer.singleShot(0, _register)
+
+    yield
+
+    _exec_with_timeout(evtLoop, timeout, slot)
+
+
+def _exec_with_timeout(loop, timeout, timeout_obj):
+    timeout_exceeded = False
+
+    def _timeout():
+        nonlocal timeout_exceeded
+        timeout_exceeded = True
+        loop.quit()
+
+    QTimer.singleShot(timeout, _timeout)
+    loop.exec_()
+
+    if timeout_exceeded:
+        raise RuntimeError(f"Timeout exceeded for {timeout_obj}")
+
+
+def wait_process_events(timeout: float = 1.0, event: Optional[threading.Event] = None):
+    """
+    Wait for a certain amount of time or until an event is set
+
+    useful in situations in which there might be interplay of UI and
+    requests.
+
+    this is ugly, especially used without an event there is no guarantee
+    that the state is as expected. but for now, don't know how else to
+    let gui and all requests settle for some actions.
+    """
+    start = time.time()
+    while not (event and event.is_set()):
+        QApplication.processEvents()
+        if time.time() - start > timeout:
+            return

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_parallel_watershed.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_parallel_watershed.py
@@ -40,7 +40,7 @@ def test_parallel_watershed_consistency(data):
     assert max_label == 8
     assert ws.min() == 1
 
-    blocking = get_blocking(data, block_shape, roi=None)
+    blocking = get_blocking(data, block_shape, roi=None, n_threads=2)
     running_max = 1
     for block_index in range(blocking.numberOfBlocks):
         block = blocking.getBlockWithHalo(blockIndex=block_index, halo=halo)

--- a/tests/test_ilastik/test_workflows/testCarvingGui.py
+++ b/tests/test_ilastik/test_workflows/testCarvingGui.py
@@ -34,14 +34,15 @@ if os.environ.get("ON_CIRCLE_CI"):
 
 
 # https://bugreports.qt.io/browse/QTBUG-87014
-is_darwin_bigsur = False
+must_skip_darwing_bigsur = False
 if platform.system().lower() == "darwin":
     mac_ver = tuple(map(int, platform.mac_ver()[0].split(".")))
-    if mac_ver >= (10, 6):
-        is_darwin_bigsur = True
+    python_ver = tuple(map(int, platform.python_version().split(".")))
+    if mac_ver >= (10, 16) and python_ver <= (3, 8, 11):
+        must_skip_darwing_bigsur = True
 
 
-@pytest.mark.skipif(is_darwin_bigsur, reason="CPython cannot find OpenGL system shared lib on macOS 11")
+@pytest.mark.skipif(must_skip_darwing_bigsur, reason="CPython cannot find OpenGL system shared lib on macOS 11")
 class TestCarvingGui(ShellGuiTestCaseBase):
     """Run a set of GUI-based tests on the carving workflow.
 

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -14,29 +14,19 @@ import h5py
 import numpy
 import pytest
 from elf.evaluation import mean_segmentation_accuracy
-from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
+from PyQt5.QtWidgets import QApplication, QMessageBox
 
 from ilastik.applets.dataSelection.opDataSelection import FilesystemDatasetInfo
 from ilastik.workflows.edgeTrainingWithMulticut import EdgeTrainingWithMulticutWorkflow
 from lazyflow.classifiers.parallelVigraRfLazyflowClassifier import ParallelVigraRfLazyflowClassifier
 from lazyflow.utility.timer import Timer
 from tests.test_ilastik.helpers import ShellGuiTestCaseBase
+from tests.test_ilastik.helpers.wait import wait_until, wait_process_events
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 logger.setLevel(logging.DEBUG)
-
-
-def waitProcessEvents(timeout: float = 1.0, event: Optional[threading.Event] = None):
-    # this is ugly, especially used without an event
-    # there is no guarantee that the state is as expected.
-    # but for now, don't know how else to let gui and all requests settle
-    # for some actions
-    start = time.time()
-    while not (event and event.is_set()):
-        QApplication.processEvents()
-        if time.time() - start > timeout:
-            return
 
 
 def get_h5_dataset(file_path, dataset_path):
@@ -72,11 +62,12 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
         cls.output_file = cls.temp_dir / "out_multicut_segmentation.h5"
 
         # reference files
-
         cls.reference_zip_file = (
             current_dir.parent / "data" / "outputdata" / "testEdgeTrainingWithMulticutReference.zip"
         )
         cls.reference_path = cls.temp_dir / "reference"
+
+        cls.sample_gt = cls.reference_path / "multicut_segmentation_rf_t0.5_kerningham-lin.h5"
         cls.reference_files = {
             "superpixels": cls.reference_path / "superpixels.h5",
             "multicut_segmentation_no_rf_t0.5_kerningham-lin": cls.reference_path
@@ -140,6 +131,10 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             opDataSelection.DatasetGroup[0][EdgeTrainingWithMulticutWorkflow.DATA_ROLE_PROBABILITIES].setValue(
                 info_prob
             )
+            info_gt = FilesystemDatasetInfo(
+                filePath=str(self.sample_gt), project_file=self.shell.projectManager.currentProjectFile
+            )
+            opDataSelection.DatasetGroup[0][EdgeTrainingWithMulticutWorkflow.DATA_ROLE_GROUNDTRUTH].setValue(info_gt)
             # Save
             shell.projectManager.saveProject()
 
@@ -201,7 +196,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
 
             # trigger the preprocessing and wait
             gui.update_ws_button.click()
-            waitProcessEvents(timeout=10, event=finished)
+            wait_process_events(timeout=10, event=finished)
             assert finished.is_set()
 
             superpixels = opWsdt.Superpixels[:].wait()
@@ -210,7 +205,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
 
             # Due to small numerical inaccuracies in filtering between the platforms, the
             # superpixels turn out slightly different
-            assert mean_segmentation_accuracy(superpixels, superpixels_reference) > 0.98
+            assert mean_segmentation_accuracy(superpixels, superpixels_reference) > 0.97
             # Save the project
             saveThread = self.shell.onSaveProjectActionTriggered()
             saveThread.join()
@@ -236,7 +231,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             # activate the carving applet
             shell.setSelectedAppletDrawer(2)
             # let the gui catch up
-            waitProcessEvents(timeout=0.1)
+            wait_process_events(timeout=0.1)
             self.waitForViews(gui.editor.imageViews)
 
             gui.train_edge_clf_box.setChecked(False)
@@ -258,7 +253,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             QApplication.processEvents()
             # TODO(k-dominik): fix this timeout thing!
 
-            waitProcessEvents(timeout=2, event=evt)
+            wait_process_events(timeout=2, event=evt)
 
             # load reference data and compare
             mc_segmentation_reference = get_h5_dataset(
@@ -279,9 +274,13 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
     @pytest.mark.skipif(
         platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
     )
+    @pytest.mark.skipif(
+        platform.system() == "Darwin",
+        reason="This test relies on superpixel ids being exactly the same. Due to floating point inaccuracies this might not be the case on Mac.",
+    )
     def test_04_train_rf(self):
         """
-        do multicut on the edge data directly
+        train classifier with edge annotations
         """
 
         def impl():
@@ -332,7 +331,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             gui.live_update_button.click()
 
             # Unfortunately didn't find a good event to wait for
-            waitProcessEvents(timeout=0.5)
+            wait_process_events(timeout=0.5)
             gui.live_update_button.click()
             assert not gui.live_update_button.isChecked()
 
@@ -347,7 +346,77 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
     @pytest.mark.skipif(
         platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
     )
-    def test_05_multicut_rf(self):
+    def test_05_train_rf_from_gt(self):
+        """
+        train classifier from ground truth data
+        """
+
+        def impl():
+            shell = self.shell
+            workflow = shell.projectManager.workflow
+            multicutApplet = workflow.edgeTrainingWithMulticutApplet
+            gui = multicutApplet.getMultiLaneGui().currentGui()
+            opMulticut = multicutApplet.topLevelOperator.getLane(0)
+
+            # activate the carving applet
+            shell.setSelectedAppletDrawer(2)
+            # let the gui catch up
+            QApplication.processEvents()
+            self.waitForViews(gui.editor.imageViews)
+
+            # test test_04_train_rf might be skipped on certain platforms, so
+            if not gui.train_edge_clf_box.isChecked():
+                assert not gui._training_box.isEnabled()
+                gui.train_edge_clf_box.setChecked(True)
+                QApplication.processEvents()
+
+            assert gui.train_edge_clf_box.isChecked()
+            assert gui._training_box.isEnabled()
+
+            # delete all labels if there are any
+            if opMulticut.EdgeLabelsDict.value:
+
+                def handle_msgbox():
+                    msgbox = wait_until(QApplication.instance().activeModalWidget)
+                    msgbox.button(QMessageBox.Ok).click()
+
+                QTimer.singleShot(100, handle_msgbox)
+                gui.clear_labels_button.click()
+                wait_process_events(timeout=1.0)
+
+            assert not opMulticut.EdgeLabelsDict.value
+
+            features = {
+                "Raw Data": ["standard_sp_mean"],
+                "Probabilities-0": [],
+                "Probabilities-1": ["standard_edge_mean"],
+            }
+            opMulticut.FeatureNames.setValue(features)
+
+            gui.train_from_gt_button.click()
+            wait_process_events(timeout=0.5)
+            self.waitForViews(gui.editor.imageViews)
+
+            assert not gui.live_update_button.isChecked()
+            gui.live_update_button.click()
+
+            # Unfortunately didn't find a good event to wait for
+            wait_process_events(timeout=0.5)
+            gui.live_update_button.click()
+            assert not gui.live_update_button.isChecked()
+
+            assert isinstance(opMulticut.opClassifierCache.Output.value, ParallelVigraRfLazyflowClassifier)
+            # Save the project
+            saveThread = self.shell.onSaveProjectActionTriggered()
+            saveThread.join()
+
+        # Run this test from within the shell event loop
+        self.exec_in_shell(impl)
+
+    @pytest.mark.skipif(
+        platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
+    )
+    def test_06_multicut_rf(self):
         """
         do multicut on the edge probabilities
         """
@@ -381,7 +450,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             gui.update_button.click()
             QApplication.processEvents()
 
-            waitProcessEvents(timeout=2, event=evt)
+            wait_process_events(timeout=2, event=evt)
 
             # load reference data and compare
             mc_segmentation_reference = get_h5_dataset(

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -13,7 +13,7 @@ from typing import Optional
 import h5py
 import numpy
 import pytest
-from elf.evaluation import mean_average_precision
+from elf.evaluation import mean_segmentation_accuracy
 from PyQt5.QtWidgets import QApplication
 
 from ilastik.applets.dataSelection.opDataSelection import FilesystemDatasetInfo
@@ -210,7 +210,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
 
             # Due to small numerical inaccuracies in filtering between the platforms, the
             # superpixels turn out slightly different
-            assert mean_average_precision(superpixels, superpixels_reference) > 0.98
+            assert mean_segmentation_accuracy(superpixels, superpixels_reference) > 0.98
             # Save the project
             saveThread = self.shell.onSaveProjectActionTriggered()
             saveThread.join()
@@ -267,7 +267,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             mc_segmentation = opMulticut.Output[:].wait()
 
             assert numpy.unique(mc_segmentation).shape == (5,)
-            assert mean_average_precision(mc_segmentation, mc_segmentation_reference) > 0.98
+            assert mean_segmentation_accuracy(mc_segmentation, mc_segmentation_reference) > 0.98
 
             # Save the project
             saveThread = self.shell.onSaveProjectActionTriggered()
@@ -390,7 +390,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             mc_segmentation = opMulticut.Output[:].wait()
 
             assert numpy.unique(mc_segmentation).shape == (3,)
-            assert mean_average_precision(mc_segmentation, mc_segmentation_reference) > 0.98
+            assert mean_segmentation_accuracy(mc_segmentation, mc_segmentation_reference) > 0.98
 
             # Save the project
             saveThread = self.shell.onSaveProjectActionTriggered()


### PR DESCRIPTION
our hacky fix is not necessary when ensuring elf > 0.4.8

Summary:
* updated pin for `elf`
* updated dependencies for pandas2 (elf --> skan2 --> pandas2)
* removed the hacky fix from #2724
* plus only very vaguely related changes
  * watershed in muticut is sensitive to small numerical inaccuracies in filters. The superpixels are not the same on OSX arm-64. In order to still test the RF training there, added a test that uses ground truth to autolabel. Related to that, we require a slightly lower accuracy (0.98 -> 0.97) to compare superpixels to ground truth.
  * Moved some of the testing utility functions into a single module (`tests.test_ilastik.helpers.wait`) in order to reuse them in the multicut test. There is some overlap in the functions there, but will not solve this now.
  * re-enabled Carving tests on osx - they work now (with python>=3.8) 


xref: #2724
fixes #2725
