### PR TITLE
Import legacy urldatasetinfo

### DIFF
--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -1197,6 +1197,13 @@ class AppletSerializer(with_metaclass(ABCMeta, object)):
         if they store relative paths."""
         pass
 
+    def updateLegacyProjectFile(self, file: h5py.File):
+        """Optional override for subclasses. Called during "Import Project".
+        Should modify the file in-place to make it compatible with the current version of the applet.
+        :param file: h5py.File to be modified - a copy of the imported project file.
+        """
+        pass
+
 
 class JSONSerialSlot(SerialSlot):
     """

--- a/ilastik/applets/base/appletSerializer.py
+++ b/ilastik/applets/base/appletSerializer.py
@@ -1197,7 +1197,7 @@ class AppletSerializer(with_metaclass(ABCMeta, object)):
         if they store relative paths."""
         pass
 
-    def updateLegacyProjectFile(self, file: h5py.File):
+    def updateLegacyEntries(self, file: h5py.File):
         """Optional override for subclasses. Called during "Import Project".
         Should modify the file in-place to make it compatible with the current version of the applet.
         :param file: h5py.File to be modified - a copy of the imported project file.

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -319,7 +319,7 @@ class DataSelectionSerializer(AppletSerializer):
         self.topLevelOperator.WorkingDirectory.setValue(newdir)
         self._projectFilePath = newdir
 
-    def updateLegacyProjectFile(self, file: File):
+    def updateLegacyEntries(self, file: File):
         """
         Presence of UrlDatasetInfo indicates this is a pre-multiscale project file created in HBP mode.
         These projects only supported working on the first scale in the list of resolutions

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -332,19 +332,18 @@ class DataSelectionSerializer(AppletSerializer):
         except KeyError:
             return
 
-        for laneIndex, (_, laneGroup) in enumerate(sorted(info_dir.items())):
-            for roleName, infoGroup in sorted(laneGroup.items()):
-                if "__class__" not in infoGroup:
+        for lane_group in info_dir.values():
+            for info_group in lane_group.values():
+                if "__class__" not in info_group or info_group["__class__"][()] != b"UrlDatasetInfo":
                     continue
-                loaded_class_name = infoGroup["__class__"][()].decode("utf-8")
-                if loaded_class_name == "UrlDatasetInfo":
-                    old_nickname = infoGroup["nickname"][()].decode("utf-8")
-                    del infoGroup["__class__"]
-                    del infoGroup["nickname"]
-                    infoGroup["__class__"] = "MultiscaleUrlDatasetInfo".encode("utf-8")
-                    infoGroup["nickname"] = MultiscaleUrlDatasetInfo.nickname_from_url(old_nickname).encode("utf-8")
-                    infoGroup["working_scale"] = "-1".encode("utf-8")
-                    infoGroup["scale_locked"] = "True".encode("utf-8")
+                old_nickname = info_group["nickname"][()].decode()
+                new_nickname = MultiscaleUrlDatasetInfo.nickname_from_url(old_nickname).encode()
+                del info_group["__class__"]
+                del info_group["nickname"]
+                info_group["__class__"] = b"MultiscaleUrlDatasetInfo"
+                info_group["nickname"] = new_nickname
+                info_group["working_scale"] = b"-1"
+                info_group["scale_locked"] = b"True"
 
     def isDirty(self):
         """Return true if the current state of this item

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -338,8 +338,11 @@ class DataSelectionSerializer(AppletSerializer):
                     continue
                 loaded_class_name = infoGroup["__class__"][()].decode("utf-8")
                 if loaded_class_name == "UrlDatasetInfo":
+                    old_nickname = infoGroup["nickname"][()].decode("utf-8")
                     del infoGroup["__class__"]
+                    del infoGroup["nickname"]
                     infoGroup["__class__"] = "MultiscaleUrlDatasetInfo".encode("utf-8")
