### PR TITLE
Reimplement urldatasetinfo as legacy

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -26,6 +26,7 @@ import vigra
 
 import ilastik.utility.globals
 from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
+from ilastik.exceptions import UserAbort
 from ilastik.utility import bind
 from lazyflow.utility import PathComponents
 from lazyflow.utility.pathHelpers import getPathVariants, isUrl, isRelative
@@ -260,7 +261,7 @@ class DataSelectionSerializer(AppletSerializer):
 
         if info_class == UrlDatasetInfo:
             if not _confirmLoadLegacyProject():
-                raise RuntimeError("Loading aborted by user.")
+                raise UserAbort("User aborted loading of legacy project file.")
             dirty = True
 
         try:

--- a/ilastik/applets/dataSelection/dataSelectionSerializer.py
+++ b/ilastik/applets/dataSelection/dataSelectionSerializer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,37 +18,25 @@ from __future__ import absolute_import
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from typing import List, Tuple, Callable
+import logging
+import os
 from pathlib import Path
 
+import vigra
+
+import ilastik.utility.globals
+from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
+from ilastik.utility import bind
+from lazyflow.utility import PathComponents
+from lazyflow.utility.pathHelpers import getPathVariants, isUrl, isRelative
+from lazyflow.utility.timer import timeLogged
 from .opDataSelection import (
-    OpDataSelection,
-    DatasetInfo,
     FilesystemDatasetInfo,
     RelativeFilesystemDatasetInfo,
     DummyDatasetInfo,
     MultiscaleUrlDatasetInfo,
 )
 from .opDataSelection import PreloadedArrayDatasetInfo, ProjectInternalDatasetInfo
-from lazyflow.operators.ioOperators import OpInputDataReader, OpStackLoader, OpH5N5WriterBigDataset
-from lazyflow.operators.ioOperators.opTiffReader import OpTiffReader
-from lazyflow.operators.ioOperators.opTiffSequenceReader import OpTiffSequenceReader
-from lazyflow.operators.ioOperators.opStreamingH5N5SequenceReaderM import OpStreamingH5N5SequenceReaderM
-from lazyflow.operators.ioOperators.opStreamingH5N5SequenceReaderS import OpStreamingH5N5SequenceReaderS
-from lazyflow.graph import Graph
-
-import os
-import vigra
-import numpy
-from lazyflow.utility import PathComponents
-from lazyflow.utility.timer import timeLogged
-from ilastik.utility import bind
-from lazyflow.utility.pathHelpers import getPathVariants, isUrl, isRelative, splitPath
-import ilastik.utility.globals
-
-from ilastik.applets.base.appletSerializer import AppletSerializer, getOrCreateGroup, deleteIfPresent
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/ilastik/exceptions.py
+++ b/ilastik/exceptions.py
@@ -1,0 +1,6 @@
+class IlastikException(Exception):
+    pass
+
+
+class UserAbort(IlastikException):
+    pass

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -77,6 +77,7 @@ import ilastik.ilastik_logging.default_config
 from ilastik.workflow import getAvailableWorkflows, getWorkflowFromName
 from ilastik.utility import bind, log_exception
 from ilastik.utility.gui import ThunkEventHandler, ThreadRouter, threadRouted
+from ilastik.exceptions import UserAbort
 from ilastik.applets.base.applet import Applet, ShellRequest
 from ilastik.applets.base.appletGuiInterface import AppletGuiInterface, VolumeViewerGui
 from ilastik.applets.base.singleToMultiGuiAdapter import SingleToMultiGuiAdapter
@@ -1661,7 +1662,6 @@ class IlastikShell(QMainWindow):
                     assert not readOnly, "Can't import into a read-only file."
                     self.projectManager.importProject(importFromPath, hdf5File, projectFilePath)
             except Exception as ex:
-                log_exception(logger)
                 self.closeCurrentProject()
 
                 # loadProject failed, so we cannot expect it to clean up
@@ -1671,7 +1671,10 @@ class IlastikShell(QMainWindow):
                     hdf5File.close()
                 except:
                     pass
-                QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + str(ex))
+
+                if not isinstance(ex, UserAbort):
+                    log_exception(logger)
+                    QMessageBox.warning(self, "Failed to Load", "Could not load project file.\n" + str(ex))
 
             else:
                 stop = time.perf_counter()

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1653,15 +1653,15 @@ class IlastikShell(QMainWindow):
                 # load the project data from file
                 if importFromPath is None:
                     # FIXME: load the project asynchronously
