### PR TITLE
Add note on 'bad features' warning for skewness and kurtosis

### DIFF
--- a/ilastik/plugins_default/vigra_objfeats.py
+++ b/ilastik/plugins_default/vigra_objfeats.py
@@ -147,6 +147,8 @@ class VigraObjFeats(ObjectFeaturesPlugin):
                 features[feature_name]["detailtext"] = (
                     "Skewness of the intensity distribution inside the object, also known as the third standardized moment. This feature measures the asymmetry of the "
                     "intensity distribution inside the object. For multi-channel data, this feature is computed channel-wise. "
+                    "If all pixels in an object have the same value, you may encounter a 'bad features' warning when computing Skewness. "
+                    "Skewness will have a value of 0 for these objects."
                 )
                 features[feature_name]["group"] = "Intensity Distribution"
 
@@ -155,6 +157,8 @@ class VigraObjFeats(ObjectFeaturesPlugin):
                 features[feature_name]["detailtext"] = (
                     "Kurtosis of the intensity distribution inside the object, also known as the fourth standardized moment. This feature measures the heaviness of the "
                     "tails for the distribution of intensity over the object's pixels. For multi-channel data, this feature is computed channel-wise. "
+                    "If all pixels in an object have the same value, you may encounter a 'bad features' warning when computing Kurtosis. "
+                    "Kurtosis will have a value of 0 for these objects."
                 )
                 features[feature_name]["group"] = "Intensity Distribution"
 


### PR DESCRIPTION
clarify warning issued for objects that have the same value for all pixels (ref: [image.sc topic](https://forum.image.sc/t/encountered-bad-objects-features-while-training/95038?u=k-dominik))

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Update [user documentation](https://github.com/ilastik/ilastik.github.io) ([ilastik.github.io/#269](https://github.com/ilastik/ilastik.github.io/pull/269)).
- [x] Rebase commits into a logical sequence.
- n/a Add docstrings and comments.
- n/a Add tests.
- n/a Reference relevant issues and other pull requests.
