### PR TITLE
Use key-strings to identify multiscales

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -704,5 +704,5 @@ class DataSelectionGui(QWidget):
 
         self.addLanes([MultiscaleUrlDatasetInfo(url=dvid_url, subvolume_roi=subvolume_roi)], roleIndex)
 
-    def handleScaleSelected(self, laneIndex, scale_index):
-        self.topLevelOperator.get_lane(laneIndex).ActiveScaleGroup.setValue(scale_index)
+    def handleScaleSelected(self, laneIndex, scale_key):
+        self.topLevelOperator.get_lane(laneIndex).ActiveScaleGroup.setValue(scale_key)

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -18,7 +18,7 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from typing import List
+from typing import List, Dict
 
 from PyQt5.QtCore import Qt, QAbstractItemModel, QModelIndex
 from ilastik.utility import bind
@@ -221,17 +221,20 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
 
         raise NotImplementedError(f"Unknown column: row={index.row()}, column={index.column()}")
 
-    def get_scale_options(self, laneIndex) -> List[str]:
+    def get_scale_options(self, laneIndex) -> Dict[str, str]:
         try:
             datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]
         except IndexError:  # This can happen during "Save Project As"
-            return []
+            return {}
         if not datasetSlot.ready():
-            return []
+            return {}
         datasetInfo = datasetSlot.value
         if not datasetInfo.scales:
-            return []
-        return [_resolution_to_display_string(s["resolution"], datasetInfo.axiskeys) for s in datasetInfo.scales]
+            return {}
+        return {
+            key: _resolution_to_display_string(scale["resolution"], datasetInfo.axiskeys)
+            for key, scale in datasetInfo.scales.items()
+        }
 
     def is_scale_locked(self, laneIndex) -> bool:
         datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
@@ -200,12 +200,12 @@ class ScaleComboBoxDelegate(QStyledItemDelegate):
 
     def createEditor(self, parent: "DatasetDetailedInfoTableView", option, index):
         model: "DatasetDetailedInfoTableModel" = index.model()
-        scales = model.get_scale_options(index.row())
-        if not scales:
+        scale_options = model.get_scale_options(index.row())
+        if not scale_options:
             return None
         combo = QComboBox(parent)
-        for scale_index, scale in enumerate(scales):
-            combo.addItem(scale, scale_index)
+        for scale_key, scale in scale_options.items():
+            combo.addItem(scale, scale_key)
         combo.currentIndexChanged.connect(partial(self.on_combo_selected, index))
         return combo
 
@@ -221,7 +221,7 @@ class ScaleComboBoxDelegate(QStyledItemDelegate):
             # De-focussing the combobox triggers setModelData.
             # We only want to emit when the user actually selects from the combobox.
             return
-        self.parent().scaleSelected.emit(index.row(), editor.currentIndex())
+        self.parent().scaleSelected.emit(index.row(), editor.currentData())
 
     def on_combo_selected(self, index):
         model = index.model()
@@ -246,7 +246,7 @@ class ScaleComboBoxDelegate(QStyledItemDelegate):
 
 class DatasetDetailedInfoTableView(QTableView):
     dataLaneSelected = pyqtSignal(object)  # Signature: (laneIndex)
