### PR TITLE
Lazyflow logging and fix default operator naming

### DIFF
--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -127,6 +127,7 @@ def get_default_config(
                 "maxBytes": 50e6,  # 20 MB
                 "backupCount": 5,
                 "formatter": "verbose",
+                "encoding": "utf-8",
             },
         },
         "root": {"handlers": root_handlers, "level": root_log_level},

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -33,6 +33,7 @@
         "lazyflow.request.SimpleRequestCondition":                  { "level":"INFO" },
         "lazyflow.graph":                                           { "level":"INFO" },
         "lazyflow.classifiers":                                     { "level":"INFO" },
+        "lazyflow.op_debug":                                        { "level":"INFO" },
         "lazyflow.operatorWrapper.OperatorWrapper":                 { "level":"INFO" },
         "lazyflow.operators.ioOperators":                           { "level":"INFO" },
         "lazyflow.operators.ioOperators.opRESTfulVolumeReader":     { "level":"INFO" },

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -32,6 +32,7 @@
         "lazyflow.request.RequestLock":                             { "level":"INFO" },
         "lazyflow.request.SimpleRequestCondition":                  { "level":"INFO" },
         "lazyflow.graph":                                           { "level":"INFO" },
+        "lazyflow.slot_debug":                                      { "level":"INFO" },
         "lazyflow.classifiers":                                     { "level":"INFO" },
         "lazyflow.op_debug":                                        { "level":"INFO" },
         "lazyflow.operators.ioOperators":                           { "level":"INFO" },

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -34,7 +34,6 @@
         "lazyflow.graph":                                           { "level":"INFO" },
         "lazyflow.classifiers":                                     { "level":"INFO" },
         "lazyflow.op_debug":                                        { "level":"INFO" },
-        "lazyflow.operatorWrapper.OperatorWrapper":                 { "level":"INFO" },
         "lazyflow.operators.ioOperators":                           { "level":"INFO" },
         "lazyflow.operators.ioOperators.opRESTfulVolumeReader":     { "level":"INFO" },
         "lazyflow.operators.opFeatureMatrixCache":                  { "level":"INFO" },

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -32,8 +32,6 @@
         "lazyflow.request.RequestLock":                             { "level":"INFO" },
         "lazyflow.request.SimpleRequestCondition":                  { "level":"INFO" },
         "lazyflow.graph":                                           { "level":"INFO" },
-        "lazyflow.graph.Slot":                                      { "level":"INFO" },
-        "lazyflow.slot.Slot":                                       { "level":"INFO" },
         "lazyflow.classifiers":                                     { "level":"INFO" },
         "lazyflow.operatorWrapper.OperatorWrapper":                 { "level":"INFO" },
         "lazyflow.operators.ioOperators":                           { "level":"INFO" },

--- a/ilastik/ilastik_logging/logging_config.json
+++ b/ilastik/ilastik_logging/logging_config.json
@@ -27,6 +27,7 @@
         "ilastik.utility":                                          { "level":"INFO" },
         "ilastik.utility.exportingOperator":                        { "level":"INFO" },
         "ilastik.utility.exportFile":                               { "level":"INFO" },
+        "lazyflow.signals":                                         { "level":"INFO" },
         "lazyflow.request":                                         { "level":"INFO" },
         "lazyflow.request.RequestLock":                             { "level":"INFO" },
         "lazyflow.request.SimpleRequestCondition":                  { "level":"INFO" },

--- a/ilastik/workflows/voxelSegmentation/classifierOperators.py
+++ b/ilastik/workflows/voxelSegmentation/classifierOperators.py
@@ -331,6 +331,8 @@ class OpSupervoxelwiseClassifierPredict(Operator):
 
     PMaps = OutputSlot()
 
+    logger = logging.getLogger(__name__ + ".OpSupervoxelwiseClassifierPredict")
+
     def __init__(self, *args, **kwargs):
         super(OpSupervoxelwiseClassifierPredict, self).__init__(*args, **kwargs)
 

