### PR TITLE
exclude broken xarray builds

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
         - vigra
-        - xarray !=2023.10.0
+        - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
         - z5py
       run_constrained:
         - tiktorch >=23.11.0

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -40,7 +40,9 @@ dependencies:
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
   - vigra 1.11.1=*_1033
-  - xarray !=2023.10.0
+  # xarray versions not compatible with numpy 1.21, 2023.08.0 might be, but lost trust
+  # 2023.10.1 correctly pins numpy to 1.22 and up
+  - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
   - z5py
 
   # Neural Network Workflow dependencies


### PR DESCRIPTION
those builds are not compatible with numpy 1.21

this is only apparent with _some_ models from the model zoo...