-    scaleSelected = pyqtSignal(int, int)  # Signature: (lane_index, scale_index)
+    scaleSelected = pyqtSignal(int, str)  # Signature: (lane_index, scale_key)
 
     replaceWithFileRequested = pyqtSignal(int)  # Signature: (laneIndex), or (-1) to indicate "append requested"
     replaceWithStackRequested = pyqtSignal(int)  # Signature: (laneIndex)

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -588,15 +588,11 @@ class UrlDatasetInfo(MultiscaleUrlDatasetInfo):
         """
         from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
 
-        remote_source = RESTfulPrecomputedChunkedVolume(group["filePath"][()].decode().lstrip("precomputed://"))
-        deserialized = super().from_h5_group(
-            group,
-            {
-                "working_scale": remote_source.original_resolution_key,
-                "scale_locked": True,
-            },
-        )
+        deserialized = super().from_h5_group(group)
+        remote_source = RESTfulPrecomputedChunkedVolume(deserialized.url.lstrip("precomputed://"))
         deserialized.nickname = cls._nickname_from_url(deserialized.nickname)
+        deserialized.working_scale = remote_source.highest_resolution_key
+        deserialized.scale_locked = True
         return deserialized
 
 

--- a/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
+++ b/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
@@ -99,8 +99,8 @@ class PrecomputedVolumeBrowser(QDialog):
             f"Full URL: {self.selected_url}\n"
             f"Dataset encoding: {rv.get_encoding()}\n"
             f"Number of scales: {len(rv.scales)}\n"
-            f"Raw dataset shape: {rv.get_shape(rv.original_resolution_key)}\n"
-            f"Lowest scale shape: {rv.get_shape(rv.lowest_scale_key)}\n"
+            f"Raw dataset shape: {rv.get_shape(rv.highest_resolution_key)}\n"
+            f"Lowest scale shape: {rv.get_shape(rv.lowest_resolution_key)}\n"
         )
         # This check-button might have been triggered by pressing Enter.
         # The timer prevents triggering the now enabled OK button by the same keypress.

--- a/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
+++ b/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
@@ -99,8 +99,8 @@ class PrecomputedVolumeBrowser(QDialog):
             f"Full URL: {self.selected_url}\n"
             f"Dataset encoding: {rv.get_encoding()}\n"
             f"Number of scales: {len(rv.scales)}\n"
-            f"Raw dataset shape: {rv.get_shape(-1)}\n"
-            f"Lowest scale shape: {rv.get_shape(0)}\n"
+            f"Raw dataset shape: {rv.get_shape(rv.original_resolution_key)}\n"
+            f"Lowest scale shape: {rv.get_shape(rv.lowest_scale_key)}\n"
         )
         # This check-button might have been triggered by pressing Enter.
         # The timer prevents triggering the now enabled OK button by the same keypress.

--- a/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
+++ b/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
@@ -58,12 +58,14 @@ class OpRESTfulPrecomputedChunkedVolumeReaderNoCache(Operator):
         # Create a RESTfulPrecomputedChunkedVolume object to handle
         self._volume_object = RESTfulPrecomputedChunkedVolume(self.BaseUrl.value)
 
-        current_scale = self.Scale.value if self.Scale.ready() else 0
-        self.chunk_size = self._volume_object.get_chunk_size(current_scale)
-        self.Output.meta.shape = tuple(self._volume_object.get_shape(current_scale))
+        active_scale = self.Scale.value if self.Scale.ready() else self._volume_object.lowest_scale_key
+        self.chunk_size = self._volume_object.get_chunk_size(active_scale)
+        self.Output.meta.shape = tuple(self._volume_object.get_shape(active_scale))
         self.Output.meta.dtype = numpy.dtype(self._volume_object.dtype).type
         self.Output.meta.axistags = vigra.defaultAxistags(self._volume_object.axes)
         self.Output.meta.scales = self._volume_object.scales
+        # To feed back to DatasetInfo and hence the project file
+        self.Output.meta.lowest_scale = self._volume_object.lowest_scale_key
 
     @staticmethod
     def get_intersecting_blocks(blockshape, roi, shape):

--- a/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
+++ b/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
@@ -58,14 +58,14 @@ class OpRESTfulPrecomputedChunkedVolumeReaderNoCache(Operator):
         # Create a RESTfulPrecomputedChunkedVolume object to handle
         self._volume_object = RESTfulPrecomputedChunkedVolume(self.BaseUrl.value)
 
-        active_scale = self.Scale.value if self.Scale.ready() else self._volume_object.lowest_scale_key
+        active_scale = self.Scale.value if self.Scale.ready() else self._volume_object.lowest_resolution_key
         self.chunk_size = self._volume_object.get_chunk_size(active_scale)
         self.Output.meta.shape = tuple(self._volume_object.get_shape(active_scale))
         self.Output.meta.dtype = numpy.dtype(self._volume_object.dtype).type
         self.Output.meta.axistags = vigra.defaultAxistags(self._volume_object.axes)
         self.Output.meta.scales = self._volume_object.scales
         # To feed back to DatasetInfo and hence the project file
-        self.Output.meta.lowest_scale = self._volume_object.lowest_scale_key
+        self.Output.meta.lowest_scale = self._volume_object.lowest_resolution_key
 
     @staticmethod
     def get_intersecting_blocks(blockshape, roi, shape):

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -29,6 +29,9 @@ import requests
 logger = logging.getLogger(__file__)
 
 
+DEFAULT_LOWEST_SCALE_KEY = ""
+
+
 class RESTfulPrecomputedChunkedVolume(object):
     """Class to access "precomputed" data in the neuroglancer style
 
