### PR TITLE
Request object features per plugin in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       ILASTIK_ROOT: /root/ilastik
     docker:
-    - image: continuumio/miniconda3
+    - image: condaforge/mambaforge
     steps:
     - checkout
     - run:
@@ -36,17 +36,17 @@ jobs:
       TEST_ENV_NAME: test-env
       VOLUMINA_SHOW_3D_WIDGET: 0
     docker:
-    - image: continuumio/miniconda3
+    - image: condaforge/mambaforge
     steps:
     - restore_cache:
         name: restoring dependency cache
         keys:
         # This branch if available
-        - v1.4.13-dep-{{ .Branch }}-{{ epoch }}
+        - v1.4.14-dep-{{ .Branch }}-{{ epoch }}
         # Default branch if not
-        - v1.4.13-dep-main-
+        - v1.4.14-dep-main-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.4.13-dep-
+        - v1.4.14-dep-
     - restore_cache:
         name: restore ilastik-repo cache
         key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
@@ -55,8 +55,7 @@ jobs:
         # due to an incompatibility of mamba with conda 4.13, one currently cannot update conda first
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
-            conda install -n base -c conda-forge mamba &&
-            mamba update -q conda -c conda-forge &&
+            mamba update -n base -c conda-forge --all &&
             mamba install -n base -c conda-forge conda-build boa
     - run:
         name: install apt dependencies
@@ -74,16 +73,15 @@ jobs:
     - run:
         name: run ilastik tests
         command: >
-            conda activate ${TEST_ENV_NAME} &&
             cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
             mkdir test-results &&
