### PR TITLE
Ensure all object features get exported to table

### DIFF
--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -90,17 +90,17 @@ def flatten_ilastik_feature_table(table, selection, signal):
     # a flat list, only with the feature names, without plugin association.
     # So we got through the whole table and and check whether there are object
     # from which we can get the column names
-    computed_features = {}  # {plugin_name: {feature_name: (feature_shape, feature_dtype)}}
+    features_by_plugin = {}  # {plugin_name: {feature_name: (feature_shape, feature_dtype)}}
     for plugins in computed_feature.values():
         for plugin in plugins:
-            if plugin in computed_features or not plugins[plugin]:
+            if plugin in features_by_plugin or not plugins[plugin]:
                 continue
 
-            computed_features[plugin] = {
+            features_by_plugin[plugin] = {
                 feat_name: (feat_array.shape[1], feat_array.dtype) for feat_name, feat_array in plugins[plugin].items()
             }
 
-    for plugin_name, feature_spec in computed_features.items():
+    for plugin_name, feature_spec in features_by_plugin.items():
         all_props = None
 
         if plugin_name == default_features_key:


### PR DESCRIPTION
Everytime I look at `exportFile.py` I want to rewrite it. In lieu of time, another hack...

Previously, only features computed in the 1st timeframe would get a column in the export table. One would expect that with this bug there would be none ;). Global features are always computed -> produce an (empty) table in every frame, but local ones, only if there are objects.

This is more a bandaid then a proper fix. It would probably be better to go from `selected` features (from the dialog) for 
column names, but currently the plugin information is stripped from those :(

CC: @oanegros (thank you for pointing it out and helping to debug)