### PR TITLE
Data selection: Remove inline Add buttons immediately

### DIFF
--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
@@ -181,11 +181,7 @@ class InlineAddButtonDelegate(QItemDelegate):
                 button.addDvidVolumeRequested.connect(partial(parent_view.handleCellAddDvidVolumeEvent, button))
                 parent_view.setIndexWidget(index, button)
         elif index.data() != "" and button is not None:
-            # If this row has data, we must delete the button.
-            # Otherwise, it can steal input events (e.g. mouse clicks) from the cell, even if it is hidden!
-            # However, we can't remove it yet, because we are currently running in the context of a signal handler for the button itself!
-            # Instead, use a QTimer to delete the button as soon as the eventloop is finished with the current event.
-            QTimer.singleShot(750, lambda: parent_view.setIndexWidget(index, None))
+            parent_view.setIndexWidget(index, None)
         super().paint(painter, option, index)
 
 


### PR DESCRIPTION
This fixes one of our most frequent flaky tests on MacOS:

```
=================================== FAILURES ===================================
___________________ TestOpDataSelection_Basic2D.testBasic2Dc ___________________
CALL ERROR: Exceptions caught in Qt event loop:
________________________________________________________________________________
Traceback (most recent call last):
  File "$SRC_DIR/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py", line 188, in <lambda>
    QTimer.singleShot(750, lambda: parent_view.setIndexWidget(index, None))
RuntimeError: wrapped C/C++ object of type DatasetDetailedInfoTableView has been deleted
```

According to the comment, the timer is there because deleting the indexWidget synchronously is impossible. It seems to work just fine for me to remove the Qtimer though, so either this has been ironed out with some newer Qt version, or the comment is simply outdated. The call is inside the `paint` of an ItemDelegate - it's not inside a signal handler of the button that we delete here.

Please confirm on Mac that the inline Add buttons are deleted as they should? (The one shown here - Create a Pixel Classification project, add raw data, swap to Prediction Mask tab, add a probabilities file there)
![image](https://github.com/ilastik/ilastik/assets/63287233/3a8e433b-6c27-4cc7-8823-954d74409466)