+                    infoGroup["nickname"] = MultiscaleUrlDatasetInfo.nickname_from_url(old_nickname).encode("utf-8")
                     infoGroup["working_scale"] = "-1".encode("utf-8")
                     infoGroup["scale_locked"] = "True".encode("utf-8")
 

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,37 +18,25 @@ from __future__ import absolute_import
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from typing import List, Tuple, Callable
+import logging
+import os
 from pathlib import Path
 
+import vigra
+
+import ilastik.utility.globals
+from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
+from ilastik.utility import bind
+from lazyflow.utility import PathComponents
+from lazyflow.utility.pathHelpers import getPathVariants, isUrl, isRelative
+from lazyflow.utility.timer import timeLogged
 from .opDataSelection import (
-    OpDataSelection,
-    DatasetInfo,
     FilesystemDatasetInfo,
     RelativeFilesystemDatasetInfo,
     DummyDatasetInfo,
     MultiscaleUrlDatasetInfo,
 )
 from .opDataSelection import PreloadedArrayDatasetInfo, ProjectInternalDatasetInfo
-from lazyflow.operators.ioOperators import OpInputDataReader, OpStackLoader, OpH5N5WriterBigDataset
-from lazyflow.operators.ioOperators.opTiffReader import OpTiffReader
-from lazyflow.operators.ioOperators.opTiffSequenceReader import OpTiffSequenceReader
-from lazyflow.operators.ioOperators.opStreamingH5N5SequenceReaderM import OpStreamingH5N5SequenceReaderM
-from lazyflow.operators.ioOperators.opStreamingH5N5SequenceReaderS import OpStreamingH5N5SequenceReaderS
-from lazyflow.graph import Graph
-
-import os
-import vigra
-import numpy
-from lazyflow.utility import PathComponents
-from lazyflow.utility.timer import timeLogged
-from ilastik.utility import bind
-from lazyflow.utility.pathHelpers import getPathVariants, isUrl, isRelative, splitPath
-import ilastik.utility.globals
-
-from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -524,7 +524,7 @@ class MultiscaleUrlDatasetInfo(DatasetInfo):
         meta = op_reader.Output.meta.copy()
         super().__init__(
             default_tags=meta.axistags,
-            nickname=nickname or self._nickname_from_url(url),
+            nickname=nickname or self.nickname_from_url(url),
             laneShape=meta.shape,
             laneDtype=meta.dtype,
             **info_kwargs,
@@ -557,7 +557,7 @@ class MultiscaleUrlDatasetInfo(DatasetInfo):
         return super().from_h5_group(group, {"url": group["filePath"][()].decode("utf-8")})
 
     @staticmethod
-    def _nickname_from_url(url: str) -> str:
+    def nickname_from_url(url: str) -> str:
         last_url_component = url.rstrip("/").rpartition("/")[2]
         filename_safe = re.sub(r"[^a-zA-Z0-9_.-]", "_", last_url_component)
         return filename_safe

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1657,15 +1657,15 @@ class IlastikShell(QMainWindow):
                 # load the project data from file
                 if importFromPath is None:
                     # FIXME: load the project asynchronously
-                    self.projectManager._loadProject(hdf5File, projectFilePath, readOnly)
+                    self.projectManager.loadProject(hdf5File, projectFilePath, readOnly)
                 else:
                     assert not readOnly, "Can't import into a read-only file."
-                    self.projectManager._importProject(importFromPath, hdf5File, projectFilePath)
+                    self.projectManager.importProject(importFromPath, hdf5File, projectFilePath)
             except Exception as ex:
                 log_exception(logger)
                 self.closeCurrentProject()
 
-                # _loadProject failed, so we cannot expect it to clean up
+                # loadProject failed, so we cannot expect it to clean up
                 # the hdf5 file (but it might have cleaned it up, so we catch
                 # the error)
                 try:

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1457,7 +1457,7 @@ class IlastikShell(QMainWindow):
     def onImportProjectActionTriggered(self):
         """
         Import an existing project into a new file.
-        This involves opening the old file, saving it to a new file, and then opening the new file.
+        Fix known legacy incompatibilities in the new file.
         """
         logger.debug("Import Project Action")
 
@@ -1470,21 +1470,21 @@ class IlastikShell(QMainWindow):
 
         # Select the paths to the ilp to import and the name of the new one we'll create
         importedFilePath = self.getProjectPathToOpen(defaultDirectory)
-        if importedFilePath is not None:
-            preferences.set("shell", "recently imported", importedFilePath)
-            defaultFile, ext = os.path.splitext(importedFilePath)
-            defaultFile += "_imported"
-            defaultFile += ext
-            newProjectFilePath = self.getProjectPathToCreate(defaultFile)
+        if importedFilePath is None:  # User cancelled
+            return
 
-        # If the user didn't cancel
-        if importedFilePath is not None and newProjectFilePath is not None:
-            if not self.ensureNoCurrentProject():
-                return
-            newProjectFile = ProjectManager.createBlankProjectFile(newProjectFilePath)
-            self._loadProject(
-                newProjectFile, newProjectFilePath, workflow_class=None, readOnly=False, importFromPath=importedFilePath
-            )
+        preferences.set("shell", "recently imported", importedFilePath)
+        defaultFile, ext = os.path.splitext(importedFilePath)
+        defaultFile += "_imported"
+        defaultFile += ext
+        newProjectFilePath = self.getProjectPathToCreate(defaultFile)
+        if newProjectFilePath is None or not self.ensureNoCurrentProject():
+            return
+
+        newProjectFile = ProjectManager.createBlankProjectFile(newProjectFilePath)
+        self._loadProject(
+            newProjectFile, newProjectFilePath, workflow_class=None, readOnly=False, importFromPath=importedFilePath
+        )
 
     def onDownloadProjectFromDvidActionTriggered(self):
         logger.debug("Download Project From DVID")

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1457,7 +1457,8 @@ class IlastikShell(QMainWindow):
     def onImportProjectActionTriggered(self):
         """
         Import an existing project into a new file.
-        Fix known legacy incompatibilities in the new file.
+        This mainly serves to convert the project to a different workflow type.
+        Also fixes known legacy incompatibilities in the new file.
         """
         logger.debug("Import Project Action")
 
@@ -1482,6 +1483,8 @@ class IlastikShell(QMainWindow):
             return
 
         newProjectFile = ProjectManager.createBlankProjectFile(newProjectFilePath)
+
+        # workflow_class=None triggers a prompt for the user to choose a workflow type
         self._loadProject(
             newProjectFile, newProjectFilePath, workflow_class=None, readOnly=False, importFromPath=importedFilePath
         )
@@ -1606,7 +1609,8 @@ class IlastikShell(QMainWindow):
 
     def _loadProject(self, hdf5File, projectFilePath, workflow_class, readOnly, importFromPath=None):
         """
-        Load the data from the given hdf5File (which should already be open).
+        Instantiate a ProjectManager and have it either load hdf5File,
+        or import into hdf5File from another project at the given importFromPath.
         Populate the shell with widgets from all the applets in the new workflow.
         """
 

--- a/ilastik/shell/headless/headlessShell.py
+++ b/ilastik/shell/headless/headlessShell.py
@@ -54,7 +54,7 @@ class HeadlessShell(object):
         self.projectManager = ProjectManager(
             self, workflow_class, headless=True, workflow_cmdline_args=self._workflow_cmdline_args
         )
-        self.projectManager._loadProject(hdf5File, newProjectFilePath, readOnly)
+        self.projectManager.loadProject(hdf5File, newProjectFilePath, readOnly)
         self.projectManager.saveProject()
 
     @classmethod
@@ -122,7 +122,7 @@ class HeadlessShell(object):
                 workflow_cmdline_args=self._workflow_cmdline_args,
                 project_creation_args=project_creation_args,
             )
