### PR TITLE
Change default export format to compressed hdf5

### DIFF
--- a/ilastik/applets/dataExport/opDataExport.py
+++ b/ilastik/applets/dataExport/opDataExport.py
@@ -93,7 +93,7 @@ class OpDataExport(Operator):
         value=cfg["ilastik"]["output_filename_format"]
     )  # A format string allowing {dataset_dir} {nickname}, {roi}, {x_start}, {x_stop}, etc.
     OutputInternalPath = InputSlot(value="exported_data")
-    OutputFormat = InputSlot(value="hdf5")
+    OutputFormat = InputSlot(value=cfg["ilastik"]["output_format"])
 
     # Only export csv/HDF5 table (don't export volume)
     TableOnlyName = InputSlot(value="Table-Only")

--- a/ilastik/config.py
+++ b/ilastik/config.py
@@ -29,7 +29,12 @@ from typing import List, Optional, Union
 import appdirs
 
 """
-ilastik will read settings from ~/.ilastikrc
+ilastik will read settings from ilastik.ini
+which should be located at
+
+* windows: C:\\Users\\<USERNAME>\\AppData\\Local\\ilastik
+* osx: /Users/<USERNAME>/Library/Caches/ilastik
+* linux: /home/<USERNAME>/.config/ilastik
 
 Example:
 
@@ -44,6 +49,7 @@ default_config = """
 debug: false
 plugin_directories: ~/.ilastik/plugins,
 output_filename_format: {dataset_dir}/{nickname}_{result_type}
+output_format: compressed hdf5
 
 [lazyflow]
 threads: -1


### PR DESCRIPTION
most ilastik outputs compress very well - compressed hdf5 should be made the default format.
Furthermore the default format can now be customized in the config.

accompanying volumina request to change the default order: https://github.com/ilastik/volumina/pull/313

CC: @oanegros (https://github.com/ilastik/ilastik/issues/2796#issuecomment-1878606777)