--- a/lazyflow/graph.py
+++ b/lazyflow/graph.py
@@ -63,6 +63,7 @@ class Graph:
             fn()
         else:
             # Subscribe to the next completion.
+            logger.debug(f"Adding to queue in setup={id(self._sig_setup_complete)}: {fn}")
             self._sig_setup_complete.subscribe(fn)
 
     class SetupDepthContext(object):
@@ -79,6 +80,7 @@ class Graph:
                 with self._graph._lock:
                     if self._graph._setup_depth == 0:
                         self._graph._sig_setup_complete = OrderedSignal()
+                        logger.debug(f"New setupDepthContext={id(self._graph._sig_setup_complete)}")
                     self._graph._setup_depth += 1
 
         def __exit__(self, *args):
@@ -88,7 +90,8 @@ class Graph:
                     self._graph._setup_depth -= 1
                     if self._graph._setup_depth == 0:
                         sig_setup_complete = self._graph._sig_setup_complete
-                        # Reset.
+                        logger.debug(f"Finish setupDepthContext={id(sig_setup_complete)}")
                         self._graph._sig_setup_complete = None
                 if sig_setup_complete:
+                    logger.debug(f"Flushing queue of setupDepthContext={id(sig_setup_complete)}")
                     sig_setup_complete()

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -205,6 +205,8 @@ class Operator(metaclass=OperatorMetaClass):
         :param parent: the parent operator; if None the instance is a
         root operator
         :param graph: a Graph instance
