### PR TITLE
Feature selection: Stop throwing if no lanes exist

### DIFF
--- a/ilastik/applets/featureSelection/featureSelectionGui.py
+++ b/ilastik/applets/featureSelection/featureSelectionGui.py
@@ -133,7 +133,8 @@ class FeatureSelectionGui(LayerViewerGui):
         # updated his data yet by the time he calls the rowsInserted signal
         def handleLayerStackDataChanged(startIndex, stopIndex):
             row = startIndex.row()
-            layerListWidget.item(row).setText(self.layerstack[row].name)
+            if self.layerstack:
+                layerListWidget.item(row).setText(self.layerstack[row].name)
 
         def handleSelectionChanged(row):
             # Only one layer is visible at a time


### PR DESCRIPTION
Every now and then I get this line throwing `AttributeError: 'NoneType' object has no attribute 'setText'`, presumably because somehow I triggered a viewer update at a moment when (1) featureSelectionGui exists and (2) no data lanes exist.

I haven't actually found a way to reliably reproduce this, but I've encountered this on-click when bringing up the web-loading dialog ("Add dataset from URL" - currently "Add Neuroglancer Precomputed") and when bringing up the feature selection dialog ("Select features...") after repeatedly adding and removing datasets.

The traceback is _extremely_ helpful, containing no trace at all:
```
Traceback (most recent call last):
  File "C:\Users\root\Code\ilastik-group\ilastik\ilastik\applets\featureSelection\featureSelectionGui.py", line 136, in handleLayerStackDataChanged
    layerListWidget.item(row).setText(self.layerstack[row].name)
AttributeError: 'NoneType' object has no attribute 'setText'
```

When debugging, I can trace the call back:

- `volumina.layer.NormalizableLayer._bounds_changed` -> (called by) `set_normalize` -> `normalizeChanged.emit` -> `changed.emit` -> 
- `volumina.LayerStackModel._onLayerChanged` -> `dataChanged.emit` -> 
- `ilastik.applets.featureSelection.FeatureSelectionGui.handleLayerStackDataChanged`

And most likely this originates from `volumina.pixelpipeline.datasources.minmaxsource.MinMaxSource._getMinMax`, which is the callback of `MinMaxUpdateRequest`, i.e. async, which explains why the trace breaks off here.