-            self.projectManager._loadProject(hdf5File, projectFilePath, readOnly)
+            self.projectManager.loadProject(hdf5File, projectFilePath, readOnly)
 
         except ProjectManager.FileMissingError:
             logger.error("Couldn't find project file: {}".format(projectFilePath))
@@ -151,7 +151,7 @@ class HeadlessShell(object):
                 project_creation_args=self._workflow_cmdline_args,
             )
 
-            self.projectManager._importProject(oldProjectFilePath, hdf5File, projectFilePath)
+            self.projectManager.importProject(oldProjectFilePath, hdf5File, projectFilePath)
 
     def setAppletEnabled(self, applet, enabled):
         """

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -502,6 +502,7 @@ class ProjectManager(object):
     def _importProject(self, importedFilePath, newProjectFile, newProjectFilePath):
         """
         Load the data from a project and save it to a different project file.
+        Then fix known legacy incompatibilities in the new file.
 
         importedFilePath - The path to a (not open) .ilp file to import data from
         newProjectFile - An hdf5 handle to a new .ilp to load data into (must be open already)
@@ -521,6 +522,7 @@ class ProjectManager(object):
 
             for serializer in serializers:
                 serializer.ignoreDirty = True
+                serializer.updateLegacyProjectFile(self.currentProjectFile)
                 serializer.deserializeFromHdf5(self.currentProjectFile, newProjectFilePath, self._headless)
                 serializer.ignoreDirty = False
             self.closed = False

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -522,7 +522,7 @@ class ProjectManager(object):
 
             for serializer in serializers:
                 serializer.ignoreDirty = True