+        :param write_logs: Debugging feature. The operator will write debug logs if True.
+        Make sure the `lazyflow.op_debug` logger has level=DEBUG in the logging config.
 
         """
         if not (parent is None or isinstance(parent, Operator)):

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -232,7 +232,7 @@ class Operator(metaclass=OperatorMetaClass):
         if write_logs:
             self._debug_logger = logging.getLogger(f"lazyflow.op_debug.{self.name}")
             self._debug_logger.debug(
-                f"Instantiated {self.name} {id(self)} with parent={self.parent.name if self.parent else ''}"
+                f"Instantiated {self.name} {id(self)} with parent={self.parent.name if self.parent is not None else ''}"
             )
 
         self._initialized = False

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -228,7 +228,7 @@ class Operator(metaclass=OperatorMetaClass):
         if parent is not None:
             parent._add_child(self)
 
-        self.logger = logging.getLogger(f"lazyflow.op_debug.{type(self).__name__}")
+        self.logger = logging.getLogger(f"lazyflow.op_debug.{self.name}")
         self.logger.debug(f"Instantiated {self.name} {id(self)} with parent={self.parent.name if self.parent else ''}")
 
         self._initialized = False

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -228,6 +228,9 @@ class Operator(metaclass=OperatorMetaClass):
         if parent is not None:
             parent._add_child(self)
 
+        self.logger = logging.getLogger(f"lazyflow.op_debug.{type(self).__name__}")
+        self.logger.debug(f"Instantiated {self.name} {id(self)} with parent={self.parent.name if self.parent else ''}")
+
         self._initialized = False
 
         self._condition = threading.Condition()
@@ -298,10 +301,6 @@ class Operator(metaclass=OperatorMetaClass):
             islot.notifyUnready(self.handleInputBecameUnready)
 
         self._initialized = True
-
-        self.logger = logging.getLogger(f"lazyflow.op_debug.{type(self).__name__}")
-        self.logger.debug(f"Instantiated {self.name} {id(self)} with parent={self.parent.name if self.parent else ''}")
-
         self._setupOutputs()
 
     def _instantiate_slots(self):

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -110,6 +110,9 @@ class OperatorMetaClass(ABCMeta):
             if isinstance(v, OutputSlot):
                 v.name = k
                 cls.outputSlots.append(v)
+
+        if "name" not in classDict:
+            cls.name = name  # better default if subclass does not provide cls.name
         return cls
 
     def __call__(cls, *args, **kwargs):
@@ -218,9 +221,6 @@ class Operator(metaclass=OperatorMetaClass):
                 )
             graph = parent.graph
 
-        if self.name == Operator.name:
-            self.name = type(self).__name__  # better default if subclass does not override self.name
-
         self._cleaningUp = False
         self.graph = graph
         self._children = collections.OrderedDict()
@@ -266,8 +266,6 @@ class Operator(metaclass=OperatorMetaClass):
 
     # continue initialization, when user overrides __init__
     def _after_init(self):
-        if self.name == Operator.name:
-            self.name = type(self).__name__  # repeat in case subclass.__init__ does not call super().__init__()
         assert self.graph is not None, (
             "Operator {}: self.graph is None, the parent ({})"
             " given to the operator must have a valid .graph attribute!".format(self, self._parent)

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -218,6 +218,9 @@ class Operator(metaclass=OperatorMetaClass):
                 )
             graph = parent.graph
 
+        if self.name == Operator.name:
+            self.name = type(self).__name__  # better default if subclass does not override self.name
+
         self._cleaningUp = False
         self.graph = graph
         self._children = collections.OrderedDict()
@@ -263,9 +266,8 @@ class Operator(metaclass=OperatorMetaClass):
 
     # continue initialization, when user overrides __init__
     def _after_init(self):
-        # provide simple default name for lazy users
         if self.name == Operator.name:
-            self.name = type(self).__name__
+            self.name = type(self).__name__  # repeat in case subclass.__init__ does not call super().__init__()
         assert self.graph is not None, (
             "Operator {}: self.graph is None, the parent ({})"
             " given to the operator must have a valid .graph attribute!".format(self, self._parent)

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -170,15 +170,6 @@ class OperatorWrapper(Operator):
         for s in list(self.outputs.values()):
             assert len(s) == 0
 
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, name):
-        self._name = name
-        self._customName = True
-
     def __getitem__(self, key):
         return self.innerOperators[key]
 
@@ -216,11 +207,6 @@ class OperatorWrapper(Operator):
         if len(self.innerOperators) >= length:
             return self.innerOperators[index]
         op = self._createInnerOperator()
-
-        # Update our name (if the client didn't already give us a
-        # special one)
-        if self._customName is False:
-            self._name = "Wrapped " + op.name
 
         # If anyone calls setValue() on one of these slots,
         # forward the setValue call to the slot's upstream_slot (the

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -38,6 +38,7 @@ class OperatorWrapper(Operator):
         graph=None,
         promotedSlotNames=None,
         broadcastingSlotNames=None,
+        write_logs=False,
     ):
         """Constructs a wrapper for the given operator. That is,
         manages a list of copies of the original operator, and
