### PR TITLE
Labeling GUI: Copy colortable

### DIFF
--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -160,9 +160,6 @@ class LabelingGui(LayerViewerGui):
         :param rawInputSlot: Data from the rawInputSlot parameter will be displayed directly underneath the elements
                              (if provided).
         """
-
-        self._colorTable16 = list(colortables.default16_new)
-
         # Do have have all the slots we need?
         assert isinstance(labelingSlots, LabelingGui.LabelingSlots)
         assert labelingSlots.labelInput is not None, "Missing a required slot."
@@ -181,7 +178,7 @@ class LabelingGui(LayerViewerGui):
 
         self._labelingSlots.labelNames.notifyDirty(bind(self._updateLabelList))
         self.__cleanup_fns.append(partial(self._labelingSlots.labelNames.unregisterDirty, bind(self._updateLabelList)))
-        self._colorTable16 = colortables.default16_new
+        self._colorTable16 = list(colortables.default16_new)
         self._programmaticallyRemovingLabels = False
 
         if drawerUiPath is None:


### PR DESCRIPTION
Not copying the list means that when a value is changed (in this case, by the user selecting another color in the ColorDialog), the original list in the colortables module import is modified. This persists until ilastik is restarted.

Fixes https://github.com/ilastik/ilastik/issues/2728
