### PR TITLE
ci: circumvent disk space limitation on D:

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -71,6 +71,7 @@ jobs:
       - uses: al-cheb/configure-pagefile-action@v1.4
         with:
           minimum-size: 12GB
+          disk-root: "C:"
         if: |
           matrix.os == 'windows-latest' &&
           matrix.ilastik_variant == 'ilastik-gpu'


### PR DESCRIPTION
we need larger pagefile size for the neural network tests. D: (default) has a size limit of 12GB, which led to an error.

https://github.com/al-cheb/configure-pagefile-action/issues/18 recommends setting disk root to C:

<details><summary>Warning/Error</summary>

```

test-conda-packages (windows-latest, ilastik-gpu)
Exception calling "SetPageFileSize" with "3" argument(s): "The operation completed successfully"
At D:\a\_actions\al-cheb\configure-pagefile-action\v1.4\scripts\SetPageFileSize.ps1:193 char:1
+ [Util.PageFile]::SetPageFileSize($minimumSize, $maximumSize, $diskRoo ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : Win32Exception
```

</details>
