### PR TITLE
Use pydantic for .ilp deserialization in experimental/api

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -47,6 +47,7 @@ outputs:
         # need to update our packages to be compatible with pandas 2 API
         - pandas
         - psutil
+        - pydantic 2.*
         - pyopengl
         - pyqt 5.15.*
         # previous versions would set thread limits globally with side effects

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -26,6 +26,7 @@ dependencies:
   - nifty
   - pandas
   - psutil
+  - pydantic 2.*
   - pyopengl
   - pyqt 5.15.*
   - pyqtgraph

--- a/ilastik/applets/base/appletSerializer/legacyClassifiers.py
+++ b/ilastik/applets/base/appletSerializer/legacyClassifiers.py
@@ -85,6 +85,12 @@ class ClassifierInfo:
         return classifier_type
 
 
+def deserialize_classifier(classifier_group: h5py.Group) -> LazyflowClassifierABC:
+    classifier_type = deserialize_classifier_type(classifier_group["pickled_type"])
+    classifier = classifier_type.deserialize_hdf5(classifier_group)
+    return classifier
+
+
 def deserialize_classifier_type(ds: h5py.Dataset) -> LazyflowClassifierTypeABC:
     """Legacy helper for classifier type_info deserialization
 

--- a/ilastik/experimental/api/_pipelines.py
+++ b/ilastik/experimental/api/_pipelines.py
@@ -40,10 +40,11 @@ class PixelClassificationPipeline:
     Example usage:
 
     ```Python
-    from ilastik.experimental.api import PixelClassificationPipeline
     import imageio.v3 as iio
+    import xarray
+    from ilastik.experimental.api import PixelClassificationPipeline
 
-    img = iio.imread("<path/to/image-file.tif>")
+    img = xarray.DataArray(iio.imread("<path/to/image-file.tif>"), dims=("y", "x"))
     pipeline = PixelClassificationPipeline.from_ilp_file("<path/to/project.ilp>")
 
     prob_maps = pipeline.get_probabilities(img)

--- a/ilastik/experimental/parser/_h5helpers.py
+++ b/ilastik/experimental/parser/_h5helpers.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2023, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -18,4 +18,21 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
-from ._projects import PixelClassificationProject as PixelClassificationProject
+import json
+from typing import Any, List, Union
+
+import h5py
+
+from ilastik.applets.base.appletSerializer.serializerUtils import deserialize_string_from_h5
+
+
+def deserialize_str_list_from_h5(str_list: h5py.Dataset) -> List[str]:
+    return [x.decode() for x in str_list]
+
+
+def deserialize_axistags_from_h5(ds: h5py.Dataset) -> dict[str, Union[float, int, str]]:
+    return json.loads(deserialize_string_from_h5(ds))["axes"]
+
+
+def deserialize_arraylike_from_h5(ds: h5py.Dataset) -> Any:
+    return ds[()]

--- a/ilastik/experimental/parser/_projects.py
+++ b/ilastik/experimental/parser/_projects.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2023, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -18,51 +18,14 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Type, TypeVar
+# pyright: strict
 
-import h5py
+from pydantic import BaseModel, Field
 
 from . import types
 
-T = TypeVar("T", bound="ILP")
 
-
-class ILP(ABC):
-    @classmethod
-    @abstractmethod
-    def from_ilp_file(cls: Type[T], h5file: h5py.File) -> T:
-        ...
-
-
-@dataclass(frozen=True)
-class PixelClassificationProject(ILP):
-    data_info: types.ProjectDataInfo
-    feature_matrix: types.FeatureMatrix
-    classifier: types.Classifier
-
-    @classmethod
-    def from_ilp_file(cls, h5file: h5py.File):
-        ILP_WORKFLOW_NAME = b"Pixel Classification"
-
-        class ILPkeys(types.StrEnum):
-            WORKFLOW = "workflowName"
-            INPUT_DATA = "Input Data/infos"
-            FEATURES = "FeatureSelections"
-            PIXEL_CLASSIFICATION = "PixelClassification"
-
-        if any(key not in h5file for key in ILPkeys):
-            raise types.IlastikAPIError(
-                f"Not a valid ilastik project pixel classification project file with keys {h5file.keys()}"
-            )
-
-        type_: bytes = h5file[ILPkeys.WORKFLOW][()]
-        if type_ != ILP_WORKFLOW_NAME:
-            raise types.IlastikAPIError(f"Expected Pixel Classification Project, found {type_!r}")
-
-        return cls(
-            types.ProjectDataInfo.from_ilp_group(h5file[ILPkeys.INPUT_DATA]),
-            types.FeatureMatrix.from_ilp_group(h5file[ILPkeys.FEATURES]),
-            types.Classifier.from_ilp_group(h5file[ILPkeys.PIXEL_CLASSIFICATION]),
-        )
+class PixelClassificationProject(BaseModel):
+    input_data: types.InputData = Field(alias="Input Data")
+    feature_matrix: types.FeatureMatrix = Field(alias="FeatureSelections")
+    classifier: types.Classifier = Field(alias="PixelClassification")

--- a/ilastik/experimental/parser/types.py
+++ b/ilastik/experimental/parser/types.py
@@ -72,9 +72,8 @@ class InputData(BaseModel):
     @property
     def axis_order(self) -> str:
         """Returns the axis keys of the last lane as a string"""
-        # should usually be 'Raw Data'
         last_lane = self._last_lane
-        base_role_name = self.role_names[0]
+        base_role_name = self.role_names[0]  # should usually be 'Raw Data'
         base_info = last_lane[base_role_name]
         assert base_info
         return "".join(ax.key for ax in base_info.axistags)
@@ -83,7 +82,7 @@ class InputData(BaseModel):
     def num_channels(self) -> int:
         """Returns the number for channels in the last lane"""
         last_lane = self._last_lane
-        base_role_name = self.role_names[0]
+        base_role_name = self.role_names[0]  # should usually be 'Raw Data'
         base_info = last_lane[base_role_name]
         assert base_info
         n_channels = 1

--- a/lazyflow/classifiers/lazyflowClassifier.py
+++ b/lazyflow/classifiers/lazyflowClassifier.py
@@ -1,6 +1,6 @@
 import abc
 
-from typing import TYPE_CHECKING, Type, TypeVar
+from typing import Type, TypeVar
 
 import h5py
 

--- a/lazyflow/classifiers/lazyflowClassifier.py
+++ b/lazyflow/classifiers/lazyflowClassifier.py
@@ -1,5 +1,12 @@
 import abc
 
+from typing import TYPE_CHECKING, Type, TypeVar
+
+import h5py
+
+
+T = TypeVar("T", bound="LazyflowVectorwiseClassifierABC")
+
 
 def _has_attribute(cls, attr):
     return any(attr in B.__dict__ for B in cls.__mro__)
@@ -115,7 +122,7 @@ class LazyflowVectorwiseClassifierABC(abc.ABC):
         raise NotImplementedError
 
     @classmethod
-    def deserialize_hdf5(cls, h5py_group):
+    def deserialize_hdf5(cls: Type[T], h5py_group: h5py.Group) -> T:
         """
         Class method.  Deserialize the classifier stored in the given ``h5py.Group`` object, and return it.
         """

--- a/tests/test_ilastik/test_experimental/test_api/test_pipelines.py
+++ b/tests/test_ilastik/test_experimental/test_api/test_pipelines.py
@@ -2,12 +2,12 @@ import subprocess
 import sys
 
 import numpy as np
+from pydantic import ValidationError
 import pytest
 import xarray
 import imageio.v3 as iio
 
 from ilastik.experimental.api import PixelClassificationPipeline, from_project_file
-from ilastik.experimental.parser.types import IlastikAPIError
 
 from ..types import ApiTestDataLookup, TestData, TestProjects
 
@@ -134,7 +134,7 @@ class TestIlastikApiPixelClassification:
     )
     def test_project_insufficient_data(self, test_data_lookup, proj):
         project_path = test_data_lookup.find_project(proj)
-        with pytest.raises(IlastikAPIError):
+        with pytest.raises(ValidationError):
             PixelClassificationPipeline.from_ilp_file(project_path)
 
     @pytest.mark.parametrize(

--- a/tests/test_ilastik/test_experimental/test_parser/test_projects.py
+++ b/tests/test_ilastik/test_experimental/test_parser/test_projects.py
@@ -22,9 +22,9 @@ class TestIlastikParser:
     def test_parse_project_number_of_channels(self, test_data_lookup: ApiTestDataLookup, proj, expected_num_channels):
         project_path = test_data_lookup.find_project(proj)
         with h5py.File(project_path, "r") as f:
-            proj = PixelClassificationProject.from_ilp_file(f)
+            proj = PixelClassificationProject.model_validate(f)
 
-        assert proj.data_info.num_channels == expected_num_channels
+        assert proj.input_data.num_channels == expected_num_channels
 
     @pytest.mark.parametrize(
         "proj, expected_factory, expected_classifier",
@@ -40,10 +40,10 @@ class TestIlastikParser:
         project_path = test_data_lookup.find_project(proj)
 
         with h5py.File(project_path, "r") as f:
-            proj = PixelClassificationProject.from_ilp_file(f)
+            proj = PixelClassificationProject.model_validate(f)
 
-        assert isinstance(proj.classifier.factory, expected_factory)
-        assert isinstance(proj.classifier.instance, expected_classifier)
+        assert isinstance(proj.classifier.classifier_factory, expected_factory)
+        assert isinstance(proj.classifier.classifier, expected_classifier)
 
     tests = [
         (
@@ -95,7 +95,7 @@ class TestIlastikParser:
         project_path = test_data_lookup.find_project(proj)
 
         with h5py.File(project_path, "r") as f:
-            proj = PixelClassificationProject.from_ilp_file(f)
+            proj = PixelClassificationProject.model_validate(f)
 
         matrix = proj.feature_matrix
         assert matrix


### PR DESCRIPTION
Summary:
* public api unchanged
* internal representations of "applets" based on pydantic models - currently limited to the data that is needed for processing (will add more along with the tool for data relocation)
* added `_h5helpers` module in `ilastik.experimental`, which could also live in `ilastik.applet.base.appletSerializer.serializerUtils`, but it's not needed there
* some internals have changed -> tests needed to be adapted

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- not needed, with pydantic classes mostly documents themselves ;D Add docstrings and comments.
- [x] Add tests.
- n/a (api unchanged) Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- n/a Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