@@ -114,29 +117,29 @@ class RESTfulPrecomputedChunkedVolume(object):
         self.dtype = self._json_info["data_type"]
         self.n_channels = self._json_info["num_channels"]
 
-    def get_chunk_size(self, scale=""):
-        scale = scale if scale else self.lowest_resolution_key
+    def get_chunk_size(self, scale=DEFAULT_LOWEST_SCALE_KEY):
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         n_channels = self.n_channels
         block_shape = numpy.array([n_channels] + self.scales[scale]["chunk_sizes"][0][::-1])
         return block_shape
 
-    def get_resolution(self, scale=""):
-        scale = scale if scale else self.lowest_resolution_key
+    def get_resolution(self, scale=DEFAULT_LOWEST_SCALE_KEY):
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         resolution = numpy.array(self.scales[scale]["resolution"][::-1])
         return resolution
 
-    def get_voxel_offset(self, scale=""):
-        scale = scale if scale else self.lowest_resolution_key
+    def get_voxel_offset(self, scale=DEFAULT_LOWEST_SCALE_KEY):
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         voxel_offset = numpy.array([0] + self.scales[scale]["voxel_offset"][::-1])
         return voxel_offset
 
-    def get_encoding(self, scale=""):
-        scale = scale if scale else self.lowest_resolution_key
+    def get_encoding(self, scale=DEFAULT_LOWEST_SCALE_KEY):
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         encoding = self.scales[scale]["encoding"]
         return encoding
 
-    def get_shape(self, scale=""):
-        scale = scale if scale else self.lowest_resolution_key
+    def get_shape(self, scale=DEFAULT_LOWEST_SCALE_KEY):
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         n_channels = self.n_channels
         shape = numpy.array([n_channels] + self.scales[scale]["size"][::-1])
         return shape
@@ -151,7 +154,7 @@ class RESTfulPrecomputedChunkedVolume(object):
 
         self._json_info = json.loads(r.content)
 
-    def download_block(self, block_coordinates, scale=""):
+    def download_block(self, block_coordinates, scale=DEFAULT_LOWEST_SCALE_KEY):
         """downloads a single block at a given scale
 
         Args:
@@ -159,7 +162,7 @@ class RESTfulPrecomputedChunkedVolume(object):
               assumed
             scale (int): index of the scale to be used
         """
-        scale = scale if scale else self.lowest_resolution_key
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         url, block_shape = self.generate_url(block_coordinates, scale)
         try:
             content = self.downloading(url)
@@ -190,7 +193,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         r = requests.get(url)
         return r.content
 
-    def generate_url(self, block_coordinates, scale=""):
+    def generate_url(self, block_coordinates, scale=DEFAULT_LOWEST_SCALE_KEY):
         """Generate url to access a specific block
 
 
@@ -202,7 +205,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         Returns:
             string: URL to access the block with the given block coordinates
         """