-                serializer.updateLegacyProjectFile(self.currentProjectFile)
+                serializer.updateLegacyEntries(self.currentProjectFile)
                 serializer.deserializeFromHdf5(self.currentProjectFile, newProjectFilePath, self._headless)
                 serializer.ignoreDirty = False
             self.closed = False

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -159,7 +159,7 @@ class ProjectManager(object):
 
         # FIXME: version comparison
         if not isVersionCompatible(projectVersion):
-            # Must use _importProject() for old project files.
+            # Must use importProject() for old project files.
             raise ProjectManager.ProjectVersionError(projectVersion, ilastik.__version__)
 
         workflow_class = None
@@ -429,7 +429,7 @@ class ProjectManager(object):
             return []
 
     @timeLogged(logger, logging.DEBUG)
-    def _loadProject(self, hdf5File, projectFilePath, readOnly):
+    def loadProject(self, hdf5File, projectFilePath, readOnly):
         """
         Load the data from the given hdf5File (which should already be open).
 
@@ -497,9 +497,9 @@ class ProjectManager(object):
         self.currentProjectFile = None
 
         # Open the snapshot of the old project that we just made
-        self._loadProject(hdf5File, newPath, readOnly)
+        self.loadProject(hdf5File, newPath, readOnly)
 
-    def _importProject(self, importedFilePath, newProjectFile, newProjectFilePath):
+    def importProject(self, importedFilePath, newProjectFile, newProjectFilePath):
         """
         Load the data from a project and save it to a different project file.
         Then fix known legacy incompatibilities in the new file.

--- a/tests/test_ilastik/test_applets/dataSelection/testDataSelectionSerializer.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testDataSelectionSerializer.py
@@ -119,7 +119,7 @@ def mock_project_file(data_path):
 
 def test_imported_legacy_urldatasetinfo_is_converted(mock_project_file, serializer):
     ilp_with_legacy_urldatasetinfo = mock_project_file
-    serializer.updateLegacyProjectFile(ilp_with_legacy_urldatasetinfo)
+    serializer.updateLegacyEntries(ilp_with_legacy_urldatasetinfo)
     datasetinfo_after_import = ilp_with_legacy_urldatasetinfo[TOP_GROUP_NAME]["infos"]["0"]["Raw Data"]
     assert datasetinfo_after_import["__class__"] == b"MultiscaleUrlDatasetInfo"
     assert datasetinfo_after_import["nickname"] == b"localhost_8000"


### PR DESCRIPTION
* Change the "Import Project" flow to allow serializers to modify the imported project file in line with the current ilastik version.
* Implement the functionality for the `DataSelectionSerializer`, upgrading legacy hbp-projects to be compatible with ilastik > 1.4.0

## Checklist

- [x] Add tests.
- [-] Introduce new h5 utils for exists-and-equals, get+decode, replace? (skipped)