### PR TITLE
Add Object Classification from label image workflow

### DIFF
--- a/benchmarks/objectExtractionRunningTime.py
+++ b/benchmarks/objectExtractionRunningTime.py
@@ -56,6 +56,7 @@ FEATURES = {
     }
 }
 
+
 # Cleanup functions (used in vigra_objfeats.py)
 def cleanup_key(k):
     return k.replace(" ", "")
@@ -207,7 +208,7 @@ class ObjectExtractionTimeComparison(object):
         # Object extraction
         self.opObjectExtraction = OpObjectExtraction(graph=g)
         self.opObjectExtraction.RawImage.connect(self.op5Raw.Output)
-        self.opObjectExtraction.BinaryImage.connect(self.op5Binary.Output)
+        self.opObjectExtraction.SegmentationImage.connect(self.op5Binary.Output)
         self.opObjectExtraction.Features.setValue(FEATURES)
 
         # Simplified object features operator (No overhead)

--- a/examples/example_python_client.py
+++ b/examples/example_python_client.py
@@ -1,10 +1,3 @@
-"""
-This script provides an example of how a pre-trained ilastik
-PixelClassification project can be used to generate predictions
-from within Python, without the need to read/write data from disk.
-Once the project is loaded, this script doesn't touch the hard-disk.
-"""
-from __future__ import print_function
 from collections import OrderedDict
 
 import numpy
@@ -12,16 +5,9 @@ import vigra
 import os
 
 from ilastik import app
-from ilastik.applets.dataSelection import DatasetInfo
 from ilastik.applets.dataSelection.opDataSelection import PreloadedArrayDatasetInfo
 from ilastik.workflows.pixelClassification import PixelClassificationWorkflow
 
-# Before we start ilastik, optionally prepare these environment variable settings.
-os.environ["LAZYFLOW_THREADS"] = "2"
-os.environ["LAZYFLOW_TOTAL_RAM_MB"] = "2000"
-
-# Programmatically set the command-line arguments directly into the argparse.Namespace object
-# Provide your project file, and don't forget to specify headless.
 args = app.parse_args([])
 args.headless = True
 args.project = "/Users/bergs/MyProject.ilp"  # REPLACE WITH YOUR PROJECT FILE
@@ -43,18 +29,8 @@ input_data1 = numpy.random.randint(0, 255, (200, 200, 1)).astype(numpy.uint8)
 input_data2 = numpy.random.randint(0, 255, (300, 300, 1)).astype(numpy.uint8)
 print(input_data1.shape)
 
-# In this example, we're using 2D data (with an extra dimension for  channel).
-# Tagging the data this way ensures that ilastik interprets the axes correctly.
 input_data1 = vigra.taggedView(input_data1, "yxc")
 input_data2 = vigra.taggedView(input_data2, "yxc")
-
-# In case you're curious about which label class is which,
-# let's read the label names from the project file.
-label_names = opPixelClassification.LabelNames.value
-label_colors = opPixelClassification.LabelColors.value
-probability_colors = opPixelClassification.PmapColors.value
-
-print(label_names, label_colors, probability_colors)
 
 # Construct an OrderedDict of role-names -> DatasetInfos
 # (See PixelClassificationWorkflow.ROLE_NAMES)
@@ -70,18 +46,4 @@ role_data_dict = OrderedDict(
     ]
 )
 
-## Note: If you want to pull your data from disk instead of in-memory, just provide filepaths like so:
-# role_data_dict = OrderedDict([ ("Raw Data", [ '/path/to/input-file-1.png',
-#                                               '/path/to/input-file-2.h5/mydata' ]) ])
-
-# Run the export via the BatchProcessingApplet
-# Note: If you don't provide export_to_array, then the results will
-#       be exported to disk accordering to your project's DataExport settings.
-#       In that case, run_export() returns None.
 predictions = shell.workflow.batchProcessingApplet.run_export(role_data_dict, export_to_array=True)
-
-print("Computed {} result arrays:".format(len(predictions)))
-for result in predictions:
-    print(result.dtype, result.shape)
-
-print("DONE.")

--- a/ilastik/applets/blockwiseObjectClassification/opBlockwiseObjectClassification.py
+++ b/ilastik/applets/blockwiseObjectClassification/opBlockwiseObjectClassification.py
@@ -117,7 +117,7 @@ class OpSingleBlockObjectPrediction(Operator):
         self._opRawSubRegion.Input.connect(self.RawImage)
 
         self._opExtract = OpObjectExtraction(parent=self)
-        self._opExtract.BinaryImage.connect(self._opBinarySubRegion.Output)
+        self._opExtract.SegmentationImage.connect(self._opBinarySubRegion.Output)
         self._opExtract.RawImage.connect(self._opRawSubRegion.Output)
         self._opExtract.Features.connect(self.SelectedFeatures)
         self.BlockwiseRegionFeatures.connect(self._opExtract.BlockwiseRegionFeatures)

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -674,8 +674,7 @@ class ObjectClassificationGui(LabelingGui):
 
         if binarySlot.ready():
             # white foreground on transparent background, even for labeled images