@@ -73,13 +74,14 @@ class OperatorWrapper(Operator):
             or not they appear in the promotedSlotNames argument.
 
         """
-        super(OperatorWrapper, self).__init__(parent=parent, graph=graph)
-        if operator_args == None:
+        super(OperatorWrapper, self).__init__(parent=parent, graph=graph, write_logs=write_logs)
+        if operator_args is None:
             operator_args = ()
-        if operator_kwargs == None:
+        if operator_kwargs is None:
             operator_kwargs = {}
         assert isinstance(operator_args, (tuple, list))
         assert isinstance(operator_kwargs, dict)
+        operator_kwargs.update({"write_logs": write_logs})
         self._createInnerOperator = functools.partial(operatorClass, parent=self, *operator_args, **operator_kwargs)
 
         self._initialized = False
@@ -203,6 +205,8 @@ class OperatorWrapper(Operator):
     def _insertInnerOperator(self, index, length):
         if len(self.innerOperators) >= length:
             return self.innerOperators[index]
+        if self._debug_logger:
+            self._debug_logger.debug(f"Inserting inner operator at index {index}")
         op = self._createInnerOperator()
 
         # If anyone calls setValue() on one of these slots,

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -21,7 +21,6 @@
 ###############################################################################
 # Python
 import functools
-import logging
 
 # lazyflow
 from lazyflow.operator import Operator
@@ -86,7 +85,8 @@ class OperatorWrapper(Operator):
         self._initialized = False
 
         self.name = "Wrapped " + operatorClass.name
-        self.logger.debug(f"Wrapper {id(self)} name={self.name}")
+        if self._debug_logger:
+            self._debug_logger.debug(f"Wrapper {id(self)} name={self.name}")
 
         allInputSlotNames = set([s.name for s in operatorClass.inputSlots])
 

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -90,7 +90,7 @@ class OperatorWrapper(Operator):
 
         self._initialized = False
 
-        if operatorClass.name == "":
+        if operatorClass.name == Operator.name:
             self._name = "Wrapped " + operatorClass.__name__
         else:
             self._name = "Wrapped " + operatorClass.name

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -60,18 +60,18 @@ class OperatorWrapper(Operator):
 
         :param graph: the graph operator to init each inner operator with
 
-        :param promotedSlotNames:
-
-          If provided, only those slots will be promoted when
+        :param promotedSlotNames: If provided, only those slots will be promoted when
             replicated. All other slots will be replicated without
             promotion, and their input values will be broadcasted to
             all inner operators.
-
           If not provided (i.e. promotedSlotNames=None), the default
             behavior is to promote ALL replicated slots.
-
           Note: Outputslots are always promoted, regardless of whether
             or not they appear in the promotedSlotNames argument.
+
+        :param write_logs: Debugging feature. The wrapper and wrapped ops will write debug logs if True.
+            The wrapped operator's __init__ must also accept the write_logs kwarg.
+            Make sure the `lazyflow.op_debug` logger has level=DEBUG in the logging config.
 
         """
         super(OperatorWrapper, self).__init__(parent=parent, graph=graph, write_logs=write_logs)
@@ -81,7 +81,8 @@ class OperatorWrapper(Operator):
             operator_kwargs = {}
         assert isinstance(operator_args, (tuple, list))
         assert isinstance(operator_kwargs, dict)
