### PR TITLE
bigger shape in 'z' for tiffs means faster browsing

### DIFF
--- a/lazyflow/operators/ioOperators/opTiffReader.py
+++ b/lazyflow/operators/ioOperators/opTiffReader.py
@@ -102,8 +102,8 @@ class OpTiffReader(Operator):
 
         blockshape = defaultdict(lambda: 1, zip(self._page_axes, self._page_shape))
         # optimization: reading bigger blockshapes in z means much smoother user experience
-        if "z" not in blockshape and "z" in axes:
-            blockshape["z"] = 32
+        # but don't change z if it's part of the page shape
+        blockshape.setdefault("z", 32)
         self.Output.meta.ideal_blockshape = tuple(blockshape[k] for k in axes)
 
     def execute(self, slot, subindex, roi, result):
@@ -141,20 +141,3 @@ class OpTiffReader(Operator):
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.Filepath:
             self.Output.setDirty(slice(None))
-
-
-if __name__ == "__main__":
-    from lazyflow.graph import Graph
-
-    graph = Graph()
-    opReader = OpTiffReader(graph=graph)
-    opReader.Filepath.setValue("/groups/flyem/home/bergs/Downloads/Tiff_t4_HOM3_10frames_4slices_28sec.tif")
-    print(opReader.Output.meta.axistags)
-    print(opReader.Output.meta.shape)
-    print(opReader.Output.meta.dtype)
-    print(opReader.Output[2:3, 2:3, 2:3, 10:20, 20:50].wait().shape)
-
-#     opReader.Filepath.setValue('/magnetic/data/synapse_small.tiff')
-#     print opReader.Output.meta.axistags
-#     print opReader.Output.meta.shape
-#     print opReader.Output.meta.dtype


### PR DESCRIPTION
I thought about overengineering this, taking into account available ram and such... but bottom line is, if you look at any 3D multipage tiff in the quadview, chances are that you're accessing maaany pages (and effectively, caching them):

![quadview(1)](https://github.com/ilastik/ilastik/assets/24434157/9b281f8f-15e6-49e0-bb7f-d9c02d803356)

In this PR the cache size along z is increased from 1 to 32 (arbitrary value, in trials this allowed for smooth scrolling). In most cases this should not even increase the size of used ram (given that the pages are already cached in z=1 blocks).

I don't think there is any benefit of doing something smarter there. If data really is so large that reading it poses a problem, having z=1 would also not be much of a benefit (when accessing in Z) and performance still would be way worse accessing any of the other views (and would equally blow ram). I think in those cases we should advice to use hdf5.