### PR TITLE
fix test mouse move

### DIFF
--- a/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
+++ b/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
@@ -135,9 +135,10 @@ class ShellGuiTestCaseBase(object):
     def hiddenCursor(self, imgView: ImageView2D):
         """Context manager that hides the given image view's cursor
 
-        Useful, e.g. when accessing the viewports rendered image - where
+        Useful, e.g. when accessing the viewport's rendered image - where
         sampling the cursor would be unwanted.
         """
+        wasVisible = imgView._crossHairCursor.isVisible()
         try:
             imgView._crossHairCursor.setVisible(False)
             # Wait for the gui to catch up
@@ -146,7 +147,7 @@ class ShellGuiTestCaseBase(object):
 
             yield
         finally:
-            imgView._crossHairCursor.setVisible(True)
+            imgView._crossHairCursor.setVisible(wasVisible)
             # Wait for the gui to catch up
             QApplication.processEvents()
             self.waitForViews([imgView])

--- a/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
+++ b/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
@@ -26,7 +26,6 @@ from typing import Iterable, Union
 
 import pytest
 from ilastik.ilastik_logging import default_config
-from past.utils import old_div
 from PyQt5.QtCore import QEvent, QPoint, QPointF, Qt
 from PyQt5.QtGui import QMouseEvent
 from PyQt5.QtWidgets import QAbstractScrollArea, QApplication, qApp
@@ -151,11 +150,12 @@ class ShellGuiTestCaseBase(object):
         return img.pixel(point)
 
     def moveMouseFromCenter(self, imgView, coords, modifier=Qt.NoModifier):
-        centerPoint = old_div(imgView.rect().bottomRight(), 2)
-        point = QPoint(*coords) + centerPoint
+        centerPoint = imgView.rect().bottomRight() / 2
+        point = _asQPointF(coords) + centerPoint
         move = QMouseEvent(QEvent.MouseMove, point, Qt.NoButton, Qt.NoButton, modifier)
-        QApplication.sendEvent(imgView, move)
+        QApplication.sendEvent(imgView.viewport(), move)
         QApplication.processEvents()