-        operator_kwargs.update({"write_logs": write_logs})
+        if write_logs:
+            operator_kwargs.update({"write_logs": write_logs})
         self._createInnerOperator = functools.partial(operatorClass, parent=self, *operator_args, **operator_kwargs)
 
         self._initialized = False

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -77,8 +77,6 @@ class OperatorWrapper(Operator):
             or not they appear in the promotedSlotNames argument.
 
         """
-        # Base class init
-        self._name = "Uninitialized OperatorWrapper"
         super(OperatorWrapper, self).__init__(parent=parent, graph=graph)
         if operator_args == None:
             operator_args = ()
@@ -90,12 +88,8 @@ class OperatorWrapper(Operator):
 
         self._initialized = False
 
-        if operatorClass.name == Operator.name:
-            self._name = "Wrapped " + operatorClass.__name__
-        else:
-            self._name = "Wrapped " + operatorClass.name
-
-        self._customName = False
+        self.name = "Wrapped " + operatorClass.name
+        self.logger.debug(f"Wrapper {id(self)} name={self.name}")
 
         allInputSlotNames = set([s.name for s in operatorClass.inputSlots])
 
@@ -140,7 +134,6 @@ class OperatorWrapper(Operator):
         self.promotedSlotNames = promotedSlotNames
 
         self.innerOperators = []
-        self.logger.log(logging.DEBUG, "wrapping operator '{}'".format(operatorClass.name))
 
         # replicate input slot definitions
         for innerSlot in sorted(operatorClass.inputSlots, key=lambda s: s._global_slot_id):

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -30,9 +30,6 @@ from lazyflow.operator import Operator
 class OperatorWrapper(Operator):
     name = "OperatorWrapper"
 
-    loggerName = __name__ + ".OperatorWrapper"
-    logger = logging.getLogger(loggerName)
-
     def __init__(
         self,
         operatorClass,

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -430,6 +430,8 @@ class OpBaseClassifierPredict(Operator):
 
     PMaps = OutputSlot()
 
+    logger = logging.getLogger(__name__ + ".OpBaseClassifierPredict")
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -525,8 +525,7 @@ class Slot(object):
                     )
 
                     if self.logger:
-                        op_name = upstream_slot.operator.name if upstream_slot.operator is not None else "Unassigned"
-                        self.logger.debug(f"Connecting to {op_name}.{upstream_slot.name}")
+                        self.logger.debug(f"Connecting to {upstream_slot}")
                     self.upstream_slot = upstream_slot
                     notifyReady = self.upstream_slot.meta._ready and not self.meta._ready
                     self.meta = self.upstream_slot.meta.copy()
@@ -634,8 +633,7 @@ class Slot(object):
         if self.upstream_slot is not None:
             had_upstream_slot = True
             if self.logger:
-                op_name = self.upstream_slot.operator.name if self.upstream_slot.operator is not None else "Unassigned"
-                self.logger.debug(f"Disconnecting from {op_name}.{self.upstream_slot.name}")
+                self.logger.debug(f"Disconnecting from {self.upstream_slot}")
             # safe to unsubscribe, even if not subscribed
             self.upstream_slot._sig_unready.unsubscribe(self._handleUpstreamUnready)
             try:
@@ -1353,11 +1351,11 @@ class Slot(object):
         old_ready = self.ready()
         if self.upstream_slot is not None and self.meta != self.upstream_slot.meta:
             if self.logger:
-                op_name = self.upstream_slot.operator.name if self.upstream_slot.operator is not None else "Unassigned"
                 msg = (
-                    f"Copying meta from {op_name}.{self.upstream_slot.name}."
+                    f"Copying meta."
                     f" Ready: {self.meta._ready} -> {self.upstream_slot.meta._ready}."
                     f" Shape: {self.meta.shape} -> {self.upstream_slot.meta.shape}."
+                    f" From {self.upstream_slot}. Previous: {self.meta}."
                 )
                 self.logger.debug(msg)
             self.meta = self.upstream_slot.meta.copy()

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -30,9 +30,7 @@ if sys.version_info.major >= 3:
 ###############################################################################
 # Python
 import logging
-import collections
 import itertools
-import threading
 from functools import partial, wraps
 from contextlib import contextmanager
 import warnings
@@ -50,6 +48,8 @@ from lazyflow.request import Request
 from lazyflow.stype import ArrayLike, Opaque
 from lazyflow.metaDict import MetaDict
 from lazyflow.utility import slicingtools, OrderedSignal
+
+module_logger = logging.getLogger(__name__)
 
 
 def is_setup_fn(func):
@@ -81,9 +81,6 @@ class Slot(object):
     Base class for InputSlot, OutputSlot
     """
 
-    loggerName = __name__ + ".Slot"
-    logger = logging.getLogger(loggerName)
-
     # Allow slots to be sorted by their order of creation for debug
     # output and diagramming purposes.
     _global_counter = itertools.count()
@@ -108,6 +105,7 @@ class Slot(object):
         allow_mask=False,
         subindex=(),
         top_level_slot=None,