-        scale = scale if scale else self.lowest_resolution_key
+        scale = scale if scale != DEFAULT_LOWEST_SCALE_KEY else self.lowest_resolution_key
         # block shape without channel
         shape = self.get_shape(scale)
         chunk_size = self.get_chunk_size(scale)

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -73,6 +73,8 @@ class RESTfulPrecomputedChunkedVolume(object):
             n_threads (int, optional): number of concurrent downloads
         """
         self.scales = None
+        self.lowest_scale_key = None
+        self.original_resolution_key = None
         self._json_info = None
         self.tmp_data_file = tmp_data_file
         self.volume_url = volume_url
@@ -104,30 +106,37 @@ class RESTfulPrecomputedChunkedVolume(object):
 
         jsonschema.validate(self._json_info, self.info_schema)
 
-        # Precomputed spec requires scales to be ordered from highest resolution (original) to lowest (most downscaled).
-        # We want the opposite: to load the lowest resolution, i.e. smallest file size, first.
-        self.scales = list(reversed(self._json_info["scales"]))
+        # Scales are ordered from original to most-downscaled in Precomputed spec
+        self.lowest_scale_key = self._json_info["scales"][-1]["key"]
+        self.original_resolution_key = self._json_info["scales"][0]["key"]
+        # Reverse so that the ScaleComboBox shows the options ordered from most-downscaled to original
+        self.scales = {scale["key"]: scale for scale in reversed(self._json_info["scales"])}
         self.dtype = self._json_info["data_type"]
         self.n_channels = self._json_info["num_channels"]
 
-    def get_chunk_size(self, scale=0):
+    def get_chunk_size(self, scale=""):
+        scale = scale if scale else self.lowest_scale_key
         n_channels = self.n_channels
         block_shape = numpy.array([n_channels] + self.scales[scale]["chunk_sizes"][0][::-1])
         return block_shape
 
-    def get_resolution(self, scale=0):
+    def get_resolution(self, scale=""):
+        scale = scale if scale else self.lowest_scale_key
         resolution = numpy.array(self.scales[scale]["resolution"][::-1])
         return resolution
 
-    def get_voxel_offset(self, scale=0):
+    def get_voxel_offset(self, scale=""):
+        scale = scale if scale else self.lowest_scale_key
         voxel_offset = numpy.array([0] + self.scales[scale]["voxel_offset"][::-1])
         return voxel_offset
 
-    def get_encoding(self, scale=0):
+    def get_encoding(self, scale=""):
+        scale = scale if scale else self.lowest_scale_key
         encoding = self.scales[scale]["encoding"]
         return encoding
 
-    def get_shape(self, scale=0):
+    def get_shape(self, scale=""):
+        scale = scale if scale else self.lowest_scale_key
         n_channels = self.n_channels
         shape = numpy.array([n_channels] + self.scales[scale]["size"][::-1])
         return shape
@@ -142,7 +151,7 @@ class RESTfulPrecomputedChunkedVolume(object):
 
         self._json_info = json.loads(r.content)
 
-    def download_block(self, block_coordinates, scale=0):
+    def download_block(self, block_coordinates, scale=""):
         """downloads a single block at a given scale
 
         Args:
@@ -150,6 +159,7 @@ class RESTfulPrecomputedChunkedVolume(object):
               assumed
             scale (int): index of the scale to be used
         """
+        scale = scale if scale else self.lowest_scale_key
         url, block_shape = self.generate_url(block_coordinates, scale)
         try:
             content = self.downloading(url)
@@ -180,7 +190,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         r = requests.get(url)
         return r.content
 
-    def generate_url(self, block_coordinates, scale=0):
+    def generate_url(self, block_coordinates, scale=""):
         """Generate url to access a specific block
 
 
