### PR TITLE
Multi-GUI adapter: Stop throwing if no lanes exist

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -60,6 +60,7 @@ outputs:
         - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
         - z5py
       run_constrained:
+        - mkl !=2024.1.0
         - tiktorch >=23.11.0
         - volumina >=1.3.10
 
@@ -94,7 +95,7 @@ outputs:
         ilastik-core package enables ilastik-api usage to mix into environments.
         ilastik is a simple, user-friendly tool for interactive image classification,
         segmentation and analysis.
-        
+
 
   - name: ilastik
     build:

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -67,3 +67,5 @@ dependencies:
   # ensure working environment on apple M1 via rosetta
   # remove once native builds are available
   # - mkl 2021.*  # [osx]
+
+  - mkl !=2024.1.0  # [linux] until pytorch is compatible with the current version

--- a/ilastik/applets/base/singleToMultiGuiAdapter.py
+++ b/ilastik/applets/base/singleToMultiGuiAdapter.py
@@ -43,6 +43,9 @@ class SingleToMultiGuiAdapter(object):
             else:
                 return None
 
+        if self._imageLaneIndex >= len(self._guis):
+            return None
+
         # Create first if necessary
         if self._guis[self._imageLaneIndex] is None:
             self._guis[self._imageLaneIndex] = self.singleImageGuiFactory(self._imageLaneIndex)


### PR DESCRIPTION
This is a band-aid for #2836 that at least stops downstream applets from throwing errors because they are looking for GUIs of lanes that do not exist.

The user then ends up on a Feature Selection applet with an empty viewer, which is less weird than seeing the data selection gui. In fact, this allows them to change the selected scales, so they can even fix the project without necessarily having to close it...
![image](https://github.com/ilastik/ilastik/assets/63287233/c5e0ae6f-4038-485b-bf5d-343ceaa910ec)
