### PR TITLE
Precomputed handling

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -216,8 +216,7 @@ class DatasetInfo(ABC):
                 elif saved_scale > 0:  # Precomputed dataset with non-default scale selected
                     from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
 
-                    url = params["url"]  # Should have url in this case
-                    remote_source = RESTfulPrecomputedChunkedVolume(url.lstrip("precomputed://"))
+                    remote_source = RESTfulPrecomputedChunkedVolume(params["url"])
                     scales = remote_source.get_scales_list_legacy()
                     params["working_scale"] = scales[saved_scale]["key"]
         if "scale_locked" in data:
@@ -601,7 +600,7 @@ class UrlDatasetInfo(MultiscaleUrlDatasetInfo):
         from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
 
         deserialized = super().from_h5_group(group)
-        remote_source = RESTfulPrecomputedChunkedVolume(deserialized.url.lstrip("precomputed://"))
+        remote_source = RESTfulPrecomputedChunkedVolume(deserialized.url)
         deserialized.nickname = cls._nickname_from_url(deserialized.nickname)
         deserialized.working_scale = remote_source.highest_resolution_key
         deserialized.scale_locked = True

--- a/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
+++ b/ilastik/applets/dataSelection/precomputedVolumeBrowser.py
@@ -9,6 +9,7 @@ Todos:
 """
 import logging
 
+from requests.exceptions import SSLError, ConnectionError
 from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import (
     QComboBox,
@@ -98,7 +99,13 @@ class PrecomputedVolumeBrowser(QDialog):
             rv = RESTfulPrecomputedChunkedVolume(volume_url=url)
         except Exception as e:
             self.qbuttons.button(QDialogButtonBox.Ok).setEnabled(False)
-            msg = f"Could not connect to a Precomputed dataset at this address. Full error message:\n\n{e}"
+            if isinstance(e, SSLError):
+                msg = "SSL error, please check that you are using the correct protocol (http/https)."
+            elif isinstance(e, ConnectionError):
+                msg = "Connection error, please check that the server is online and the URL is correct."
+            else:
+                msg = "Unknown error while trying to connect to this address."
+            msg += f"\n\nFull error message:\n{e}"
             self.result_text_box.setText(msg)
             return
 

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -289,10 +289,9 @@ class OpInputDataReader(Operator):
     def _attemptOpenAsRESTfulPrecomputedChunkedVolume(self, filePath):
         if not filePath.lower().startswith("precomputed://"):
             return ([], None)
-        url = filePath.lstrip("precomputed://")
         reader = OpRESTfulPrecomputedChunkedVolumeReader(parent=self)
         reader.Scale.connect(self.ActiveScale)
-        reader.BaseUrl.setValue(url)
+        reader.BaseUrl.setValue(filePath)
         return [reader], reader.Output
 
     def _attemptOpenAsH5N5Stack(self, filePath):

--- a/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
+++ b/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
@@ -177,7 +177,7 @@ class OpRESTfulPrecomputedChunkedVolumeReader(Operator):
 if __name__ == "__main__":
     # assumes there is a server running at localhost
     logging.basicConfig(level=logging.DEBUG)
-    volume_url = "http://localhost:8000/cremi"
+    volume_url = "precomputed://http://localhost:8000/cremi"
 
     from lazyflow import graph
 

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -80,7 +80,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         self.highest_resolution_key = None
         self._json_info = None
         self.tmp_data_file = tmp_data_file
-        self.volume_url = volume_url
+        self.volume_url = volume_url.lstrip("precomputed://")
 
         # Assuming axes and dtype will be the same in every scale
         # neuroglancer axes are always in this order; channel axis might singleton
@@ -100,7 +100,7 @@ class RESTfulPrecomputedChunkedVolume(object):
               instance. If not, `self.volume_url` is used.
         """
         if volume_url is not None:
-            self.volume_url = volume_url
+            self.volume_url = volume_url.lstrip("precomputed://")
 
         if volume_description is None and self.volume_url is not None:
             self.download_info()

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -63,7 +63,7 @@ class RESTfulPrecomputedChunkedVolume(object):
         "required": ["type", "data_type", "num_channels", "scales"],
     }
 
-    def __init__(self, volume_url, tmp_data_file=None, n_threads=4):
+    def __init__(self, volume_url: str, tmp_data_file=None, n_threads=4):
         """
         Args:
             volume_url (string): base url of the precomputed volume.
@@ -80,7 +80,8 @@ class RESTfulPrecomputedChunkedVolume(object):
         self.highest_resolution_key = None
         self._json_info = None
         self.tmp_data_file = tmp_data_file
-        self.volume_url = volume_url.lstrip("precomputed://")
+        self.volume_url = volume_url
+        self.base_url = volume_url.lstrip("precomputed://")
 
         # Assuming axes and dtype will be the same in every scale
         # neuroglancer axes are always in this order; channel axis might singleton
@@ -88,24 +89,11 @@ class RESTfulPrecomputedChunkedVolume(object):
         self.dtype = None
         self.n_channels = None
 
-        if volume_url is not None:
-            self._init_config()
+        self._init_from_url()
 
-    def _init_config(self, volume_url=None, volume_description=None):
-        """Downloads and checks the volume info file
-
-        Args:
-            volume_url (string, optional): volume_url (see `self.__init__`). If
-              supplied, the given volume is checked and set as volume for the
-              instance. If not, `self.volume_url` is used.
-        """
-        if volume_url is not None:
-            self.volume_url = volume_url.lstrip("precomputed://")
-
-        if volume_description is None and self.volume_url is not None:
-            self.download_info()
-        else:
-            self._json_info = volume_description
+    def _init_from_url(self):
+        """Downloads and checks the volume info file"""
+        self.download_info()
 
         jsonschema.validate(self._json_info, self.info_schema)
 
@@ -145,12 +133,12 @@ class RESTfulPrecomputedChunkedVolume(object):
         return shape
 
     def download_info(self):
-        logger.debug(f"getting volume from {self.volume_url}/info")
-        r = requests.get(f"{self.volume_url}/info")
+        logger.debug(f"getting volume from {self.base_url}/info")
+        r = requests.get(f"{self.base_url}/info")
 
         # check if success:
         if r.status_code != 200:
-            raise ValueError(f"Could not find info file at {self.volume_url}, status code {r.status_code}!")
+            raise ValueError(f"Could not find info file at {self.base_url}, status code {r.status_code}!")
 
         self._json_info = json.loads(r.content)
 
@@ -216,7 +204,7 @@ class RESTfulPrecomputedChunkedVolume(object):
                 f"Supplied coordinates ({coordinates}) not a valid block- start for block shape {chunk_size}."
             )
 
-        base_url = self.volume_url
+        base_url = self.base_url
         min_values = coordinates
         max_values = min_values + chunk_size
         max_values = numpy.min([shape, max_values], axis=0)
@@ -234,7 +222,7 @@ class RESTfulPrecomputedChunkedVolume(object):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
-    volume_url = "http://localhost:8080/precomputed/cremi"
+    volume_url = "precomputed://http://localhost:8080/precomputed/cremi"
     cvol = RESTfulPrecomputedChunkedVolume(volume_url=volume_url)
     print(f"dtype: {cvol.dtype}")
     print(f"scales: {len(cvol.scales)}")


### PR DESCRIPTION
A couple of smaller changes from my OME branch that we can independently integrate into main:
- Better feedback for connection errors in the URL dialog
- Moving stripping the "precomputed://" prefix from URLs into the Precomputed adapter to reduce duplications of the string constant across data loading classes (and because knowing about the prefix should be none of their concern)