+        write_logs=False,
     ):
         """Constructor of the Slot class.
 
@@ -162,6 +160,13 @@ class Slot(object):
         self._optional = optional
         self.operator = operator
         self.allow_mask = allow_mask
+        self.logger = None
+        if write_logs:
+            # Using module-like dot separation allows turning on/off all slot loggers at once
+            logger_name = f"lazyflow.slot.NoOperator.{self.name}"
+            if self.operator is not None:
+                logger_name = f"lazyflow.slot.{self.operator.name}.{self.name}"
+            self.logger = logging.getLogger(logger_name)
 
         # in the case of an InputSlot this is the slot to which it is
         # connected
@@ -519,6 +524,9 @@ class Slot(object):
                         )
                     )
 
+                    if self.logger:
+                        op_name = upstream_slot.operator.name if upstream_slot.operator is not None else "Unassigned"
+                        self.logger.debug(f"Connecting to {op_name}.{upstream_slot.name}")
                     self.upstream_slot = upstream_slot
                     notifyReady = self.upstream_slot.meta._ready and not self.meta._ready
                     self.meta = self.upstream_slot.meta.copy()
@@ -604,11 +612,10 @@ class Slot(object):
                     # Well, this is bad.  We caused an exception while handling an exception.
                     # We're more interested in the FIRST exception, so print this one out and
                     #  continue unwinding the stack with the first one.
-                    self.logger.error("Error: Caught a secondary exception while handling a different exception.")
+                    module_logger.error("Caught a secondary exception while handling a different exception.")
                     import traceback
 
                     traceback.print_exc()
-                    pass
 
     @is_setup_fn
     def disconnect(self):
@@ -626,6 +633,9 @@ class Slot(object):
         had_upstream_slot = False
         if self.upstream_slot is not None:
             had_upstream_slot = True
+            if self.logger:
+                op_name = self.upstream_slot.operator.name if self.upstream_slot.operator is not None else "Unassigned"
+                self.logger.debug(f"Disconnecting from {op_name}.{self.upstream_slot.name}")
             # safe to unsubscribe, even if not subscribed
             self.upstream_slot._sig_unready.unsubscribe(self._handleUpstreamUnready)
             try:
@@ -672,8 +682,8 @@ class Slot(object):
             return
 
         self._resizing = True
-        if self.operator is not None:
-            self.logger.debug("Resizing slot {} of operator {} to size {}".format(self.name, self.operator.name, size))
+        if self.logger:
+            self.logger.debug(f"Resizing to {size=}")
 
         # call before resize callbacks
         self._sig_resize(self, oldsize, size)
@@ -718,19 +728,14 @@ class Slot(object):
         # call after insert callbacks
         self._sig_insert(self, position, finalsize)
 
+        if self.logger:
+            self.logger.debug(f"Inserting slot {position} to {finalsize=}")
+
         slot = self._insertNew(position)
 
         # New slot inherits our settings
         slot.backpropagate_values = self.backpropagate_values
 
-        operator_name = "<NO OPERATOR>"
-        if self.operator:
-            operator_name = self.operator.name
-        self.logger.debug(
-            "Inserting slot {} into slot {} of operator {} to size {}".format(
-                position, self.name, operator_name, finalsize
-            )
-        )
         if propagate:
             if self.upstream_slot is not None and self.upstream_slot.level == self.level:
                 self.upstream_slot.insertSlot(position, finalsize)
@@ -754,12 +759,8 @@ class Slot(object):
         if len(self) <= finalsize:
             return None
         assert position < len(self)
-        if self.operator is not None:
-            self.logger.debug(
-                "Removing slot {} into slot {} of operator {} to size {}".format(
-                    position, self.name, self.operator.name, finalsize
-                )
-            )
+        if self.logger:
+            self.logger.debug(f"Removing slot {position} to {finalsize=}")
 
         # call before-remove callbacks
         self._sig_remove(self, position, finalsize)
@@ -793,6 +794,8 @@ class Slot(object):
 
         """
         if self._value is not None:
+            if self.logger:
+                self.logger.debug(f"Returning value={self._value}")
             # this handles the case of an inputslot
             # having a ._value
             # --> construct cheaper request object for this case
@@ -801,6 +804,8 @@ class Slot(object):
         elif self.upstream_slot is not None:
             # this handles the case of an inputslot
             # --> just relay the request
+            if self.logger:
+                self.logger.debug(f"Passing request to {self.upstream_slot}.")
             return self.upstream_slot.get(roi)
         else:
             if not self.ready():
