### PR TITLE
also exclude broken xarray version in conda pkg

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra
-        - xarray
+        - xarray !=2023.10.0
         - z5py
       run_constrained:
         - tiktorch >=23.11.0


### PR DESCRIPTION
forgot to do that for 1.4.1b8 (which is broken because of that) -> 1.4.1b9