### PR TITLE
Remove string concatenation when raising

### DIFF
--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -326,7 +326,7 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
         elif display_mode == "binary-mask":
             layer = cls._create_binary_mask_layer_from_slot(slot)
         else:
-            raise RuntimeError("unknown channel display mode: " + display_mode)
+            raise RuntimeError(f"unknown channel display mode: {display_mode}")
 
         layer.name = name or slot.name
         layer.visible = visible

--- a/ilastik/workflow.py
+++ b/ilastik/workflow.py
@@ -201,7 +201,7 @@ class Workflow(Operator):
         for subcls in cls.all_subclasses:
             if subcls.__name__ == name:
                 return subcls
-        raise RuntimeError("No known workflow class has name " + name)
+        raise RuntimeError(f"No known workflow class has name {name}")
 
     ###################
     # Private methods #


### PR DESCRIPTION
This fixes as far as I can find all instances where we string-concatenate while `raise`ing. We should avoid this because:

```
> a = None
> "bla" + a
TypeError: can only concatenate str (not "NoneType") to str
```

Tiny detail but this just popped up obscuring an error for me.