### PR TITLE
ilastik 1.4.0post1

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -107,7 +107,7 @@ outputs:
         - volumina >=1.3.8
         - pytorch >=1.6
         - tensorflow 1.14.*
-        - tiktorch 23.2.0*
+        - tiktorch 23.2.0post1*
         - cpuonly
         - inferno
         - torchvision
@@ -156,7 +156,7 @@ outputs:
         - volumina >=1.3.8
         - pytorch >=1.6
         - tensorflow 1.14.*
-        - tiktorch 23.2.0*
+        - tiktorch 23.2.0post1*
         - inferno
         - torchvision
         - cudatoolkit >=10.2

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -49,7 +49,7 @@ dependencies:
   # - pytorch 1.9.*=*cu*
   # - cudatoolkit 11.1.*
   - tensorflow 1.14.*
-  - tiktorch >=23.2.0
+  - tiktorch 23.2.0post1*
 
   # dev-only dependencies
   - conda-build


### PR DESCRIPTION
In order for the Neural Network Workflow to function again we need to include bioimageio packages that support it. This is done via tiktorch pins (and corresponding post release 23.2.0post1).

There is no intention to merge this, but I want to see some success on CI before going further with this.