### PR TITLE
First try most compatible H5 saving, otherwise use v1.8 

### DIFF
--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -463,7 +463,7 @@ class ExportFile(object):
                 except ValueError as e:
                     if libver == "latest":
                         logger.error("latest version of HDF5 export failed in export")
-                        raise ValueError(e)
+                        raise
                     logger.warning(f"Writing {libver} H5 failed, attempting more recent format: {e} ")
                     count = 0
                     self.ExportProgress(0)

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -447,7 +447,7 @@ class ExportFile(object):
         count = 0
         self.ExportProgress(0)
         if mode in ("h5", "hd5", "hdf5"):
-            for libver in ["earliest", "v108"]:
+            for libver in ["earliest", "v108", "latest"]:
                 try:
                     with h5py.File(self.file_name, "w", libver=libver) as fout:
                         for table_name, table in self.table_dict.items():
@@ -460,8 +460,11 @@ class ExportFile(object):
                             )
                             count += 1
                             self.ExportProgress(count * 100 / len(self.table_dict))
-                except ValueError:
-                    logger.warning("Writing most compatible H5 failed, attempting HDF5 v1.8 format")
+                except ValueError as e:
+                    if libver == "latest":
+                        logger.error("latest version of HDF5 export failed in export")
+                        raise ValueError(e)
+                    logger.warning(f"Writing {libver} H5 failed, attempting more recent format: {e} ")
                     count = 0
                     self.ExportProgress(0)
                     continue

--- a/tests/test_ilastik/test_utility/test_exportFile.py
+++ b/tests/test_ilastik/test_utility/test_exportFile.py
@@ -1,7 +1,8 @@
-import pytest
+import h5py
 import numpy as np
+import pytest
 
-from ilastik.utility.exportFile import create_slicing
+from ilastik.utility.exportFile import ExportFile, Mode, create_slicing
 
 
 class TestCreateSlicing:
@@ -20,3 +21,44 @@ class TestCreateSlicing:
 
         with pytest.raises(ValueError):
             all_slicings = list(slicings)
+
+
+@pytest.mark.parametrize("n_records", [100, 1000, 1200, 1800, 2000, 2200])
+def test_write_huge_tables(tmp_path, n_records):
+    """
+    test that we can write tables with a large number of columns (>1000)
+
+    xref: https://github.com/ilastik/ilastik/issues/2714
+    """
+    fname = tmp_path / "test.h5"
+
+    export_file = ExportFile(file_name=fname)
+
+    export_file.add_columns(
+        "test_table", np.ones((1, n_records), dtype=[(f"{i}", "f2") for i in range(n_records)]), Mode.NumpyStructArray
+    )
+
+    export_file.write_all(mode="h5")
+
+    with h5py.File(fname, "r") as f:
+        assert "test_table" in f
+        assert f["test_table"].shape == (1, n_records)
+
+
+def test_table_to_large_raises(tmp_path):
+    """
+    test that if table really gets to large, it errors out
+
+    xref: https://github.com/ilastik/ilastik/issues/2714
+    """
+    fname = tmp_path / "test.h5"
+    n_records = 2500
+
+    export_file = ExportFile(file_name=fname)
+
+    export_file.add_columns(
+        "test_table", np.ones((1, n_records), dtype=[(f"{i}", "f2") for i in range(n_records)]), Mode.NumpyStructArray
+    )
+
+    with pytest.raises(ValueError):
+        export_file.write_all(mode="h5")


### PR DESCRIPTION
fix for #2714, only uses the v1.8 H5 if necessary