+        self.waitForViews([imgView])
 
     def strokeMouse(
         self,

--- a/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
+++ b/tests/test_ilastik/helpers/shellGuiTestCaseBase.py
@@ -20,12 +20,14 @@
 ###############################################################################
 
 import atexit
+import contextlib
 import numbers
 import threading
-from typing import Iterable, Union
+from typing import Iterable, Sequence, Union
 
 import pytest
 from ilastik.ilastik_logging import default_config
+from volumina.imageView2D import ImageView2D
 from PyQt5.QtCore import QEvent, QPoint, QPointF, Qt
 from PyQt5.QtGui import QMouseEvent
 from PyQt5.QtWidgets import QAbstractScrollArea, QApplication, qApp
@@ -117,7 +119,7 @@ class ShellGuiTestCaseBase(object):
     ### Convenience functions for subclasses to use during testing.
     ###
 
-    def waitForViews(self, views):
+    def waitForViews(self, views: Sequence[ImageView2D]):
         """
         Wait for the given image views to complete their rendering and repainting.
         """
@@ -129,15 +131,38 @@ class ShellGuiTestCaseBase(object):
         # Let the GUI catch up: Process all events
         QApplication.processEvents()
 
+    @contextlib.contextmanager
+    def hiddenCursor(self, imgView: ImageView2D):
+        """Context manager that hides the given image view's cursor
+
+        Useful, e.g. when accessing the viewports rendered image - where
+        sampling the cursor would be unwanted.
+        """
+        try:
+            imgView._crossHairCursor.setVisible(False)
+            # Wait for the gui to catch up
+            QApplication.processEvents()
+            self.waitForViews([imgView])
+
+            yield
+        finally:
+            imgView._crossHairCursor.setVisible(True)
+            # Wait for the gui to catch up
+            QApplication.processEvents()
+            self.waitForViews([imgView])
+
     def getPixelColor(self, imgView, coordinates, debugFileName=None, relativeToCenter=True):
         """
         Sample the color of the pixel at the given coordinates.
         If debugFileName is provided, export the view for debugging purposes.
 
+        Cursor is hidden while sampling the image.
+
         Example:
             self.getPixelColor(myview, (10,10), 'myview.png')
         """
-        img = imgView.grab().toImage()
+        with self.hiddenCursor(imgView):
+            img = imgView.grab().toImage()
 
         if debugFileName is not None:
             img.save(debugFileName)
@@ -149,9 +174,22 @@ class ShellGuiTestCaseBase(object):
 
         return img.pixel(point)
 
-    def moveMouseFromCenter(self, imgView, coords, modifier=Qt.NoModifier):
+    def moveMouseFromCenter(
+        self,
+        imgView: QAbstractScrollArea,
+        point: Union[QPointF, QPoint, Iterable[numbers.Real]],
+        modifier: int = Qt.NoModifier,
+    ):
+        """Move the mouse to a specific point.
+
+        Args:
+            imgView: View that will receive mouse events.
+            point: Target coordinate in relation to imageView center.
+            modifier: This modifier will be active when pressing, moving and releasing.
+
+        """
         centerPoint = imgView.rect().bottomRight() / 2
-        point = _asQPointF(coords) + centerPoint
+        point = _asQPointF(point) + centerPoint
         move = QMouseEvent(QEvent.MouseMove, point, Qt.NoButton, Qt.NoButton, modifier)
         QApplication.sendEvent(imgView.viewport(), move)
         QApplication.processEvents()

--- a/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
+++ b/tests/test_ilastik/test_applets/pixelClassification/testPixelClassificationGui.py
@@ -575,7 +575,6 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             imgView = gui.currentGui().editor.imageViews[1]
 
             # Sanity check: There should be labels in the view that we can erase
-            self.waitForViews([imgView])
             observedColor = self.getPixelColor(imgView, self.LABEL_SAMPLE)
             labelColor = gui.currentGui()._colorTable16[2]
             assert (
@@ -588,7 +587,6 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             labelLayer = gui.currentGui().layerstack[0]
             assert labelLayer.name == "Labels"
             labelLayer.visible = False
-            self.waitForViews([imgView])
             rawDataColor = self.getPixelColor(imgView, self.LABEL_SAMPLE)
             assert (
                 rawDataColor != labelColor
@@ -605,7 +603,6 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
 
             # Erase and verify
             self.strokeMouseFromCenter(imgView, self.LABEL_START, self.LABEL_STOP)
-            self.waitForViews([imgView])
             erasedColor = self.getPixelColor(imgView, self.LABEL_SAMPLE)
             assert erasedColor == rawDataColor, "Eraser did not remove labels! Expected {}, got {}".format(
                 hex(rawDataColor), hex(erasedColor)
@@ -620,10 +617,6 @@ class TestPixelClassificationGui(ShellGuiTestCaseBase):
             rawDataColor = self.getPixelColor(imgView, (5, -5))
             self.strokeMouseFromCenter(imgView, (10, -10), (0, 0))
 
-            # Move the cursor out of the way so we can sample the image
-            self.moveMouseFromCenter(imgView, (20, 20))
-
-            self.waitForViews([imgView])
             erasedColor = self.getPixelColor(imgView, (5, -5))
             assert (
                 erasedColor == rawDataColor


### PR DESCRIPTION
**Summary**

* fixed test "mouse moves" by sending event to the viewport
* fixed getting pixel values from viewports by hiding the cursor.

**Details**

tests relying on getting pixel values from one of the viewports seemed to be involving mouse moves (not strokes) in order to move the cursor out of the fov. I think these might have worked by chance before. At least on osx, where `TestPixelClassificationGui.test_7_EraseCompleteLabel` stopped working.

Mouse move works if sent to the viewport imageview itself, which is fixed in https://github.com/ilastik/ilastik/pull/2736/commits/0857884d4c53e3aaf4cd30e4a0aba1e97f0f4470

I have confirmed that this issue also affects windows. There the test passes by coincidence, due to maybe some slightly different rendering of the crosshair.

In order to get pixel values more reliably than moving the mouse cursor (hopefully) away from the sampled pixel, I changed the `getPixelColor` method to hide the cursor prior to sampling the data. I made sure to confirm that all tests using this method do in fact _not_ want to sample the cursor. I left the `moveMouseFromCenter` method in, as it might be useful in the future, although it's currently not really needed anymore. (https://github.com/ilastik/ilastik/pull/2736/commits/0fa48c761f76cc38856f1722e2f0a07fdefb42a7)

