### PR TITLE
Fix layerviewer update after shape change

### DIFF
--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -458,20 +458,6 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
             msg += str([l.name for l in newGuiLayers])
             raise RuntimeError(msg)
 
-        # If the datashape changed, tell the editor
-        # FIXME: This may not be necessary now that this gui doesn't handle the multi-image case...
-        newDataShape = self.determineDatashape()
-        if newDataShape is not None and self.editor.dataShape != newDataShape:
-            self.editor.dataShape = newDataShape
-            if self._isAnySlotPrefer2d():
-                self.volumeEditorWidget.quadview.ensureMaximized(2)
-
-            # Find the xyz midpoint
-            midpos5d = [x // 2 for x in newDataShape]
-
-            # center viewer there
-            self.setViewerPos(midpos5d)
-
         # Old layers are deleted if
         # (1) They are not in the new set or
         # (2) Their data has changed
@@ -489,6 +475,20 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
                     ShortcutManager().unregister(action_info)
                 self.layerstack.selectRow(index)
                 self.layerstack.deleteSelected()
+
+        # If the datashape changed, tell the editor.
+        # Happens during setup ([0,0,0,0,0] to image shape) and when switching scales (multiscale datasets)
+        newDataShape = self.determineDatashape()
+        if newDataShape is not None and self.editor.dataShape != newDataShape:
+            self.editor.dataShape = newDataShape
+            if self._isAnySlotPrefer2d():
+                self.volumeEditorWidget.quadview.ensureMaximized(2)
+
+            # Find the xyz midpoint
+            midpos5d = [x // 2 for x in newDataShape]
+
+            # center viewer there
+            self.setViewerPos(midpos5d)
 
         # Insert all layers that aren't already in the layerstack
         # (Identified by the name attribute)

--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -463,6 +463,8 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
         newDataShape = self.determineDatashape()
         if newDataShape is not None and self.editor.dataShape != newDataShape:
             self.editor.dataShape = newDataShape
+            if self._isAnySlotPrefer2d():
+                self.volumeEditorWidget.quadview.ensureMaximized(2)
 
             # Find the xyz midpoint
             midpos5d = [x // 2 for x in newDataShape]
@@ -667,15 +669,18 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
             view.doScaleTo(1)
 
         # Should we default to 2D?
+        if self._isAnySlotPrefer2d():
+            # Default to Z (axis 2 in the editor)
+            self.volumeEditorWidget.quadview.ensureMaximized(2)
+
+    def _isAnySlotPrefer2d(self):
         prefer_2d = False
         for multislot in self.observedSlots:
             for slot in multislot:
                 if slot.ready() and slot.meta.prefer_2d:
                     prefer_2d = True
                     break
-        if prefer_2d:
-            # Default to Z (axis 2 in the editor)
-            self.volumeEditorWidget.quadview.ensureMaximized(2)
+        return prefer_2d
 
     def _convertPositionToDataSpace(self, voluminaPosition):
         taggedPosition = {k: p for k, p in zip("txyzc", voluminaPosition)}

--- a/tests/test_ilastik/test_applets/layerViewer/testLayerViewerGui.py
+++ b/tests/test_ilastik/test_applets/layerViewer/testLayerViewerGui.py
@@ -1,0 +1,27 @@
+import numpy
+
+from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
+from lazyflow.operator import Operator
+from lazyflow.slot import OutputSlot, InputSlot
+
+
+class OpPassthrough(Operator):
+    Image = InputSlot()
+    Output = OutputSlot()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.Output.connect(self.Image)
+
+    def propagateDirty(self, slot, subindex, roi):
+        pass
+
+
+def test_layer_update_respects_2d_default(graph):
+    op = OpPassthrough(parent=Operator(graph=graph))
+    op.Image.setValue(numpy.random.rand(5, 5, 5))
+    op.Output.meta.prefer_2d = True
+    gui = LayerViewerGui(None, op)
+    assert gui.volumeEditorWidget.quadview.dock1_ofSplitHorizontal1._isMaximized
+    assert not gui.volumeEditorWidget.quadview.dock2_ofSplitHorizontal1._isMaximized
+    assert not gui.volumeEditorWidget.quadview.dock1_ofSplitHorizontal2._isMaximized

--- a/tests/test_ilastik/test_applets/layerViewer/testLayerViewerGui.py
+++ b/tests/test_ilastik/test_applets/layerViewer/testLayerViewerGui.py
@@ -1,11 +1,15 @@
 import numpy
+import vigra
 
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
+from lazyflow.graph import Graph
 from lazyflow.operator import Operator
 from lazyflow.slot import OutputSlot, InputSlot
 
 
 class OpPassthrough(Operator):
+    """Op with a slot for LayerViewerGui to put in self.observedSlots"""
+
     Image = InputSlot()
     Output = OutputSlot()
 
@@ -17,11 +21,55 @@ class OpPassthrough(Operator):
         pass
 
 
-def test_layer_update_respects_2d_default(graph):
-    op = OpPassthrough(parent=Operator(graph=graph))
-    op.Image.setValue(numpy.random.rand(5, 5, 5))
+def make_simple_op():
+    op = OpPassthrough(parent=Operator(graph=Graph()))
+    op.Image.setValue(numpy.array([[1, 1], [1, 1]]))
+    op.Output.meta.axistags = vigra.defaultAxistags("xy")
+    return op
+
+
+def test_layer_update_respects_2d_default():
+    # This test relies on the default implementation of LayerViewerGui.setupLayers provided in the base class.
+    op = make_simple_op()
     op.Output.meta.prefer_2d = True
     gui = LayerViewerGui(None, op)
     assert gui.volumeEditorWidget.quadview.dock1_ofSplitHorizontal1._isMaximized
     assert not gui.volumeEditorWidget.quadview.dock2_ofSplitHorizontal1._isMaximized
     assert not gui.volumeEditorWidget.quadview.dock1_ofSplitHorizontal2._isMaximized
+
+
+def test_layer_update_does_not_update_viewer_with_unready_layers(monkeypatch):
+    """
+    This reproduces a complex race condition encountered when switching scales in the dev-version OME implementation.
+    * LayerViewerGui.updateAllLayers detects shape change, sets self.editor.dataShape = newShape
+    * Qt triggers drawBackground on the editor's imageScenes (I think this happens after `dataShape.setter` exits)
+    * _refreshTile calls `LazyflowSource.request` (tileprovider.py:277 `ims_req = ims.request(dataRect, stack_id[1])`)
+    * dispatches the req to the threadpool (tileprovider.py:287 `fetch_fn = partial(self._fetch_layer_tile, ...)`)
+    * `ims.request` calls op.Output[] and catches SlotNotReadyErrors, but at this time the slot is still ready
+    * the delayed _fetch_layer_tile awaits the request, but now the slot is not ready anymore
+    * _fetch_layer_tile does not catch SlotNotReadyErrors, so it crashes
+
+    Reproducing the exact problem is difficult, but in general volumina should be able to expect layers to be ready
+    whenever it is asked to draw them.
+    """
+    gui = LayerViewerGui(None, make_simple_op())
+    first_op = make_simple_op()
+    layer_with_op_to_be_dropped = gui.createStandardLayerFromSlot(first_op.Output)
+    layer_with_ready_op = gui.createStandardLayerFromSlot(make_simple_op().Output)
+
+    # Feed first layer to the gui, then clean it up and prepare a new (ready) layer
+    monkeypatch.setattr(gui, "setupLayers", lambda: [layer_with_op_to_be_dropped])
+    monkeypatch.setattr(gui, "determineDatashape", lambda: (1, 5, 5, 5, 1))
+    gui.updateAllLayers()
+    first_op.cleanUp()
+    monkeypatch.setattr(gui, "setupLayers", lambda: [layer_with_ready_op])
+    monkeypatch.setattr(gui, "determineDatashape", lambda: (1, 6, 6, 6, 1))
+
+    # Ensure the gui only feeds the shape update to the viewer after it has dropped the obsolete layer
+    def assert_gui_layers_ready():
+        for layer in gui.layerstack:
+            msg = f"updateAllLayers should not update dataShape={gui.editor.dataShape} while holding obsolete {layer=}."
+            assert layer.datasources[0].dataSlot.ready(), msg
+
+    gui.editor.shapeChanged.connect(assert_gui_layers_ready)
+    gui.updateAllLayers()


### PR DESCRIPTION
Fixing and test-covering a couple of subtle bugs I found in the layerViewerGui while implementing OME support