-            binct = [QColor(255, 255, 255, 255).rgba()] * 65536
-            binct[0] = 0
+            binct = [0, QColor(255, 255, 255, 255).rgba()]
             binaryimagesrc = createDataSource(binarySlot)
             binLayer = ColortableLayer(binaryimagesrc, binct)
             binLayer.name = "Binary image"

--- a/ilastik/applets/objectExtraction/objectExtractionApplet.py
+++ b/ilastik/applets/objectExtraction/objectExtractionApplet.py
@@ -19,11 +19,11 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 from ilastik.applets.base.standardApplet import StandardApplet
-from ilastik.applets.objectExtraction.opObjectExtraction import OpObjectExtraction
 from ilastik.applets.objectExtraction.objectExtractionSerializer import ObjectExtractionSerializer
+from ilastik.applets.objectExtraction.opObjectExtraction import OpObjectExtraction, OpObjectExtractionFromLabels
 
 
-class ObjectExtractionApplet(StandardApplet):
+class ObjectExtractionAppletBase(StandardApplet):
     """Calculates object features for each object in an image.
 
     Features are provided by plugins, which are responsible for
@@ -34,12 +34,8 @@ class ObjectExtractionApplet(StandardApplet):
     def __init__(
         self, name="Object Extraction", workflow=None, projectFileGroupName="ObjectExtraction", interactive=True
     ):
-        super(ObjectExtractionApplet, self).__init__(name=name, workflow=workflow, interactive=interactive)
+        super().__init__(name=name, workflow=workflow, interactive=interactive)
         self._serializableItems = [ObjectExtractionSerializer(self.topLevelOperator, projectFileGroupName)]
-
-    @property
-    def singleLaneOperatorClass(self):
-        return OpObjectExtraction
 
     @property
     def broadcastingSlots(self):
@@ -47,8 +43,10 @@ class ObjectExtractionApplet(StandardApplet):
 
     @property
     def singleLaneGuiClass(self):
-        from ilastik.applets.objectExtraction.objectExtractionGui import ObjectExtractionGui
-        from ilastik.applets.objectExtraction.objectExtractionGui import ObjectExtractionGuiNonInteractive
+        from ilastik.applets.objectExtraction.objectExtractionGui import (
+            ObjectExtractionGui,
+            ObjectExtractionGuiNonInteractive,
+        )
 
         if self.interactive:
             return ObjectExtractionGui
@@ -58,3 +56,17 @@ class ObjectExtractionApplet(StandardApplet):
     @property
     def dataSerializers(self):
         return self._serializableItems
+
+
+class ObjectExtractionApplet(ObjectExtractionAppletBase):
+
+    @property
+    def singleLaneOperatorClass(self):
+        return OpObjectExtraction
+
+
+class ObjectExtractionAppletFromLabels(ObjectExtractionAppletBase):
+
+    @property
+    def singleLaneOperatorClass(self):
+        return OpObjectExtractionFromLabels

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -479,10 +479,10 @@ class ObjectExtractionGui(LayerViewerGui):
             layers.append(layer)
 
         # white foreground on transparent background, even for labeled images
-        binct = [QColor(255, 255, 255, 255).rgba()] * 65536
+        binct = [QColor(255, 255, 255, 255).rgba()] * 2
         binct[0] = 0
-        if mainOperator.BinaryImage.ready():
-            self.binaryimagesrc = createDataSource(mainOperator.BinaryImage)
+        if mainOperator.LabelImage.ready():
+            self.binaryimagesrc = createDataSource(mainOperator.LabelImage)
             self.binaryimagesrc.setObjectName("Binary LazyflowSrc")
             layer = ColortableLayer(self.binaryimagesrc, binct)
             layer.name = "Binary image"

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -516,14 +516,14 @@ class ObjectExtractionGui(LayerViewerGui):
         mainOperator.RawImage.notifyMetaChanged(self._onMetaChanged)
         self.__cleanup_fns.append(partial(mainOperator.RawImage.unregisterMetaChanged, self._onMetaChanged))
 
-        mainOperator.BinaryImage.notifyMetaChanged(self._onMetaChanged)
-        self.__cleanup_fns.append(partial(mainOperator.BinaryImage.unregisterMetaChanged, self._onMetaChanged))
+        mainOperator.SegmentationImage.notifyMetaChanged(self._onMetaChanged)
+        self.__cleanup_fns.append(partial(mainOperator.SegmentationImage.unregisterMetaChanged, self._onMetaChanged))
 
         return layers
 
     def _onMetaChanged(self, slot):
         # FiXME: why do we need that?
-        if slot is self.topLevelOperatorView.BinaryImage:
+        if slot is self.topLevelOperatorView.SegmentationImage:
             if slot.meta.shape:
                 self.editor.dataShape = slot.meta.shape
 
@@ -578,7 +578,7 @@ class ObjectExtractionGui(LayerViewerGui):
             mexBox.exec_()
             return
 
-        if not mainOperator.BinaryImage.ready():
+        if not mainOperator.SegmentationImage.ready():
             mexBox = QMessageBox()
             mexBox.setText("Please add binary (segmentation) data before selecting features ")
             mexBox.exec_()

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -121,6 +121,7 @@ class OpCachedRegionFeatures(Operator):
 
     RawImage = InputSlot()
     Atlas = InputSlot(optional=True)
+    ObjectIDMapping = InputSlot(optional=True, rtype=List, stype=Opaque)
     LabelImage = InputSlot()
     CacheInput = InputSlot(optional=True)
     Features = InputSlot(rtype=List, stype=Opaque)
@@ -143,6 +144,7 @@ class OpCachedRegionFeatures(Operator):
         self._opRegionFeatures = OpRegionFeatures(parent=self)
         self._opRegionFeatures.RawVolume.connect(self.RawImage)
         self._opRegionFeatures.Atlas.connect(self.Atlas)
+        self._opRegionFeatures.ObjectIDMapping.connect(self.ObjectIDMapping)
         self._opRegionFeatures.LabelVolume.connect(self.LabelImage)
         self._opRegionFeatures.Features.connect(self.Features)
 
@@ -421,6 +423,10 @@ class OpObjectExtractionBase(Operator, ABC):
 
 
 class OpObjectExtractionFromLabels(OpObjectExtractionBase):
+
+    def __init__(self, parent=None, graph=None):
+        super().__init__(parent, graph)
+        self._opRegFeats.ObjectIDMapping.connect(self._opLabelVolume.CachedRelabelDict)
 
     def _create_label_volume_op(self):
         opLabelVolume = OpRelabelConsecutive(parent=self)

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -385,6 +385,9 @@ class OpObjectExtractionBase(Operator, ABC):
         self.BlockwiseRegionFeatures.connect(self._opRegFeats.Output)
         self.CleanLabelBlocks.connect(self._opLabelVolume.CleanBlocks)
 
+        self.RawImage.notifyReady(self._checkConstraints)
+        self.SegmentationImage.notifyReady(self._checkConstraints)
+
     def _checkConstraints(self, *_):
         if self.RawImage.ready() and self.SegmentationImage.ready():
             rawTaggedShape = self.RawImage.meta.getTaggedShape()
@@ -403,11 +406,6 @@ class OpObjectExtractionBase(Operator, ABC):
         assert (
             slot == self.RegionFeaturesCacheInput or slot == self.LabelImageCacheInput
         ), "Invalid slot for setInSlot(): {}".format(slot.name)
-
-    def _install_constraint_checks(self):
-        """listen input changes and check compatibility"""
-        self.RawImage.notifyReady(self._checkConstraints)
-        self.SegmentationImage.notifyReady(self._checkConstraints)
 
     @abstractmethod
     def _create_label_volume_op(self) -> Operator:

--- a/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
+++ b/ilastik/applets/trackingFeatureExtraction/opTrackingFeatureExtraction.py
@@ -188,7 +188,7 @@ class OpTrackingFeatureExtraction(Operator):
 
         # connect internal operators
         self._objectExtraction.RawImage.connect(self.RawImage)
-        self._objectExtraction.BinaryImage.connect(self.BinaryImage)
+        self._objectExtraction.SegmentationImage.connect(self.BinaryImage)
         self._objectExtraction.BypassModeEnabled.connect(self.BypassModeEnabled)
         self._objectExtraction.Features.connect(self.FeatureNamesVigra)
         self._objectExtraction.RegionFeaturesCacheInput.connect(self.RegionFeaturesCacheInputVigra)

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -669,6 +669,7 @@ class IlastikShell(QMainWindow):
                 "workflows": [
                     "Object Classification (from prediction image)",
                     "Object Classification (from binary image)",
+                    "Object Classification (from label image)",
                 ],
                 "expanded": True,
             },

--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -29,6 +29,7 @@ import warnings
 import numpy
 import h5py
 
+from ilastik.applets.objectExtraction.objectExtractionApplet import ObjectExtractionAppletFromLabels
 from ilastik.workflow import Workflow
 from ilastik.applets.dataSelection import DataSelectionApplet
 from ilastik.applets.featureSelection import FeatureSelectionApplet
@@ -146,7 +147,7 @@ class ObjectClassificationWorkflow(Workflow):
             self._applets.append(self.fillMissingSlicesApplet)
 
         # our main applets
-        self.objectExtractionApplet = ObjectExtractionApplet(workflow=self, name="Object Feature Selection")
+        self.objectExtractionApplet = self._createObjectExtractionApplet()
         self.objectClassificationApplet = ObjectClassificationApplet(workflow=self)
         self._tableExporter = TableExporter(self.objectClassificationApplet.topLevelOperator)
         self.dataExportApplet = ObjectClassificationDataExportApplet(
@@ -209,6 +210,9 @@ class ObjectClassificationWorkflow(Workflow):
         opData = self.dataSelectionApplet.topLevelOperator
         opData.DatasetRoles.setValue(self.InputImageRoles.asDisplayNameList())
         self._applets.append(self.dataSelectionApplet)
+
+    def _createObjectExtractionApplet(self):
+        return ObjectExtractionApplet(workflow=self, name="Object Feature Selection")
 
     @property
     def exportsArgParser(self):
@@ -297,7 +301,7 @@ class ObjectClassificationWorkflow(Workflow):
         opBlockwiseObjectClassification = self.blockwiseObjectClassificationApplet.topLevelOperator.getLane(laneIndex)
 
         opObjExtraction.RawImage.connect(rawslot)
-        opObjExtraction.BinaryImage.connect(binaryslot)
+        opObjExtraction.SegmentationImage.connect(binaryslot)
         opObjExtraction.Atlas.connect(atlas_slot)
 
         opObjClassification.RawImages.connect(rawslot)
@@ -768,6 +772,41 @@ class ObjectClassificationWorkflowBinary(ObjectClassificationWorkflow):
         input_ready = self._inputReady()
 
         super(ObjectClassificationWorkflowBinary, self).handleAppletStateUpdateRequested(upstream_ready=input_ready)
+
+
+class ObjectClassificationWorkflowLabels(ObjectClassificationWorkflow):
+    workflowName = "Object Classification (from label image)"
+    workflowDisplayName = "Object Classification [Inputs: Raw Data, Label Image]"
+
+    class InputImageRoles(SlotNameEnum):
+        RAW_DATA = enum.auto()
+        LABEL_IMAGE = enum.auto()
+        ATLAS = enum.auto()
+
+    @property
+    def data_instructions(self):
+        return (
+            super().data_instructions
+            + f'Use the "{self.InputImageRoles.LABEL_IMAGE.displayName}" tab to load your label image(s).'
+        )
+
+    def connectInputs(self, laneIndex):
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(laneIndex)
+        canonicalRawDataSlot = self.createRawDataSourceSlot(laneIndex)
+        canonicalSegmentationSlot = self.toDefaultAxisOrder(opData.ImageGroup[self.InputImageRoles.LABEL_IMAGE])
+        return canonicalRawDataSlot, canonicalSegmentationSlot
+
+    def handleAppletStateUpdateRequested(self):
+        """
+        Overridden from Workflow base class
+        Called when an applet has fired the :py:attr:`Applet.appletStateUpdateRequested`
+        """
+        input_ready = self._inputReady()
+
+        super().handleAppletStateUpdateRequested(upstream_ready=input_ready)
+
+    def _createObjectExtractionApplet(self):
+        return ObjectExtractionAppletFromLabels(workflow=self, name="Object Feature Selection")
 
 
 class ObjectClassificationWorkflowPrediction(ObjectClassificationWorkflow):

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -265,7 +265,7 @@ class StructuredTrackingWorkflowBase(Workflow):
         op5Binary.Input.connect(binarySrc)
 
         opObjExtraction.RawImage.connect(op5Raw.Output)
-        opObjExtraction.BinaryImage.connect(op5Binary.Output)
+        opObjExtraction.SegmentationImage.connect(op5Binary.Output)
 
         opTrackingFeatureExtraction.RawImage.connect(op5Raw.Output)
         opTrackingFeatureExtraction.BinaryImage.connect(op5Binary.Output)

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 from traceback import walk_tb, FrameSummary, format_list
 
 # lazyflow
+from lazyflow.rtype import Roi, SubRegion
 from lazyflow.slot import InputSlot, OutputSlot, Slot
 from lazyflow.utility import exception_chain
 
@@ -609,7 +610,7 @@ class Operator(metaclass=OperatorMetaClass):
         finally:
             self._decrementOperatorExecutionCount()
 
-    def execute(self, slot, subindex, roi, result):
+    def execute(self, slot: OutputSlot, subindex: int, roi: SubRegion, result):
         """This method of the operator is called when a connected
         operator or an outside user of the graph wants to retrieve the
         calculation results from the operator.