-            xvfb-run --server-args="-screen 0 1024x768x24" pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
+            xvfb-run --server-args="-screen 0 1024x768x24" mamba run -n ${TEST_ENV_NAME} pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
             bash <(curl -s https://codecov.io/bash)
     - store_test_results:
         path: test-results
     - save_cache:
         name: store dependency cache
-        key: v1.4.13-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.4.14-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /opt/conda/pkgs
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,25 +5,31 @@ clone_folder: c:\projects\ilastik
 environment:
   ENV_NAME: test-env
   # set miniconda version explicitly
-  MINICONDA: C:\Miniconda38-x64
+  MINIFORGE: C:\Miniforge
   IlASTIK_ROOT: C:\ilastik
   VOLUMINA_SHOW_3D_WIDGET: 0
   APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -xr!*/ -ir-!*.tar.bz2 -ir-!*.conda  # Exclude directories only cache downloaded tars
 
-cache:
-  - C:\Miniconda38-x64\pkgs -> appveyor.yml
 
 install:
-  - cmd: set "PATH=%MINICONDA%;%MINICONDA%\Scripts;%MINICONDA%\Library\bin;%PATH%
-  - cmd: where conda
+  - ps: |
+        if (!(Test-Path $env:MINIFORGE)) {
+          Write-Output "Downloading and installing Miniforge"
+          Invoke-WebRequest https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe -OutFile miniforge.exe
+          Start-Process -FilePath "miniforge.exe" -ArgumentList "/NoRegistry=1","/S","/D=$env:MINIFORGE" -Wait
+        }
+        else {
+          Write-Output "Using cached Miniforge install"
+        }
+  - cmd: set PATH=%MINIFORGE%;%MINIFORGE%\Scripts;%MINIFORGE%\Library\bin;%PATH%
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority strict
-  - cmd: conda update -n base -c conda-forge --all
-  - cmd: conda install -n base -c conda-forge mamba conda-build boa setuptools_scm
+  - cmd: conda update -n base -c conda-forge conda mamba
+  - cmd: mamba install -n base -c conda-forge setuptools_scm
   - |
     mamba env create --name %ENV_NAME% --file dev\environment-dev.yml
     mamba install --name %ENV_NAME% --freeze-installed -c ilastik-forge -c conda-forge volumina
     mamba run -n %ENV_NAME% pip install -e .
-  - mamba clean -p
+  - conda clean -p
 
 build: off
 
@@ -31,6 +37,13 @@ test_script:
   - cmd: CALL activate %ENV_NAME%
   - cmd: set VOLUMINA_SHOW_3D_WIDGET=0
   - cmd: pytest --run-legacy-gui
+
+after_test:
+  # don't cache the test environment to get clean builds every time
+  - ps: Remove-Item -Path $env:MINIFORGE\envs\$env:ENV_NAME -Recurse -Force
+
+cache:
+  - C:\Miniforge -> appveyor.yml, dev\environment-dev.yml
 
 # on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -698,54 +698,40 @@ class OpRegionFeatures(Operator):
         maxcoords = extrafeats["Coord<Maximum>"].astype(int)
         nobj = mincoords.shape[0]
 
-        # local features: loop over all objects
-        def dictextend(a, b):
-            for key in b:
-                a[key].append(b[key])
-            return a
-
         local_features = collections.defaultdict(lambda: collections.defaultdict(list))
         margin = max_margin(feature_names)
-        has_local_features = {}
-        for plugin_name, feature_dict in feature_names.items():
-            has_local_features[plugin_name] = False
-            for features in feature_dict.values():
-                if "margin" in features:
-                    has_local_features[plugin_name] = True
-                    break
 
-        if numpy.any(margin) > 0:
+        if numpy.any(margin):
             bboxes = {}
             for plugin_name, feature_dict in feature_names.items():
-                if not has_local_features[plugin_name]:
+                if not any("margin" in features for features in feature_dict.values()):
                     continue
 
                 plugin = pluginManager.getPluginByName(plugin_name, "ObjectFeatures")
-                pool = RequestPool()
                 tmp_dicts = [None] * nobj
 
                 def _calc_single(i, raw_bbox, binary_bbox):
                     feats = plugin.plugin_object.compute_local(raw_bbox, binary_bbox, feature_dict, axes)
                     tmp_dicts[i] = feats
 
-                # starting from 0, we stripped 0th background object in global computation
-                for i in range(0, nobj):
-                    logger.debug("processing object {}".format(i))
-                    if i not in bboxes:
-                        extent = self.compute_extent(i, image, mincoords, maxcoords, axes, margin)
-                        raw_bbox = self.compute_rawbbox(image, extent, axes)
-                        # it's i+1 here, because the background has label 0
-                        binary_bbox = numpy.where(labels[tuple(extent)] == i + 1, 1, 0).astype(bool)
-                        bboxes[i] = (raw_bbox, binary_bbox)
+                with RequestPool() as pool:
+                    # starting from 0, we stripped 0th background object in global computation
+                    for i in range(nobj):
+                        logger.debug("processing object {}".format(i))
+                        if i not in bboxes:
+                            extent = self.compute_extent(i, image, mincoords, maxcoords, axes, margin)
+                            raw_bbox = self.compute_rawbbox(image, extent, axes)
+                            # it's i+1 here, because the background has label 0
+                            binary_bbox = labels[tuple(extent)] == i + 1
+                            bboxes[i] = (raw_bbox, binary_bbox)
 
-                    raw_bbox, binary_bbox = bboxes[i]
-                    pool.add(Request(partial(_calc_single, i, raw_bbox, binary_bbox)))
+                        raw_bbox, binary_bbox = bboxes[i]
+                        pool.add(Request(partial(_calc_single, i, raw_bbox, binary_bbox)))
 
-                pool.wait()
-                pool.clean()
                 # merge the results
-                for i in range(0, nobj):
-                    local_features[plugin_name] = dictextend(local_features[plugin_name], tmp_dicts[i])
+                for feature_dict in tmp_dicts:
+                    for feature_name, features in feature_dict.items():
+                        local_features[plugin_name][feature_name].append(features)
 
         logger.debug("computing done, removing failures")
         # remove local features that failed

--- a/lazyflow/request/request.py
+++ b/lazyflow/request/request.py
@@ -1246,6 +1246,8 @@ class RequestPool(object):
         - don't call add() from more than one thread
         - don't call wait() from more than one thread, but you CAN add requests
           that are already executing in a different thread to a requestpool
+
+    When used as a context manager, wait() is called on exit, so don't call it yourself.
     """
 
     class RequestPoolError(Exception):
@@ -1271,6 +1273,15 @@ class RequestPool(object):
         self._max_active = max_active or max(max_active, Request.global_thread_pool.num_workers)
 
         self.clean()  # Initialize request sets
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            self.clean()
+        else:
+            self.wait()
 
     def clean(self):
         """

--- a/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localHeadless.py
+++ b/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localHeadless.py
@@ -42,6 +42,8 @@ def test_nn_local_headless_prediction(project_path: pathlib.Path, data_path, tmp
         "yx",
         "--output_filename_format",
         f"{output_file}",
+        "--nn_device",
+        "cpu",
     ]
     # Clear the existing commandline args so it looks like we're starting fresh.
     sys.argv = ["ilastik.py"]


### PR DESCRIPTION
Use request system to allow for parallel computation of local object features.

Will speed up computation if gil is released in features `compute_local` somewhere.

fixes part of #2744 

Todos:

- [x] cleanup
- [x] benchmark our features (also with time-series)
   for our [drosophila example](https://data.ilastik.org/drosophila.zip) I found a 2-3 times speedup in feature computation (all excl location) on my M1 without any numbers changing.