### PR TITLE
lazyflow: use exception chaining in requests

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra
-        - xarray
+        - xarray !=2023.10.0
         - z5py
       run_constrained:
         - tiktorch >=23.7.0

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -40,7 +40,8 @@ dependencies:
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
   - vigra 1.11.1=*_1033
-  - xarray
+  # xarray 2023.10.0 package is broken (requires numpy >1.22, but doesn't state this in the dependencies)
+  - xarray !=2023.10.0
   - z5py
 
   # Neural Network Workflow dependencies

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -534,7 +534,7 @@ class OpMissingDataSource(Operator):
         pass
 
     def execute(self, slot, subindex, roi, result):
-        raise MissingDataAccessError
+        raise MissingDataAccessError()
 
     def propagateDirty(self, *args, **kwargs):
         raise ValueError("Will never go here, no inputs...")

--- a/lazyflow/request/request.py
+++ b/lazyflow/request/request.py
@@ -125,7 +125,6 @@ class RequestError(Exception):
             slot = fn.slot.name
             msg = f"Failed to request data from `{op}.{slot}`"
         except Exception:
-            op = slot = None
             msg = "Request failed."
 
         super().__init__(msg)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1217,10 +1217,9 @@ class Slot(object):
             try:
                 self.disconnect()
             except Exception as e:
-                # Well, this is bad.  We caused an exception while handling an exception.
-                # We're more interested in the FIRST exception, so print this one out and
-                #  continue unwinding the stack with the first one.
-                raise RuntimeError("Error while handling an Exception in slot.setValue") from e
+                raise RuntimeError(
+                    f"Unable to disconnect slot after an error in slot.setValues. Slot: {self.name}"
+                ) from e
             raise
 
     @property

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -2,7 +2,6 @@ from builtins import next
 
 from builtins import range
 from builtins import object
-from future.utils import raise_with_traceback
 import sys
 
 if sys.version_info.major >= 3:
@@ -1216,18 +1215,12 @@ class Slot(object):
             self._sig_connect(self)
         except:
             try:
-                exc_info = sys.exc_info()
                 self.disconnect()
-            except:
+            except Exception as e:
                 # Well, this is bad.  We caused an exception while handling an exception.
-                # We're more interested in the FIRST excpetion, so print this one out and
+                # We're more interested in the FIRST exception, so print this one out and
                 #  continue unwinding the stack with the first one.
-                self.logger.error("Error: Caught a secondary exception while handling a different exception.")
-                import traceback
-
-                traceback.print_exc()
-                exc_type, exc_value, exc_tb = exc_info
-                raise_with_traceback(exc_type(exc_value), exc_tb)
+                raise RuntimeError("Error while handling an Exception in slot.setValue") from e
             raise
 
     @property

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -33,7 +33,7 @@ from .fileLock import FileLock
 from .tracer import Tracer, traceLogged
 from .pathHelpers import PathComponents, getPathVariants, isUrl, make_absolute, globH5N5, globList, mkdir_p, lsH5N5
 
-from .roiRequestBatch import RoiRequestBatch
+from .roiRequestBatch import RoiRequestBatch, RoiRequestBatchException
 from .roiRequestBuffer import RoiRequestBufferIter
 from .bigRequestStreamer import BigRequestStreamer
 from . import io_util

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 # 		   http://ilastik.org/license/
 ###############################################################################
 from .alternative_numpy_functions import vigra_bincount, chunked_bincount
+from .exception_helpers import is_root_cause, exception_chain
 from .memory import Memory
 from . import helpers
 from . import jsonConfig

--- a/lazyflow/utility/exception_helpers.py
+++ b/lazyflow/utility/exception_helpers.py
@@ -1,0 +1,44 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from typing import Iterator, Type, Union
+
+
+def exception_chain(exc: Union[BaseException, None]) -> Iterator[BaseException]:
+    """
+    Iterate through an Exception chain
+
+    in order to capture potential `raise from` chains of exceptions.
+    """
+    while exc:
+        yield exc
+        exc = exc.__cause__ or exc.__context__
+
+
+def root_cause(exc: BaseException) -> BaseException:
+    """
+    Traverses the Exception chain and returns the root cause Exception
+    """
+    *_, root_cause = exception_chain(exc)
+    return root_cause
+
+
+def is_root_cause(root_class: Type[BaseException], exc: BaseException) -> bool:
+    return isinstance(root_cause(exc), root_class)

