### PR TITLE
Data input: Phrase axistags error message more user-friendly

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -64,8 +64,15 @@ class CantSaveAsRelativePathsException(Exception):
 
 
 class UnsuitedAxistagsException(Exception):
-    def __init__(self, axistags, shape):
-        super().__init__(f"Axistags {axistags} don't fit data shape {shape}")
+    def __init__(self, axistags: AxisTags, shape):
+        if len(axistags) > len(shape):
+            problem = "Inconsistent metadata: The dataset reports dimensions for which it contains no data."
+        else:
+            problem = "Inconsistent metadata: The dataset has more dimensions than it reports."
+        super().__init__(
+            f"{problem}\nReported axes: {', '.join([tag.key for tag in axistags])}\n"
+            f"Actual data dimensions: {', '.join([str(s) for s in shape])} (pixels/channels/timepoints)"
+        )
 
 
 class DatasetInfo(ABC):


### PR DESCRIPTION
Inspired by https://forum.image.sc/t/error-loading-file-ilastik/81584, I was looking for error messages relating to axistags and image shape, as I recall seeing some during my own use that were quite ugly and not understandable.

I couldn't find any other ones though, so here's a suggestion for the one mentioned in the issue on the forum.

Old: 
<img width="256" alt="Screenshot from image.sc" src="https://global.discourse-cdn.com/business4/uploads/imagej/original/3X/c/b/cb4a9bf4e64d985bcfb17650cb7452748b0ff024.png">

New (with a forced error, since I have no broken example file 🙃 ): 
<img width="256" alt="Screenshot 2023-08-31 114309" src="https://github.com/ilastik/ilastik/assets/63287233/56b66d43-6088-4909-8f44-9a121b901ab4">