@@ -826,6 +831,8 @@ class Slot(object):
                 ), "This inputSlot has no value and no upstream_slot.  You can't ask for its data yet!"
             # normal (outputslot) case
             # --> construct heavy request object..
+            if self.logger:
+                self.logger.debug(f"Getting data for {roi=}")
             execWrapper = Slot.RequestExecutionWrapper(self, roi)
             request = Request(execWrapper)
 
@@ -961,9 +968,6 @@ class Slot(object):
                 # Something is wrong.  Are we cancelled?
                 Request.raise_if_cancelled()
                 if not self.ready():
-                    # msg = "This slot ({}.{}) isn't ready yet, which means " \
-                    #      "you can't ask for its data.  Is it connected?".format(self.operator and self.operator.name, self.name)
-                    # self.logger.error(msg)
                     problem_slot = Slot._findUpstreamProblemSlot(self)
                     problem_str = str(problem_slot)
                     if isinstance(problem_slot, Slot):
@@ -978,7 +982,6 @@ class Slot(object):
                         "First upstream problem slot is: {}"
                         "".format(self.operator and self.operator.__class__, self.name, problem_str)
                     )
-                    # self.logger.error(slotInfoMsg)
                     raise Slot.SlotNotReadyError(slotInfoMsg)
                 assert self.meta.shape is not None, (
                     "Can't ask for slices of this slot yet:"
@@ -1099,6 +1102,8 @@ class Slot(object):
                     " Call disconnect first if that's what you really wanted."
                 )
             elif self.upstream_slot is not None:
+                if self.logger:
+                    self.logger.debug("Propagating setValue upstream.")
                 self.upstream_slot.setValue(value, notify, check_changed)
                 return
 
@@ -1139,6 +1144,8 @@ class Slot(object):
                     changed = not same
 
             if changed:
+                if self.logger:
+                    self.logger.debug(f"Setting {value=}")
                 # call disconnect callbacks
                 self._sig_disconnect(self)
                 self._value = value
@@ -1155,10 +1162,14 @@ class Slot(object):
                 # a slot with a value is ready unless the value is None.
                 if self._value is not None:
                     if self.meta._ready != True:
+                        if self.logger:
+                            self.logger.debug("Now ready.")
                         self.meta._ready = True
                         self._sig_ready(self)
                 else:
                     if self.meta._ready != False:
+                        if self.logger:
+                            self.logger.debug("Now unready.")
                         self.meta._ready = False
                         self._sig_unready(self)
 
@@ -1191,11 +1202,10 @@ class Slot(object):
                     # Well, this is bad.  We caused an exception while handling an exception.
                     # We're more interested in the FIRST excpetion, so print this one out and
                     #  continue unwinding the stack with the first one.
-                    self.logger.error("Error: Caught a secondary exception while handling a different exception.")
+                    module_logger.error("Caught a secondary exception while handling a different exception.")
                     import traceback
 
                     traceback.print_exc()
-                    pass
 
     @is_setup_fn
     def setValues(self, values):
@@ -1269,6 +1279,7 @@ class Slot(object):
         return ready
 
     def _setReady(self):
+        """Called at the end of Operator._setupOutputs to set all outputs ready."""
         wasReady = self.ready()
 
         for p in self._subSlots:
@@ -1278,6 +1289,8 @@ class Slot(object):
 
         # If we just became ready...
         if not wasReady and self.meta._ready:
+            if self.logger:
+                self.logger.debug("Now ready. Notifying downstream slots.")
             # Notify downstream_slots of changed readystatus
             self._changed()
             self._sig_ready(self)
@@ -1324,6 +1337,7 @@ class Slot(object):
         init_kwargs["level"] = self.level
         init_kwargs["nonlane"] = self.nonlane
         init_kwargs["allow_mask"] = self.allow_mask
+        init_kwargs["write_logs"] = self.logger is not None
         if self._type == "input":
             init_kwargs["optional"] = self._optional
 