@@ -192,10 +202,10 @@ class RESTfulPrecomputedChunkedVolume(object):
         Returns:
             string: URL to access the block with the given block coordinates
         """
+        scale = scale if scale else self.lowest_scale_key
         # block shape without channel
         shape = self.get_shape(scale)
         chunk_size = self.get_chunk_size(scale)
-        scale_key = self.scales[scale]["key"]
         coordinates = block_coordinates
 
         if not numpy.allclose(numpy.remainder(coordinates, chunk_size), 0):
@@ -211,7 +221,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         min_z, min_y, min_x = min_values[1:]  # ignore c
         max_z, max_y, max_x = max_values[1:]
 
-        url = f"{base_url}/{scale_key}/{min_x}-{max_x}_{min_y}-{max_y}_{min_z}-{max_z}"
+        url = f"{base_url}/{scale}/{min_x}-{max_x}_{min_y}-{max_y}_{min_z}-{max_z}"
         return url, downloaded_block_shape
 
 

--- a/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
@@ -32,7 +32,7 @@ def dataset_table(qtbot) -> DatasetDetailedInfoTableView:
     def mock_DatasetDetailedInfoTableModel():
         m = QStandardItemModel()
         m.isEmptyRow = lambda _row: False
-        m.get_scale_options = lambda _row: ["100, 100, 10", "50, 50, 10"] if _row > 0 else []
+        m.get_scale_options = lambda _row: {"100_100_10": "100, 100, 10", "50_50_10": "50, 50, 10"} if _row > 0 else {}
         m.is_scale_locked = lambda _row: _row == 2
         data_rows = [
             ["image", "/usr/root/image.png", "", "z: 1, y: 10, x: 10", "", ""],

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -867,12 +867,13 @@ class TestOpDataSelection_PrecomputedChunks:
         _ = MockRemoteDataset(monkeypatch, self.MOCK_DATASET_URL, self.INFO_JSON, self.CHUNKS)
         op = OpDataSelection(graph=graph)
         op.WorkingDirectory.setValue(os.getcwd())
-        op.ActiveScale.setValue(0)
+        op.ActiveScale.setValue("")
         op.Dataset.setValue(MultiscaleUrlDatasetInfo(url=self.MOCK_DATASET_URL))
         loaded_scale0 = op.Image[:].wait()
         assert numpy.allclose(loaded_scale0, self.IMAGE_SCALED)
 
-        op.ActiveScale.setValue(1)
+        scale_keys = list(op.Image.meta.scales.keys())
+        op.ActiveScale.setValue(scale_keys[1])
         loaded_scale1 = op.Image[:].wait()
         assert numpy.allclose(loaded_scale1, self.IMAGE_ORIGINAL)
 
@@ -884,7 +885,7 @@ class TestOpDataSelection_DatasetInfo:
         "type": "image",
         "data_type": "uint16",
         "num_channels": 1,
-        "scales": [{"chunk_sizes": [[1, 1, 1]], "resolution": [""], "size": [1, 1, 1]}],
+        "scales": [{"key": "foo", "chunk_sizes": [[1, 1, 1]], "resolution": [""], "size": [1, 1, 1]}],
     }
 
     @pytest.fixture
@@ -947,7 +948,7 @@ class TestOpDataSelection_DatasetInfo:
 
         # We know that as of now, a legacy UrlDatasetInfo would be equivalent to a modern MultiscaleUrlDatasetInfo
         # with the scale set to the original resolution (the last in the list), and locked-in.
-        modern_dataset_info.working_scale = -1
+        modern_dataset_info.working_scale = self.MOCK_PRECOMPUTED_INFO["scales"][-1]["key"]
         modern_dataset_info.scale_locked = True
         assert legacy_dataset_info.to_json_data() == modern_dataset_info.to_json_data()
 


### PR DESCRIPTION
The primary benefit of this is to avoid storing integers in the project file, which only make sense to a consumer of the project file if they know the context of how ilastik handles the list of scales (i.e. in reverse order).

In the context of Precomputed specifically, the key-string even contains resolution information. Also for upcoming ome-zarr support, this will allow us to be more flexible in identifying a specific dataset inside the container.

~This branch is based on [btbest:import-legacy-urldatasetinfo](https://github.com/ilastik/ilastik/pull/2795), only the last two commits are additions in this PR.~ Rebased on main since we dropped that one.