-                    self.projectManager._loadProject(hdf5File, projectFilePath, readOnly)
+                    self.projectManager.loadProject(hdf5File, projectFilePath, readOnly)
                 else:
                     assert not readOnly, "Can't import into a read-only file."
-                    self.projectManager._importProject(importFromPath, hdf5File, projectFilePath)
+                    self.projectManager.importProject(importFromPath, hdf5File, projectFilePath)
             except Exception as ex:
                 log_exception(logger)
                 self.closeCurrentProject()
 
-                # _loadProject failed, so we cannot expect it to clean up
+                # loadProject failed, so we cannot expect it to clean up
                 # the hdf5 file (but it might have cleaned it up, so we catch
                 # the error)
                 try:

--- a/ilastik/shell/headless/headlessShell.py
+++ b/ilastik/shell/headless/headlessShell.py
@@ -54,7 +54,7 @@ class HeadlessShell(object):
         self.projectManager = ProjectManager(
             self, workflow_class, headless=True, workflow_cmdline_args=self._workflow_cmdline_args
         )
-        self.projectManager._loadProject(hdf5File, newProjectFilePath, readOnly)
+        self.projectManager.loadProject(hdf5File, newProjectFilePath, readOnly)
         self.projectManager.saveProject()
 
     @classmethod
@@ -122,7 +122,7 @@ class HeadlessShell(object):
                 workflow_cmdline_args=self._workflow_cmdline_args,
                 project_creation_args=project_creation_args,
             )
-            self.projectManager._loadProject(hdf5File, projectFilePath, readOnly)
+            self.projectManager.loadProject(hdf5File, projectFilePath, readOnly)
 
         except ProjectManager.FileMissingError:
             logger.error("Couldn't find project file: {}".format(projectFilePath))
@@ -151,7 +151,7 @@ class HeadlessShell(object):
                 project_creation_args=self._workflow_cmdline_args,
             )
 
-            self.projectManager._importProject(oldProjectFilePath, hdf5File, projectFilePath)
+            self.projectManager.importProject(oldProjectFilePath, hdf5File, projectFilePath)
 
     def setAppletEnabled(self, applet, enabled):
         """

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -159,7 +159,7 @@ class ProjectManager(object):
 
         # FIXME: version comparison
         if not isVersionCompatible(projectVersion):
-            # Must use _importProject() for old project files.
+            # Must use importProject() for old project files.
             raise ProjectManager.ProjectVersionError(projectVersion, ilastik.__version__)
 
         workflow_class = None
@@ -429,7 +429,7 @@ class ProjectManager(object):
             return []
 
     @timeLogged(logger, logging.DEBUG)
-    def _loadProject(self, hdf5File, projectFilePath, readOnly):
+    def loadProject(self, hdf5File, projectFilePath, readOnly):
         """
         Load the data from the given hdf5File (which should already be open).
 
@@ -497,9 +497,9 @@ class ProjectManager(object):
         self.currentProjectFile = None
 
         # Open the snapshot of the old project that we just made
-        self._loadProject(hdf5File, newPath, readOnly)
+        self.loadProject(hdf5File, newPath, readOnly)
 
-    def _importProject(self, importedFilePath, newProjectFile, newProjectFilePath):
+    def importProject(self, importedFilePath, newProjectFile, newProjectFilePath):
         """
         Load the data from a project and save it to a different project file.
 


### PR DESCRIPTION
Here's what legacy UrlDatasetInfo compatibility could look like if we want to "upgrade in memory".

When attempting to load an old HBP-style project, the user gets a warning to please make a copy: 
![image](https://github.com/ilastik/ilastik/assets/63287233/aeb73173-47a6-4c30-845c-5c16c1dab759)

If the user loads, we use a reimplemented UrlDatasetInfo class that provides the additional fields to upgrade the deserialized dict to a MultiscaleUrlDatasetInfo-equivalent. If the user then saves, we store the upgraded dict claiming to be a "MultiscaleUrlDatasetInfo", which makes older ilastik versions unable to load the newly saved project file.

This is an alternative solution to https://github.com/ilastik/ilastik/pull/2795

## Checklist

- [x] Add test to ensure UrlDatasetInfo.from_h5_group outputs an equivalent dict to MultiscaleUrlDatasetInfo.from_h5_group.
