### PR TITLE
bump numpy 1.22

### DIFF
--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -6,7 +6,7 @@ channels:
   - nodefaults
 dependencies:
   - python 3.9.*
-  - numpy 1.21.*
+  - numpy 1.22.*
   - appdirs
   - cachetools
   - dpct


### PR DESCRIPTION
I wanted to bump vigra, too, with this PR, but currently it is not as straight forward as I was hoping: #2776 