@@ -1338,6 +1352,14 @@ class Slot(object):
     def _changed(self):
         old_ready = self.ready()
         if self.upstream_slot is not None and self.meta != self.upstream_slot.meta:
+            if self.logger:
+                op_name = self.upstream_slot.operator.name if self.upstream_slot.operator is not None else "Unassigned"
+                msg = (
+                    f"Copying meta from {op_name}.{self.upstream_slot.name}."
+                    f" Ready: {self.meta._ready} -> {self.upstream_slot.meta._ready}."
+                    f" Shape: {self.meta.shape} -> {self.upstream_slot.meta.shape}."
+                )
+                self.logger.debug(msg)
             self.meta = self.upstream_slot.meta.copy()
 
         if self._type == "output":
@@ -1377,6 +1399,8 @@ class Slot(object):
 
         """
         if self.operator is not None:
+            if self.logger:
+                self.logger.debug(f"Calling setupOutputs of {id(self.operator)}.")
             # check whether all slots are connected and notify operator
             self.operator._setupOutputs()
 

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -134,6 +134,9 @@ class Slot(object):
         :param subindex: index within the top level slot
 
         :param top_level_slot: in case of multilevel slots a slot with the highest level
+
+        :param write_logs: Debugging feature. The slot will write debug logs if True.
+        Make sure the `lazyflow.slot_debug` logger has level=DEBUG in the logging config.
         """
         # This assertion is here for a reason: default values do NOT work on OutputSlots.
         # (We should probably change that at some point...)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -163,9 +163,9 @@ class Slot(object):
         self.logger = None
         if write_logs:
             # Using module-like dot separation allows turning on/off all slot loggers at once
-            logger_name = f"lazyflow.slot.NoOperator.{self.name}"
+            logger_name = f"lazyflow.slot_debug.NoOperator.{self.name}"
             if self.operator is not None:
-                logger_name = f"lazyflow.slot.{self.operator.name}.{self.name}"
+                logger_name = f"lazyflow.slot_debug.{self.operator.name}.{self.name}"
             self.logger = logging.getLogger(logger_name)
 
         # in the case of an InputSlot this is the slot to which it is

--- a/lazyflow/utility/orderedSignal.py
+++ b/lazyflow/utility/orderedSignal.py
@@ -1,5 +1,3 @@
-from builtins import object
-
 ###############################################################################
 #   lazyflow: data flow based lazy parallel computation framework
 #
@@ -22,6 +20,9 @@ from builtins import object
 # 		   http://ilastik.org/license/
 ###############################################################################
 from collections import OrderedDict
+import logging
+
+logger = logging.getLogger("lazyflow.signals")
 
 
 class OrderedSignal(object):
@@ -77,6 +78,7 @@ class OrderedSignal(object):
 
         for f, kw in list(self.callbacks.items()):
             try:
+                logger.debug(f"Calling {f}")
                 f(*args, **kw)
             except Request.CancellationException:
                 # We cannot allow graph setup operations to fail due to


### PR DESCRIPTION
Now that debug logging actually works, this introduces a bunch of new debug statements that allow tracing what lazyflow is doing. Also:

- Fix default naming of operators. This was only happening in `_after_init`, which is too late. We want the default name to already be set at the start of `__init__` so that slots instantiated during `__init__` can put it in their logger name.
- Add utf-8 encoding to log config to override cp1252 on windows and make it possible to log slot.meta (which can contain σ,  throws in cp1252)

At this point, the changes I make when I need to debug lazyflow are:

1. Start ilastik with `--debug`
2. Set `write_logs=True` in `Slot.__init__` instead of False to set up slot-wise logging
3. Change `INFO` to `DEBUG` in logging_config.json for lazyflow.signals, lazyflow.graph and lazyflow.op_debug
4. Exchange `module` for `name` in the `verbose` format in `default_config.py` -- This is also the format for the log file in prod, otherwise I would commit this change.