--- a/lazyflow/utility/roiRequestBatch.py
+++ b/lazyflow/utility/roiRequestBatch.py
@@ -19,11 +19,6 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from __future__ import division
-from builtins import next
-from builtins import range
-from builtins import object
-from future.utils import raise_with_traceback
 import sys
 from functools import partial
 
@@ -40,7 +35,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class RoiRequestBatch(object):
+class RoiRequestBatchException(Exception):
+    pass
+
+
+class RoiRequestBatch:
     """
     A simple utility for requesting a list of rois from an output slot.
     The number of rois requested in parallel is throttled by the batch size given to the constructor.
@@ -183,7 +182,7 @@ class RoiRequestBatch(object):
 
                 if self._failure_excinfo:
                     exc_type, exc_value, exc_tb = self._failure_excinfo
-                    raise_with_traceback(exc_type(exc_value), exc_tb)
+                    raise RoiRequestBatchException() from exc_value
 
                 # Launch new requests until we have the correct number of active requests
                 while not self._failure_excinfo and self._activated_count - self._completed_count < self._batchSize:
@@ -193,7 +192,7 @@ class RoiRequestBatch(object):
 
                 if self._failure_excinfo:
                     exc_type, exc_value, exc_tb = self._failure_excinfo
-                    raise_with_traceback(exc_type(exc_value), exc_tb)
+                    raise RoiRequestBatchException() from exc_value
 
         except StopIteration:
             # We've run out of requests to launch.
@@ -204,7 +203,7 @@ class RoiRequestBatch(object):
 
             if self._failure_excinfo:
                 exc_type, exc_value, exc_tb = self._failure_excinfo
-                raise_with_traceback(exc_type(exc_value), exc_tb)
+                raise RoiRequestBatchException() from exc_value
 
         self.progressSignal(100)
 

--- a/lazyflow/utility/roiRequestBuffer.py
+++ b/lazyflow/utility/roiRequestBuffer.py
@@ -4,7 +4,7 @@ from queue import Queue
 import numpy
 
 from lazyflow.graph import Slot
-from lazyflow.utility.roiRequestBatch import RoiRequestBatch
+from lazyflow.utility import RoiRequestBatch, RoiRequestBatchException
 from lazyflow.utility.helpers import bigintprod
 
 

--- a/tests/test_ilastik/test_workflows/carving/test_opPreprocessing.py
+++ b/tests/test_ilastik/test_workflows/carving/test_opPreprocessing.py
@@ -26,27 +26,31 @@ import vigra
 from pytest import raises
 from contextlib import nullcontext as does_not_raise
 from lazyflow.graph import Graph
+from lazyflow.utility import is_root_cause
+from lazyflow.request import RequestError
 
 from ilastik.workflows.carving.opPreprocessing import OpSimpleBlockwiseWatershed
 
 
 @pytest.mark.parametrize(
-    "shape,do_agglo,expectation",
+    "shape,do_agglo,expectation,exp_root_cause",
     [
-        ((9, 9, 9, 9, 1), 0, raises(ValueError)),
-        ((9, 9, 9, 9, 1), 1, raises(ValueError)),
-        ((1, 9, 9, 9, 1), 0, does_not_raise()),
-        ((1, 9, 9, 9, 1), 1, does_not_raise()),
-        ((1, 9, 9, 1, 1), 0, does_not_raise()),
-        ((1, 9, 9, 1, 1), 1, does_not_raise()),
-        ((1, 9, 1, 1, 1), 0, raises(ValueError)),
-        ((1, 9, 1, 1, 1), 1, raises(ValueError)),
+        ((9, 9, 9, 9, 1), 0, raises(RequestError), ValueError),
+        ((9, 9, 9, 9, 1), 1, raises(RequestError), ValueError),
+        ((1, 9, 9, 9, 1), 0, does_not_raise(), None),
+        ((1, 9, 9, 9, 1), 1, does_not_raise(), None),
+        ((1, 9, 9, 1, 1), 0, does_not_raise(), None),
+        ((1, 9, 9, 1, 1), 1, does_not_raise(), None),
+        ((1, 9, 1, 1, 1), 0, raises(RequestError), ValueError),
+        ((1, 9, 1, 1, 1), 1, raises(RequestError), ValueError),
     ],
 )
-def test_OpSimpleBlockwiseWatershed_dimensions(shape, do_agglo, expectation):
+def test_OpSimpleBlockwiseWatershed_dimensions(shape, do_agglo, expectation, exp_root_cause):
     op = OpSimpleBlockwiseWatershed(graph=Graph())
     input_ = vigra.taggedView(np.zeros(shape, dtype="uint8"), "txyzc")
     op.Input.setValue(input_)
     op.DoAgglo.setValue(do_agglo)
-    with expectation:
+    with expectation as exc_info:
         op.Output[:].wait()
+        if exp_root_cause:
+            assert is_root_cause(exp_root_cause, exc_info.value)

--- a/tests/test_lazyflow/conftest.py
+++ b/tests/test_lazyflow/conftest.py
@@ -10,7 +10,7 @@ from lazyflow.graph import Graph
 @pytest.hookimpl()
 def pytest_exception_interact(node, call, report):
     if call.excinfo:
-        stack = format_operator_stack(call.excinfo.tb)
+        stack = format_operator_stack(call.excinfo.value)
         if stack:
             formatted_stack = "".join(stack)
             report.sections.append(("Operator Stack", formatted_stack))

--- a/tests/test_lazyflow/test_operators/testOpReorderAxes.py
+++ b/tests/test_lazyflow/test_operators/testOpReorderAxes.py
@@ -21,12 +21,15 @@ from builtins import range
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-import sys
 import unittest
 import random
 import vigra
 import numpy
+
+import pytest
+
 from lazyflow.graph import Graph, Operator, InputSlot, OutputSlot
+from lazyflow.request.request import RequestError
 from lazyflow.roi import TinyVector
 from lazyflow.roi import roiToSlice
 
@@ -258,7 +261,6 @@ class TestOpReorderAxes(unittest.TestCase):
 
         # Make sure this results in an error.
         req = op.Output[:]
-        req.notify_failed(
-            lambda *args: None
-        )  # We expect an exception here, so disable the default fail handler to hide the traceback
-        self.assertRaises(AssertionError, req.wait)
+
+        with pytest.raises(RequestError):
+            req.wait()

--- a/tests/test_lazyflow/test_operators/testOperatorInterface.py
+++ b/tests/test_lazyflow/test_operators/testOperatorInterface.py
@@ -262,7 +262,7 @@ class OpMultiOutput(graph.Operator):
 
 
 class TestOperatorMultiSlotExecute(object):
-    def setup(self):
+    def setup_method(self):
         self.g = graph.Graph()
 
     def test(self):
@@ -354,11 +354,8 @@ class OpDirectConnection(graph.Operator):
 
 
 class TestSlotStates(object):
-    def setup(self):
+    def setup_method(self):
         self.g = graph.Graph()
-
-    def teardown(self):
-        pass
 
     def test_directlyConnectedOutputs(self):
         op = OpDirectConnection(graph=self.g)

--- a/tests/test_lazyflow/test_operators/testValueProviders.py
+++ b/tests/test_lazyflow/test_operators/testValueProviders.py
@@ -25,6 +25,7 @@ from functools import partial
 import numpy
 import vigra
 import lazyflow.graph
+from lazyflow.utility import is_root_cause
 from lazyflow.operators import OpBlockedArrayCache
 from lazyflow.operators.valueProviders import (
     OpMetadataInjector,
@@ -37,6 +38,8 @@ from lazyflow.operators.valueProviders import (
     MissingDataAccessError,
 )
 import pytest
+
+from lazyflow.request.request import RequestError
 
 
 class TestOpMetadataInjector:
@@ -318,5 +321,7 @@ def test_OpMissingDataSource(graph, metadata):
     for k, v in metadata.items():
         assert op.Output.meta[k] == v
 
-    with pytest.raises(MissingDataAccessError):
-        output = op.Output[...].wait()
+    with pytest.raises(RequestError) as exc_info:
+        _ = op.Output[...].wait()
+
+    assert is_root_cause(MissingDataAccessError, exc_info.value)

--- a/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
+++ b/tests/test_lazyflow/test_utility/testRoiRequestBuffer.py
@@ -3,9 +3,10 @@ import pytest
 from unittest import mock
 
 import vigra
+from lazyflow.utility import is_root_cause
 
 from lazyflow.operators import OpArrayPiper
-from lazyflow.utility import RoiRequestBufferIter
+from lazyflow.utility import RoiRequestBufferIter, RoiRequestBatchException
 from lazyflow.utility.roiRequestBuffer import _RoiIter
 import lazyflow.utility.roiRequestBuffer
 
@@ -106,6 +107,8 @@ def test_raises(raising_op):
     """Make sure iterator does not block indefinitely if exception occurs in thread"""
     rb = RoiRequestBufferIter(raising_op.Output, batchsize=2, iterate_axes="tzc")
 
-    with pytest.raises(ProcessingException):
+    with pytest.raises(RoiRequestBatchException) as exc_info:
         for item in rb:
             assert item.shape == (1, 1, 1, 16, 32)
+
+    assert is_root_cause(ProcessingException, exc_info.value)

--- a/tests/test_lazyflow/test_utility/test_exception_helpers.py
+++ b/tests/test_lazyflow/test_utility/test_exception_helpers.py
@@ -1,0 +1,83 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2023, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+import pytest
+from lazyflow.utility.exception_helpers import exception_chain, is_root_cause, root_cause
+
+
+def test_none_in_exc_chain():
+    exc_chain = list(exception_chain(None))
+
+    assert exc_chain == []
+
+
+@pytest.fixture
+def example_exceptions():
+    ex0 = RuntimeError("ex 0")
+    ex1 = ValueError("ex 1")
+    ex2 = TypeError("ex 2")
+
+    return [ex2, ex1, ex0]
+
+
+@pytest.fixture
+def raising_func(example_exceptions):
+    ex2, ex1, ex0 = example_exceptions
+
+    def fun0():
+        raise ex0
+
+    def fun1():
+        try:
+            fun0()
+        except Exception as e:
+            raise ex1 from e
+
+    def fun2():
+        try:
+            fun1()
+        except Exception as e:
+            raise ex2 from e
+
+    return fun2
+
+
+def test_exc_chain(example_exceptions, raising_func):
+    try:
+        raising_func()
+    except Exception as e:
+        for exc, expected_exc in zip(exception_chain(e), example_exceptions):
+            assert exc == expected_exc
+
+
+def test_root_cause(example_exceptions, raising_func):
+    *_, chain_root_cause = example_exceptions
+    try:
+        raising_func()
+    except Exception as e:
+        assert root_cause(e) == chain_root_cause
+
+
+def test_is_root_cause(example_exceptions, raising_func):
+    *_, chain_root_cause = example_exceptions
+    try:
+        raising_func()
+    except Exception as e:
+        assert is_root_cause(type(chain_root_cause), e)

--- a/tests/test_lazyflow/test_utility/test_exception_helpers.py
+++ b/tests/test_lazyflow/test_utility/test_exception_helpers.py
@@ -38,7 +38,7 @@ def example_exceptions():
 
 
 @pytest.fixture
-def raising_func(example_exceptions):
+def raise_nested_exception(example_exceptions):
     ex2, ex1, ex0 = example_exceptions
 
     def fun0():
@@ -59,25 +59,25 @@ def raising_func(example_exceptions):
     return fun2
 
 
-def test_exc_chain(example_exceptions, raising_func):
+def test_exc_chain(example_exceptions, raise_nested_exception):
     try:
-        raising_func()
+        raise_nested_exception()
     except Exception as e:
         for exc, expected_exc in zip(exception_chain(e), example_exceptions):
             assert exc == expected_exc
 
 
-def test_root_cause(example_exceptions, raising_func):
+def test_root_cause(example_exceptions, raise_nested_exception):
     *_, chain_root_cause = example_exceptions
     try:
-        raising_func()
+        raise_nested_exception()
     except Exception as e:
         assert root_cause(e) == chain_root_cause
 
 
-def test_is_root_cause(example_exceptions, raising_func):
+def test_is_root_cause(example_exceptions, raise_nested_exception):
     *_, chain_root_cause = example_exceptions
     try:
-        raising_func()
+        raise_nested_exception()
     except Exception as e:
         assert is_root_cause(type(chain_root_cause), e)


### PR DESCRIPTION
## Motivation

I always struggled with making sense of our tracebacks.

### Example

![image](https://github.com/ilastik/ilastik/assets/24434157/6d17b9a3-6809-42c4-aa1c-c9991cd80cd0)

<details><summary><code>exception-test.py</code></summary>

```Python
# coding: utf-8
from lazyflow.graph import InputSlot, OutputSlot, Graph, Operator


class OpBroken(Operator):
    Out = OutputSlot()

    def setupOutputs(self):
        self.Out.meta.shape = (1,)
        self.Out.meta.dtype = object

    def execute(self, *args, **kwargs):
        raise Exception("OpBroken 👿")

    def propagateDirty(self, *args, **kwargs):
        pass


class OpPassThrough(Operator):
    In = InputSlot()
    Out = OutputSlot()

    def setupOutputs(self):
        self.Out.meta.shape = (1,)
        self.Out.meta.dtype = object

    def execute(self, *args, **kwargs):
        self.In[:].wait()

    def propagateDirty(self, *args, **kwargs):
        pass

g = Graph()
b = OpBroken(graph=g)
m = OpPassThrough(graph=g)
m.name = "OpPT_1"
n = OpPassThrough(graph=g)
n.name = "OpPT_2"
m.In.connect(b.Out)
n.In.connect(n.Out)

n.Out[:].wait()
```

</details>

### Traceback before

```pytb
Traceback (most recent call last):
  File "/Users/kutra/sources/ilastik-meta/ilastik/excptest.py", line 46, in <module>
    n.Out[:].wait()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 541, in wait
    return self._wait(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 564, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 624, in _wait_within_foreign_thread
    raise_with_traceback(exc_value, exc_tb)
  File "/Users/kutra/mambaforge/envs/idev/lib/python3.9/site-packages/future/utils/__init__.py", line 449, in raise_with_traceback
    raise exc.with_traceback(traceback)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 360, in _execute
    self._result = self.fn()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/slot.py", line 870, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operator.py", line 601, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/Users/kutra/sources/ilastik-meta/ilastik/excptest.py", line 30, in execute
    self.In[:].wait()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 541, in wait
    return self._wait(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 564, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 624, in _wait_within_foreign_thread
    raise_with_traceback(exc_value, exc_tb)
  File "/Users/kutra/mambaforge/envs/idev/lib/python3.9/site-packages/future/utils/__init__.py", line 449, in raise_with_traceback
    raise exc.with_traceback(traceback)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 360, in _execute
    self._result = self.fn()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/slot.py", line 870, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operator.py", line 601, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/Users/kutra/sources/ilastik-meta/ilastik/excptest.py", line 30, in execute
    self.In[:].wait()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 541, in wait
    return self._wait(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 564, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 624, in _wait_within_foreign_thread
    raise_with_traceback(exc_value, exc_tb)
  File "/Users/kutra/mambaforge/envs/idev/lib/python3.9/site-packages/future/utils/__init__.py", line 449, in raise_with_traceback
    raise exc.with_traceback(traceback)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/request/request.py", line 360, in _execute
    self._result = self.fn()
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/slot.py", line 870, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/Users/kutra/sources/ilastik-meta/ilastik/lazyflow/operator.py", line 601, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/Users/kutra/sources/ilastik-meta/ilastik/excptest.py", line 15, in execute
    raise Exception("OpBroken 👿")
Exception: OpBroken 👿
```

As a small challenge I invite everyone to try and find the lines that were result of exception passing through each of the operators in the chain/graph.

### Traceback _with_ this PR

```pytb
Traceback (most recent call last):
  File "/ilastik/lazyflow/request/request.py", line 384, in _execute
    self._result = self.fn()
  File "/ilastik/lazyflow/slot.py", line 869, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/ilastik/lazyflow/operator.py", line 602, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/ilastik/excptest.py", line 15, in execute
    raise Exception("OpBroken 👿")
Exception: OpBroken 👿

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/ilastik/lazyflow/request/request.py", line 384, in _execute
    self._result = self.fn()
  File "/ilastik/lazyflow/slot.py", line 869, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/ilastik/lazyflow/operator.py", line 602, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/ilastik/excptest.py", line 30, in execute
    self.In[:].wait()
  File "/ilastik/lazyflow/request/request.py", line 565, in wait
    return self._wait(timeout)
  File "/ilastik/lazyflow/request/request.py", line 588, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/ilastik/lazyflow/request/request.py", line 648, in _wait_within_foreign_thread
    raise RequestError(self.fn) from exc_value
lazyflow.request.request.RequestError: Failed to request data from `OpBroken.Out`

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/ilastik/lazyflow/request/request.py", line 384, in _execute
    self._result = self.fn()
  File "/ilastik/lazyflow/slot.py", line 869, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File "/ilastik/lazyflow/operator.py", line 602, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File "/ilastik/excptest.py", line 30, in execute
    self.In[:].wait()
  File "/ilastik/lazyflow/request/request.py", line 565, in wait
    return self._wait(timeout)
  File "/ilastik/lazyflow/request/request.py", line 588, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/ilastik/lazyflow/request/request.py", line 648, in _wait_within_foreign_thread
    raise RequestError(self.fn) from exc_value
lazyflow.request.request.RequestError: Failed to request data from `OpPT_1.Out`

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/ilastik/excptest.py", line 46, in <module>
    n.Out[:].wait()
  File "/ilastik/lazyflow/request/request.py", line 565, in wait
    return self._wait(timeout)
  File "/ilastik/lazyflow/request/request.py", line 588, in _wait
    self._wait_within_foreign_thread(timeout)
  File "/ilastik/lazyflow/request/request.py", line 648, in _wait_within_foreign_thread
    raise RequestError(self.fn) from exc_value
lazyflow.request.request.RequestError: Failed to request data from `OpPT_2.Out`
```

With exception chaining it is possible to follow the flow of the graph, each operator has it's own little section.
I don't want to get ahead of myself, but I'd say it now is even a bit possible to follow the traceback without knowing about lazyflow.

## Details

(here I already omit `future.utils.raise_with_traceback`)

Before we would re-raise new exceptions of the same type that was encountered with the original exception instance as first argument, e.g.:

```Python
raise OriginalExcType(OriginalExc) from OriginalExc
```

which, and I guess that was a design feature, would result in the same type being raised at the end of the exception chain, as at the root.
In one way this is really nice, the last line of the traceback points towards the root Exception being raised.
With this one could try-except for the root cause.
I cannot really see many other advantages.
I guess its not a big surprise I couldn't find any code of ours that exploits this behavior.
In the end it is really hard to predict, what exceptions can happen along the graph.
However, I'd argue this has several disadvantages:
* produces dense tracebacks that are very hard to interpret, flow of exception is obfuscated
* in many exceptions the arguments matter, we would always stick in an instance of the same type
  * can fail if exceptions don't take any arguments

The code in the proposed changes here makes use of Exception chaining, to better represent the flow of exceptions through the graph. Bottom most section is the most downstream part, the root cause is found at the beginning of the chain. For test code that previously tested exception propagation I added the `is_root_cause` utility function, that enables these tests to still work.

Todo:

* [x] update dev documentation if/once this PR is accepted
* [x] check excepthook for unhandled exceptions, might want to communicate root cause in gui