### PR TITLE
Tests: Deflake scale combobox in test on MacOS

### DIFF
--- a/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
-from PyQt5.QtWidgets import QComboBox, QMessageBox, QApplication
+from PyQt5.QtWidgets import QComboBox, QMessageBox
 
 from ilastik.applets.dataSelection.datasetDetailedInfoTableModel import DatasetColumn
 from ilastik.applets.dataSelection.datasetDetailedInfoTableView import DatasetDetailedInfoTableView
@@ -75,11 +75,14 @@ def test_scale_select_exists_and_triggers_gui_event(dataset_table, mock_gui):
     assert mock_gui.handleScaleSelected.called_once_with(1, 1)
 
 
-def test_locked_scale_select_does_not_trigger_gui_and_informs_user(dataset_table, mock_gui, intercept_info_popup):
+def test_locked_scale_select_does_not_trigger_gui_and_informs_user(
+    qtbot, dataset_table, mock_gui, intercept_info_popup
+):
     dataset_table.scaleSelected.connect(mock_gui.handleScaleSelected)
     scale_cell_multiscale_locked = dataset_table.model().index(2, DatasetColumn.Scale)
+    # Wait needed on Mac to avoid `combobox is None` race condition
+    qtbot.waitUntil(lambda: dataset_table.indexWidget(scale_cell_multiscale_locked) is not None, timeout=1500)
     combobox = dataset_table.indexWidget(scale_cell_multiscale_locked)
-    QApplication.processEvents()  # Needed on Mac to avoid `combobox is None` race condition
     index_changed_mock = mock.Mock()
     combobox.currentIndexChanged.connect(index_changed_mock)
 


### PR DESCRIPTION
`QApplication.processEvents` didn't actually deflake the test unfortunately. I've messed around a bit with a `QTimer` to try whether a hard wait would fix it, and what amount of time would be required.

~Sadly, this seems to work, but only with 200ms or more wait time. It's not a small amount of time to sacrifice for a single test, so I'm not sure if we want to do this or if it's better to skip this test on MacOS...~ This didn't work because QTimer.singleShot of course dispatches the timer on a separate thread, it doesn't make the test thread wait :facepalm: Would have had to use time.sleep or sth.