--- a/lazyflow/operators/opRelabelConsecutive.py
+++ b/lazyflow/operators/opRelabelConsecutive.py
@@ -1,6 +1,34 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 import logging
+from typing import Union
+
+import numpy
 import vigra
-from lazyflow.graph import Operator, InputSlot, OutputSlot
+
+from lazyflow.graph import InputSlot, Operator, OutputSlot
+from lazyflow.operators.generic import OpPixelOperator
+from lazyflow.operators.opBlockedArrayCache import OpBlockedArrayCache
+from lazyflow.operators.opReorderAxes import OpReorderAxes
+from lazyflow.slot import Slot
 from lazyflow.utility import timeLogged
 
 logger = logging.getLogger(__name__)
@@ -8,8 +36,79 @@ logger = logging.getLogger(__name__)
 
 class OpRelabelConsecutive(Operator):
     Input = InputSlot()
-    StartLabel = InputSlot(value=0)
+    StartLabel = InputSlot(value=1)
+    BypassModeEnabled = InputSlot(value=False)
     Output = OutputSlot()
+    CachedOutput = OutputSlot()
+    CleanBlocks = OutputSlot()
+
+    supportedDtypes = [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
+
+    def __init__(self, parent=None, graph=None):
+        super().__init__(parent, graph)
+
+        # internally we want a default order to simplify things
+        self._op5 = OpReorderAxes(parent=self, Input=self.Input, AxisOrder="tzyxc")
+
+        self._opDtypeConvert = OpPixelOperator(parent=self, Input=self._op5.Output, Function=lambda x: x)
+
+        self._opRelabel = OpRelabelConsecutive5DNoCache(
+            parent=self, Input=self._opDtypeConvert.Output, StartLabel=self.StartLabel
+        )
+
+        self._cache = OpBlockedArrayCache(parent=self)
+        self._cache.name = "OpLabelVolume.OutputCache"
+        self._cache.BypassModeEnabled.connect(self.BypassModeEnabled)
+        self._cache.Input.connect(self._opRelabel.Output)
+        self.CleanBlocks.connect(self._cache.CleanBlocks)
+
+        self._reoder_to_input_order = OpReorderAxes(parent=self, Input=self._opRelabel.Output, AxisOrder=None)
+        self._reoder_to_input_order_cached = OpReorderAxes(parent=self, Input=self._cache.Output, AxisOrder=None)
+
+        self.Output.connect(self._reoder_to_input_order.Output)
+        self.CachedOutput.connect(self._reoder_to_input_order_cached.Output)
+
+    def setupOutputs(self):
+        # check if the input dtype is valid
+        if self.Input.ready():
+            dtype = self.Input.meta.dtype
+            if dtype not in self.supportedDtypes:
+                msg = f"{self.name}: dtype '{dtype}' not supported. Supported types: {self.supportedDtypes}"
+                raise ValueError(msg)
+
+        # set cache chunk shape to the whole spatial volume
+        shape = numpy.asarray(self._op5.Output.meta.shape, dtype=numpy.int64)
+        shape[0] = 1
+        shape[4] = 1
+        self._cache.BlockShape.setValue(tuple(shape))
+
+        # vigra cannot handle uint16 images in relabel - we'll convert
+        # those automatically to uint32
+        if self.Input.meta.dtype == numpy.uint16:
+            self._opDtypeConvert.Function.setValue(lambda x: x.astype("uint32"))
+        else:
+            self._opDtypeConvert.Function.setValue(lambda x: x)
+
+        # ensure Output is returned in the same order as input data
+        input_order = self.Input.meta.getAxisKeys()
+        self._reoder_to_input_order.AxisOrder.setValue(input_order)
+        self._reoder_to_input_order_cached.AxisOrder.setValue(input_order)
+
+    def propagateDirty(self, slot, subindex, roi):
+        pass
+
+
+class OpRelabelConsecutive5DNoCache(Operator):
+    Input = InputSlot()
+    StartLabel = InputSlot()
+    Output = OutputSlot()
+
+    supportedDtypes = [numpy.uint8, numpy.uint32, numpy.uint64]
+
+    def __init__(self, graph=None, parent=None, Input=None, StartLabel: Union[int, Slot] = 1):
+        super().__init__(graph=graph, parent=parent)
+        self.Input.setOrConnectIfAvailable(Input)
+        self.StartLabel.setOrConnectIfAvailable(StartLabel)
 
     def setupOutputs(self):
         self.Output.meta.assignFrom(self.Input.meta)
@@ -19,8 +118,8 @@ class OpRelabelConsecutive(Operator):
         self.Input.get(roi).writeInto(result).wait()
         result = vigra.taggedView(result, self.Output.meta.axistags).withAxes("zyx")
         _res, _max_label, _labelmap_dict = vigra.analysis.relabelConsecutive(
-            result, self.StartLabel.value, keep_zeros=False, out=result
+            result, self.StartLabel.value, keep_zeros=True, out=result
         )
 
     def propagateDirty(self, slot, subindex, roi):
-        self.Output.setDirty(roi.start, roi.stop)
+        self.Output.setDirty(())

--- a/lazyflow/operators/opRelabelConsecutive.py
+++ b/lazyflow/operators/opRelabelConsecutive.py
@@ -18,6 +18,7 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
+from functools import partial
 import logging
 from typing import Union
 
@@ -29,9 +30,8 @@ from lazyflow.operators.generic import OpPixelOperator
 from lazyflow.operators.opBlockedArrayCache import OpBlockedArrayCache
 from lazyflow.operators.opReorderAxes import OpReorderAxes
 from lazyflow.operators.valueProviders import OpValueCache
-from lazyflow.rtype import List
+from lazyflow.request.request import Request, RequestPool
 from lazyflow.slot import Slot
-from lazyflow.stype import Opaque
 from lazyflow.utility import timeLogged
 
 logger = logging.getLogger(__name__)
@@ -42,8 +42,9 @@ class OpRelabelConsecutive(Operator):
     StartLabel = InputSlot(value=1)
     BypassModeEnabled = InputSlot(value=False)
     Output = OutputSlot()
+    RelabelDict = OutputSlot()  # will always have only a "t" axis
+    CachedRelabelDict = OutputSlot()  # will always have only a "t" axis
     CachedOutput = OutputSlot()
-    CachedRelabelDict = OutputSlot(rtype=List, stype=Opaque)
     CleanBlocks = OutputSlot()
 
     supportedDtypes = [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]
@@ -74,6 +75,7 @@ class OpRelabelConsecutive(Operator):
         self._reoder_to_input_order_cached = OpReorderAxes(parent=self, Input=self._cache.Output, AxisOrder=None)
 
         self.Output.connect(self._reoder_to_input_order.Output)
+        self.RelabelDict.connect(self._opRelabel.RelabelDict)
         self.CachedOutput.connect(self._reoder_to_input_order_cached.Output)
 
     def setupOutputs(self):
@@ -107,9 +109,11 @@ class OpRelabelConsecutive(Operator):
 
 
 class OpRelabelConsecutive5DNoCache(Operator):
-    Input = InputSlot()
+    Input = InputSlot()  # in "tzyxc" order
     StartLabel = InputSlot()
     Output = OutputSlot()
+
+    RelabelDict = OutputSlot()
 
     supportedDtypes = [numpy.uint8, numpy.uint32, numpy.uint64]
 
@@ -118,27 +122,48 @@ class OpRelabelConsecutive5DNoCache(Operator):
         self.Input.setOrConnectIfAvailable(Input)
         self.StartLabel.setOrConnectIfAvailable(StartLabel)
 
-        self._relable_dict = None
+        self._relable_dict = {}
 
     def setupOutputs(self):
+        assert "".join(self.Input.meta.getAxisKeys()) == "tzyxc"
         self.Output.meta.assignFrom(self.Input.meta)
-        self.Output.meta.relabel_dict = [None] * self.Input.meta.getTaggedShape()["t"]
+        self.RelabelDict.meta.shape = (self.Input.meta.getTaggedShape()["t"],)
+        self.RelabelDict.meta.dtype = object
+        self.RelabelDict.meta.axistags = vigra.defaultAxistags("t")
+
+        self._relable_dict = {}
 
     @timeLogged(logger)
-    @Operator.forbidParallelExecute
     def execute(self, slot, subindex, roi, result):
-        # Todo: in fact iterate over time (can be parallel)
-        assert slot == self.Output
         t_idx = self.Input.meta.getAxisKeys().index("t")
 
-        self.Input.get(roi).writeInto(result).wait()
-        result = vigra.taggedView(result, self.Output.meta.axistags).withAxes("zyx")
-        _res, _max_label, labelmap_dict = vigra.analysis.relabelConsecutive(
-            result, self.StartLabel.value, keep_zeros=True, out=result
-        )
-        # slot.meta.relable_dict[] = labelmap_dict
+        def relabel_single_slice(t, res_t):
+            if slot == self.RelabelDict and t in self._relable_dict:
+                result[res_t] = self._relable_dict[t]
+                return
+
+            t_slice_roi = roi.copy()
+            t_slice_roi.start[t_idx] = t
+            t_slice_roi.stop[t_idx] = t + 1
+
+            t_slice = vigra.taggedView(self.Input.get(t_slice_roi).wait(), self.Input.meta.axistags).withAxes("zyx")
+            _res, _max_label, labelmap_dict = vigra.analysis.relabelConsecutive(
+                t_slice, self.StartLabel.value, keep_zeros=True, out=t_slice
+            )
+
+            self._relable_dict[t] = labelmap_dict
+            result_roi = roi.copy()
+            result_roi.start[t_idx] = res_t
+            result_roi.stop[t_idx] = res_t + 1
+            result[result_roi.toSlice()] = t_slice.withAxes(self.Output.meta.axistags)
+
+        pool = RequestPool()
+        for res_t_ind, t in enumerate(range(roi.start[t_idx], roi.stop[t_idx])):
+            pool.add(Request(partial(relabel_single_slice, t, res_t_ind)))
+
+        pool.wait()
 
     def propagateDirty(self, slot, subindex, roi):
-        self._relable_dict = None
+        self._relable_dict = {}
         self.Output.setDirty(())
         self.RelabelDict.setDirty(())

--- a/lazyflow/roi.py
+++ b/lazyflow/roi.py
@@ -254,7 +254,7 @@ def sliceToRoi(
     shape: Sequence[numbers.Integral],
     *,
     extendSingleton: bool = True,
-) -> Tuple[Sequence[int], Sequence[int]]:
+) -> Tuple[TinyVector, TinyVector]:
     """Convert slicing to ROI.
 
     Negative indices and slices are allowed similarly to usual Python

--- a/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
+++ b/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
@@ -176,7 +176,7 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
         opObjectExtraction = OpObjectExtraction(graph=self.graph)
 
         opObjectExtraction.RawImage.connect(self.rawSource.Output)
-        opObjectExtraction.BinaryImage.connect(self.binarySource.Output)
+        opObjectExtraction.SegmentationImage.connect(self.binarySource.Output)
         opObjectExtraction.BackgroundLabels.setValue([0])
         opObjectExtraction.Features.setValue(self.testingFeatures)
 

--- a/tests/test_ilastik/test_applets/objectClassification/testOperators.py
+++ b/tests/test_ilastik/test_applets/objectClassification/testOperators.py
@@ -332,7 +332,7 @@ class TestFeatureSelection(unittest.TestCase):
         }
 
         self.extrOp = OpObjectExtraction(graph=g)
-        self.extrOp.BinaryImage.setValue(binimg)
+        self.extrOp.SegmentationImage.setValue(binimg)
         self.extrOp.RawImage.setValue(rawimg)
         self.extrOp.Features.setValue(features)
 
@@ -500,7 +500,7 @@ class TestFullOperator(unittest.TestCase):
         }
 
         self.extrOp = OpObjectExtraction(graph=g)
-        self.extrOp.BinaryImage.setValue(binimg)
+        self.extrOp.SegmentationImage.setValue(binimg)
         self.extrOp.RawImage.setValue(rawimg)
         self.extrOp.Features.setValue(features)
         assert self.extrOp.RegionFeatures.ready()

--- a/tests/test_ilastik/test_applets/objectClassification/testPrediction.py
+++ b/tests/test_ilastik/test_applets/objectClassification/testPrediction.py
@@ -119,7 +119,7 @@ class TestWithCube(unittest.TestCase):
         opPredict = OpObjectClassification(graph=gr)
 
         opExtract.RawImage.setValue(self.rawimg)
-        opExtract.BinaryImage.setValue(self.binimg)
+        opExtract.SegmentationImage.setValue(self.binimg)
         opExtract.Features.setValue(self.features)
 
         opPredict.RawImages.setValues([self.rawimg])
@@ -190,7 +190,7 @@ class TestWithCube(unittest.TestCase):
         opPredict = OpObjectClassification(graph=gr)
 
         opExtract.RawImage.setValue(self.rawimg)
-        opExtract.BinaryImage.setValue(self.binimg)
+        opExtract.SegmentationImage.setValue(self.binimg)
         opExtract.Features.setValue(self.features)
 
         opPredict.RawImages.setValues([self.rawimg])
@@ -206,7 +206,7 @@ class TestWithCube(unittest.TestCase):
         opPredictT = OpObjectClassification(graph=grT)
 
         opExtractT.RawImage.setValue(self.rawimgt)
-        opExtractT.BinaryImage.setValue(self.binimgt)
+        opExtractT.SegmentationImage.setValue(self.binimgt)
         opExtractT.Features.setValue(self.features)
 
         opPredictT.RawImages.setValues([self.rawimgt])

--- a/tests/test_ilastik/test_applets/objectExtraction/testOperators.py
+++ b/tests/test_ilastik/test_applets/objectExtraction/testOperators.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -21,15 +18,12 @@ from __future__ import division
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
-from past.utils import old_div
 import unittest
 import numpy as np
 import vigra
 from lazyflow.graph import Graph
 from lazyflow.operators import OpLabelVolume
 from ilastik.applets.objectExtraction.opObjectExtraction import OpAdaptTimeListRoi, OpRegionFeatures, OpObjectExtraction
-from ilastik.plugins.manager import pluginManager
 
 import warnings
 
@@ -129,7 +123,7 @@ class TestPlugins(unittest.TestCase):
         # self.op.Features.setValue(FEATURES)
         bm = binaryImage()
         bm = bm[:, :, :, 0:1, :]
-        self.op.BinaryImage.setValue(bm)
+        self.op.SegmentationImage.setValue(bm)
 
     def test_plugins(self):
         self.op.Features.setValue(self.Features_standard)

--- a/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
+++ b/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
@@ -232,7 +232,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
 
             # make sure some preconditions are met:
             assert op_object_features.RawImage.ready()
-            assert op_object_features.BinaryImage.ready()
+            assert op_object_features.SegmentationImage.ready()
 
             # we cannot test the feature-selection dialog here, as it's modal.
             # we therefore select a set of object features (all of them) and

--- a/tests/test_lazyflow/test_operators/testOpRelabelConsecutive.py
+++ b/tests/test_lazyflow/test_operators/testOpRelabelConsecutive.py
@@ -1,29 +1,67 @@
-from builtins import object
 import numpy as np
 import pytest
 import vigra
-from lazyflow.graph import Graph
+
 from lazyflow.operators import OpRelabelConsecutive
 
-pandas = pytest.importorskip("pandas")
+
+@pytest.fixture
+def oprelabel(graph):
+    return OpRelabelConsecutive(graph=graph)
 
 
-class TestOpRelabelConsecutive(object):
-    def test_simple(self):
-        op = OpRelabelConsecutive(graph=Graph())
+@pytest.fixture
+def labels() -> vigra.VigraArray:
+    return vigra.taggedView(2 * np.arange(0, 100, dtype=np.uint8).reshape((10, 10)), "yx")
 
-        labels = 2 * np.arange(0, 100, dtype=np.uint8).reshape((10, 10))
-        labels = vigra.taggedView(labels, "yx")
-        op.Input.setValue(labels)
-        relabeled = op.Output[:].wait()
-        assert (relabeled == labels // 2).all()
 
-    def test_startlabel(self):
-        op = OpRelabelConsecutive(graph=Graph())
-        op.StartLabel.setValue(10)
+@pytest.mark.parametrize("axistags", ["yx", "zyx", "xyz", "xztyc"])
+def test_preserve_axistags(oprelabel, labels, axistags):
+    labels = labels.withAxes(axistags)
+    oprelabel.Input.setValue(labels)
 
-        labels = 2 * np.arange(0, 100, dtype=np.uint8).reshape((10, 10))
-        labels = vigra.taggedView(labels, "yx")
-        op.Input.setValue(labels)
-        relabeled = op.Output[:].wait()
-        assert (relabeled == 10 + labels // 2).all()
+    assert "".join(oprelabel.Output.meta.getAxisKeys()) == axistags
+
+
+def test_simple(oprelabel, labels):
+    oprelabel.Input.setValue(labels)
+    relabeled = oprelabel.Output[:].wait()
+    np.testing.assert_array_equal(relabeled, labels // 2)
+
+
+def test_startlabel(oprelabel, labels):
+    oprelabel.StartLabel.setValue(10)
+    oprelabel.Input.setValue(labels)
+    relabeled = oprelabel.Output[:].wait()
+
+    # 0 is a special label (we assume it's background), so it is unchanged
+    # the first found object will have value 10
+    # with the input data being 0, 2, 4, 6, 8 ...: 0, 10, 11, 12, 13 ...
+    expected = labels // 2
+    expected[expected > 0] += 9
+    np.testing.assert_array_equal(relabeled, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype_in, expected_dtype",
+    [
+        ("uint8", "uint8"),
+        ("uint16", "uint32"),  # uint16 will be converted to uint32 (vigra cannot handle uint16)
+        ("uint32", "uint32"),
+        ("uint64", "uint64"),
+    ],
+)
+def test_input_datatypes(oprelabel, labels, dtype_in, expected_dtype):
+    labels = labels.astype(dtype_in)
+    oprelabel.Input.setValue(labels)
+    relabeled = oprelabel.Output[:].wait()
+    np.testing.assert_array_equal(relabeled, labels // 2)
+    assert relabeled.dtype == expected_dtype
+
+
+@pytest.mark.parametrize("dtype", ["float", "float16", "float32", "float64"])
+def test_unsupported_dtype_raises(oprelabel, labels, dtype):
+    labels = labels.astype(dtype)
+
+    with pytest.raises(ValueError):
+        oprelabel.Input.setValue(labels)


### PR DESCRIPTION
This is wip - but already kinda works ;)

Inputs such as label images from cellpose or stardist are treated a bit poorly  in ilastik - connected components is run again (with possibly different connectivity) resulting in different objects in ilastik after loading such label image data.

This PR introduces a new workflow that internally doesn't do CCA anymore but merely relabels the label image to ensure consecutive labels (required by feature extraction).

see discussion in #2416

fixes #2416

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] **Add original labels to export table.** 
- [ ] simplify `OpObjectExtraction` such that `setupOutputs` can also go to the base class (labelingop should expose a slot for cache pre-loading).
- [x] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [x] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
