### PR TITLE
bump tiktorch

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -60,7 +60,7 @@ outputs:
         - xarray
         - z5py
       run_constrained:
-        - tiktorch >=23.7.0
+        - tiktorch >=23.11.0
         - volumina >=1.3.10
 
     test:
@@ -104,7 +104,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.7.0*
+        - tiktorch 23.11.0*
         - inferno
         - torchvision
         - volumina
@@ -153,7 +153,7 @@ outputs:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
         - pytorch >=1.6
-        - tiktorch 23.7.0*
+        - tiktorch 23.11.0*
         - inferno
         - torchvision
         - cudatoolkit >=10.2

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -40,7 +40,7 @@ dependencies:
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
   - vigra 1.11.1=*_1033
-  - xarray
+  - xarray !=2023.10.0
   - z5py
 
   # Neural Network Workflow dependencies
@@ -53,7 +53,7 @@ dependencies:
   - ilastik-pytorch-version-helper-cpu  # comment out for pytorch with cuda
   # - pytorch-cuda=11.3  # uncomment for pytorch with cuda, specify cuda version
 
-  - tiktorch >=23.7.0
+  - tiktorch 23.11.0*
 
   # dev-only dependencies
   - conda-build


### PR DESCRIPTION
bump tiktorch in order to fix NN workflows // changed zenodo API

fixes: #2764 