### PR TITLE
let pytest use pytest.ini to discover tests

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -73,6 +73,8 @@ outputs:
         - lazyflow
 
       source_files:
+        - ilastik
+        - lazyflow
         - tests
         - pytest.ini
 
@@ -83,7 +85,7 @@ outputs:
         - tiktorch
 
       commands:
-        - pytest -v .
+        - pytest -v
 
     about:
       home: https://github.com/ilastik/ilastik
@@ -111,6 +113,8 @@ outputs:
 
     test:
       source_files:
+        - ilastik
+        - lazyflow
         - tests
         - pytest.ini
 
@@ -132,7 +136,7 @@ outputs:
 
       commands:
         - ilastik --help
-        - pytest -v .
+        - pytest -v
 
     about:
       home: https://github.com/ilastik/ilastik
@@ -161,6 +165,8 @@ outputs:
 
     test:
       source_files:
+        - ilastik
+        - lazyflow
         - tests
         - pytest.ini
 
@@ -183,7 +189,7 @@ outputs:
 
       commands:
         - ilastik --help
-        - pytest -v .
+        - pytest -v
 
     about:
       home: https://github.com/ilastik/ilastik

--- a/tests/test_ilastik/widgets/test_ImageFileDialog.py
+++ b/tests/test_ilastik/widgets/test_ImageFileDialog.py
@@ -11,7 +11,6 @@ from PyQt5.QtWidgets import QApplication
 from volumina.utility import preferences
 
 
-GH_ACTIONS = os.environ.get("GITHUB_ACTIONS", "false") == "true"
 WIN = platform.system() == "Windows"
 OSX = platform.system() == "Darwin"
 
@@ -37,7 +36,7 @@ def test_default_image_directory_is_home_with_blank_preferences_file():
     assert dialog.directory().absolutePath() == Path.home().as_posix()
 
 
-@pytest.mark.skipif(OSX or GH_ACTIONS and WIN, reason="This test hangs on osx, and on windows when run in GH actions.")
+@pytest.mark.skipif(OSX or WIN, reason="This test hangs on osx, and on windows when run in GH actions.")
 def test_picking_file_updates_default_image_directory_to_previously_used(image: Path, tmp_preferences):
     dialog = ImageFileDialog(None)
     dialog.selectFile(image.as_posix())
@@ -55,7 +54,7 @@ def test_picking_file_updates_default_image_directory_to_previously_used(image: 
         assert json.load(f) == {"DataSelection": {"recent image": image.as_posix()}}
 
 
-@pytest.mark.skipif(OSX or GH_ACTIONS and WIN, reason="This test hangs on osx, and on windows when run in GH actions.")
+@pytest.mark.skipif(OSX or WIN, reason="This test hangs on osx, and on windows when run in GH actions.")
 def test_picking_n5_json_file_returns_directory_path(tmp_n5_file: Path):
     dialog = ImageFileDialog(None)
     dialog.setDirectory(str(tmp_n5_file))


### PR DESCRIPTION
in the conda recipe we had practically overridden the paths for tests by specifying `.` as path. So in the gh actions it worked before as no source folders were present (e.g. collection errors out for me locally when the `bin` folder is checked for tests...)

Also add source folders for doctests.