### PR TITLE
Improve web loading gui

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -648,14 +648,20 @@ class DataSelectionGui(QWidget):
             self.applyDatasetInfos(editorDlg.edited_infos, selected_info_slots)
 
     def addPrecomputedVolume(self, roleIndex, laneIndex):
-        # add history...
-        history = []
+        PREFERENCES_GROUP = "DataSelection"
+        RECENT_URLS_KEY = "recent urls"
+        history = preferences.get(PREFERENCES_GROUP, RECENT_URLS_KEY) or []
         browser = PrecomputedVolumeBrowser(history=history, parent=self)
 
         if browser.exec_() == PrecomputedVolumeBrowser.Rejected:
             return
 
-        info = self.instantiate_dataset_info(url=browser.selected_url, role=roleIndex)
+        url = browser.selected_url
+        if url in history:
+            history.remove(url)
+        preferences.set(PREFERENCES_GROUP, RECENT_URLS_KEY, [url] + history[:9])
+
+        info = self.instantiate_dataset_info(url=url, role=roleIndex)
         self.addLanes([info], roleIndex=roleIndex, startingLaneNum=laneIndex)
 
     def addDvidVolume(self, roleIndex, laneIndex):

--- a/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
+++ b/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
@@ -85,6 +85,14 @@ class PrecomputedVolumeBrowser(QDialog):
         url = self.combo.currentText().strip().lstrip("precomputed://")
         if url == "":
             return
+        if "http" not in url:
+            self.combo.lineEdit().setText(f"https://{url}")
+            msg = (
+                'Address must contain "http". Only web sources are supported.\n\n'
+                'The default "https://" has been added to your URL automatically, please try again.'
+            )
+            self.result_text_box.setText(msg)
+            return
         logger.debug(f"Entered URL: {url}")
         try:
             rv = RESTfulPrecomputedChunkedVolume(volume_url=url)


### PR DESCRIPTION
A couple of small improvements to the web-source selector dialog: Ensuring the URL contains "http", and a history.

`        RECENT_URLS_KEY = "Recent URLs"` <- is this an acceptable key to use for inside the preferences?