### PR TITLE
try larger resource class for tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
   checkout_ilastik:
+    resource_class: medium
     working_directory: /root/ilastik/ilastik
     parallelism: 1
     shell: /bin/bash --login
@@ -28,6 +29,7 @@ jobs:
 
   test:
     working_directory: /root/ilastik/ilastik
+    resource_class: large
     parallelism: 1
     shell: /bin/bash --login
     environment:


### PR DESCRIPTION
I'm honestly not sure if this fixes #2766, but it didn't hang in this PR ;). Also makes probably sense to go to larger resource as we are pretty much maxing out the ram usage on the medium ones.

For reference the memory graph for the large one with 8Gb of Ram (medium has 4Gb):

![image](https://github.com/ilastik/ilastik/assets/24434157/0ed9e086-0f14-44f0-af1d-5f9504c49b46)

for the checkout part, I kept the medium resource - cause why not :)