### PR TITLE
Object size filter: Increase permitted value range

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/drawer.ui
+++ b/ilastik/applets/thresholdTwoLevels/drawer.ui
@@ -368,63 +368,71 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Min:</string>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>5</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="minSizeSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Min object area in pixels</string>
-       </property>
-       <property name="maximum">
-        <number>100000</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_7">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Max:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="maxSizeSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Max object area in pixels</string>
-       </property>
-       <property name="maximum">
-        <number>100000000</number>
-       </property>
-      </widget>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Min:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="minSizeSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Min object area in pixels</string>
+           </property>
+           <property name="maximum">
+            <number>2000000000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <property name="spacing">
+          <number>5</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Max:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="maxSizeSpinBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Max object area in pixels</string>
+           </property>
+           <property name="maximum">
+            <number>2000000000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/ilastik/applets/thresholdTwoLevels/drawer.ui
+++ b/ilastik/applets/thresholdTwoLevels/drawer.ui
@@ -393,10 +393,10 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Min object area in pixels</string>
+            <string>Min object area in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
            </property>
            <property name="maximum">
-            <number>2000000000</number>
+            <number>2147483647</number>
            </property>
           </widget>
          </item>
@@ -423,10 +423,10 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Max object area in pixels</string>
+            <string>Max object area in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
            </property>
            <property name="maximum">
-            <number>2000000000</number>
+            <number>2147483647</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
See #2778 

The maximum on QSPinBox also determines its width, so increasing the max also makes the layout wider.

I arranged the Min and Max spin boxes vertically because this applet drawer is already too wide:

![image](https://private-user-images.githubusercontent.com/63287233/290546205-c68019bc-27c6-4d04-b25a-b327050cf389.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDI1NjQ0NDUsIm5iZiI6MTcwMjU2NDE0NSwicGF0aCI6Ii82MzI4NzIzMy8yOTA1NDYyMDUtYzY4MDE5YmMtMjdjNi00ZDA0LWIyNWEtYjMyNzA1MGNmMzg5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFJV05KWUFYNENTVkVINTNBJTJGMjAyMzEyMTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjMxMjE0VDE0MjkwNVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTQ1ZTg5MzNiMmRiN2MzODA4OGY0NjIyZjk3NmE5Yjk5YjM1N2MxNmYzZjRiNDg3M2ExYzc3NWNhN2JjZTZhNGQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.OPaNdZXAaO02dnyYCGna0ufk3lHbN_V4aio69hVwFzY) 

In terms of computation, there are no issues with allowing arbitrary values - if the user chooses nonsensical min and max (e.g. with min > max), there are simply no objects that match the filter. The user can also do this in the current version already.


Fixes #2778 