### PR TITLE
Data Export: Update buttons after removing lane

### DIFF
--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -142,6 +142,7 @@ class DataExportGui(QWidget):
             multislot[index].notifyReady(self._updateExportButtons)
 
         self.topLevelOperator.ExportPath.notifyInserted(bind(handleNewDataset))
+        self.topLevelOperator.ImageToExport.notifyRemoved(self._updateExportButtons)
 
         # For each dataset that already exists, update the GUI
         for i, subslot in enumerate(self.topLevelOperator.ExportPath):


### PR DESCRIPTION
This fixes the disabled "Export All" button by adding a listener to sync the button state to backend after the temporary lane added by batch processing is removed.

Arguably, the real fix is to remove the entire disabling/enabling logic for this button. We prevent the user from reaching the export applet if their project is in a state that cannot be exported anyway. In what state would an individual lane be unexportable?

Fixes #2811

