### PR TITLE
Cache output from all types of readers

### DIFF
--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -71,6 +71,7 @@ class OpImageReader(Operator):
             self.Image.meta.shape = shape_yxc
             v_tags = info.getAxisTags()
             self.Image.meta.axistags = vigra.AxisTags([v_tags[k] for k in "yxc"])
+            self.Image.meta.ideal_blockshape = self.Image.meta.shape
         else:
             # For 3D, we use zyxc
             # Insert z-axis shape
@@ -78,10 +79,9 @@ class OpImageReader(Operator):
             self.Image.meta.shape = shape_zyxc
 
             # Insert z tag
-            z_tag = vigra.defaultAxistags("z")[0]
-            tags_xyc = [tag for tag in info.getAxisTags()]
-            tags_zyxc = [z_tag] + list(reversed(tags_xyc[:-1])) + tags_xyc[-1:]
-            self.Image.meta.axistags = vigra.AxisTags(tags_zyxc)
+            self.Image.meta.axistags = vigra.defaultAxistags("zyxc")
+            ideal_blockshape = tuple([1] + list(self.Image.meta.shape)[1:])
+            self.Image.meta.ideal_blockshape = ideal_blockshape
 
     def execute(self, slot, subindex, rroi, result):
         filename = self.Filename.value

--- a/lazyflow/operators/ioOperators/opTiffReader.py
+++ b/lazyflow/operators/ioOperators/opTiffReader.py
@@ -101,9 +101,6 @@ class OpTiffReader(Operator):
         self.Output.meta.dtype = numpy.dtype(dtype_code).type
 
         blockshape = defaultdict(lambda: 1, zip(self._page_axes, self._page_shape))
-        # optimization: reading bigger blockshapes in z means much smoother user experience
-        # but don't change z if it's part of the page shape
-        blockshape.setdefault("z", 32)
         self.Output.meta.ideal_blockshape = tuple(blockshape[k] for k in axes)
 
     def execute(self, slot, subindex, roi, result):


### PR DESCRIPTION


We've been kind of inefficient with reading some file formats, e.g. multipage tiff z-stacks. As a remedy [we added a cache](https://github.com/ilastik/ilastik/pull/2737). When axes are not recognized correctly, this cache could still be off (e.g. recognizing the axis first as "t", then the user changing it to "z", the viewing would still suffer, as this change cannot be communicated back to the cache efficiently.

This PR will adds a cache to all output formats that respects the readers `ideal_blockshape` attribute, with the exception for the "z" dimension, where a minimum cache size of `32` is enforced, that guarantees better interactivity for the orthoviews.

This might also be beneficial for the web-formats (but need to check if `ideal_blockshape` there is set up correctly.


## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Check this does not impact performance with formats that might already do some form of internal caching (what about h5 files that have a chunk size of 1 in z, would we be faster there, or does the hdf5 library already do some magic caching there)
- [ ] check _all_ readers if they set `ideal_blockshape` in a sensible way. Maybe enforce it for readers.
- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.


fixes https://github.com/ilastik/ilastik/issues/2797