### PR TITLE
Python 3.10 compatiblity fixes

### DIFF
--- a/ilastik/applets/counting/countingGui.py
+++ b/ilastik/applets/counting/countingGui.py
@@ -56,7 +56,7 @@ def _countingColorTable():
     colortable = matplotlib_to_qt4_colortable("jet", N=n_gradual, asLong=False)
     weights = numpy.tanh(numpy.linspace(0, 1.0, n_gradual))
     for w, c in zip(weights, colortable):
-        c.setAlpha(w * 255)
+        c.setAlpha(int(w * 255))
     colortable = [c.rgba() for c in colortable]
 
     return [*colortable, *[colortable[-1]] * (n_total - n_gradual)]

--- a/ilastik/applets/counting/countingGuiBoxesInterface.py
+++ b/ilastik/applets/counting/countingGuiBoxesInterface.py
@@ -449,7 +449,7 @@ class QGraphicsResizableRect(QGraphicsRectItem):
     def setOpacity(self, float):
         logger.debug("Resetting Opacity {}".format(float))
 
-        self._normalColor.setAlpha(float * 255)
+        self._normalColor.setAlpha(int(float * 255))
 
         self.updateColor()
 

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1105,7 +1105,7 @@ class IlastikShell(QMainWindow):
         self.updateShellProjectDisplay()
         # Default to a 50-50 split
         totalSplitterHeight = sum(self.sideSplitter.sizes())
-        self.sideSplitter.setSizes([totalSplitterHeight / 2, totalSplitterHeight / 2])
+        self.sideSplitter.setSizes([totalSplitterHeight // 2, totalSplitterHeight // 2])
 
     @threadRouted
     def updateShellProjectDisplay(self):

--- a/ilastik/widgets/featureTableWidget.py
+++ b/ilastik/widgets/featureTableWidget.py
@@ -19,8 +19,7 @@
 #          http://ilastik.org/license.html
 ###############################################################################
 import enum
-from past.utils import old_div
-from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QImage, QPainter, QPen, QPixmap, QPolygon, QKeyEvent
+from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QPainter, QPen, QPixmap, QPolygon, QKeyEvent
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QHeaderView,
@@ -173,8 +172,8 @@ class FeatureTableWidgetHHeader(QTableWidgetItem):
         painter.setBrush(brush)
         painter.drawEllipse(
             QRect(
-                old_div(self.pixmapSize.width(), 2) - old_div(self.brushSize, 2),
-                old_div(self.pixmapSize.height(), 2) - old_div(self.brushSize, 2),
+                self.pixmapSize.width() // 2 - self.brushSize // 2,
+                self.pixmapSize.height() // 2 - self.brushSize // 2,
                 self.brushSize,
                 self.brushSize,
             )
@@ -297,8 +296,8 @@ class ItemDelegate(QItemDelegate):
         painter.drawRect(QRect(5, 5, width - 10, height - 10))
         pen.setWidth(4)
         painter.setPen(pen)
-        painter.drawLine(width / 2 - 5, height / 2, width / 2, height - 10)
-        painter.drawLine(width / 2, height - 10, width / 2 + 10, 2)
+        painter.drawLine(width // 2 - 5, height // 2, width // 2, height - 10)
+        painter.drawLine(width // 2, height - 10, width // 2 + 10, 2)
         painter.end()
 
     def drawPixmapForPartiallyChecked(self, painter: QPainter, width: int, height: int) -> None:
@@ -310,8 +309,8 @@ class ItemDelegate(QItemDelegate):
         pen.setWidth(4)
         pen.setColor(QColor(139, 137, 137))
         painter.setPen(pen)
-        painter.drawLine(width / 2 - 5, height / 2, width / 2, height - 10)
-        painter.drawLine(width / 2, height - 10, width / 2 + 10, 2)
+        painter.drawLine(width // 2 - 5, height // 2, width // 2, height - 10)
+        painter.drawLine(width // 2, height - 10, width // 2 + 10, 2)
         painter.end()
 
     def paint(self, painter, option, index):

--- a/ilastik/widgets/featureTableWidget.py
+++ b/ilastik/widgets/featureTableWidget.py
@@ -350,22 +350,6 @@ class ItemDelegate(QItemDelegate):
                 painter.fillRect(option.rect.adjusted(5, 5, -5, -5), QColor(0, 250, 154))
                 painter.drawPixmap(option.rect, self.getPixmap(self.Role.CHECKED, option.rect.size()))
 
-    def adjustRectForImage(self, option):
-        if self.itemWidth > self.itemHeight:
-            return option.rect.adjusted(
-                old_div((self.itemWidth - self.itemHeight), 2) + 5,
-                5,
-                -(old_div((self.itemWidth - self.itemHeight), 2)) - 5,
-                -5,
-            )
-        else:
-            return option.rect.adjusted(
-                5,
-                old_div((self.itemHeight - self.itemWidth), 2) + 5,
-                -(old_div((self.itemHeight - self.itemWidth), 2)) - 5,
-                -5,
-            )
-
 
 # ==============================================================================
 # FeatureTableWidget2d

--- a/ilastik/widgets/preView.py
+++ b/ilastik/widgets/preView.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
@@ -20,10 +18,10 @@ from __future__ import division
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from past.utils import old_div
-from PyQt5.QtGui import QPixmap, QPainter, QBrush, QPen, QPalette, QColor
+from PyQt5.QtGui import QPixmap, QPainter, QBrush, QPen, QPalette
 from PyQt5.QtWidgets import QGraphicsView, QVBoxLayout, QLabel, QGraphicsScene
 from PyQt5.QtCore import Qt, QRect, QSize, QEvent
+
 
 # ===============================================================================
 # PreView
@@ -32,13 +30,11 @@ class PreView(QGraphicsView):
     def __init__(self):
         QGraphicsView.__init__(self)
 
-        self.zoom = 2
+        self.zoom: int = 2
         self.scale(self.zoom, self.zoom)
-        self.lastSize = 0
+        self.lastSize: int = 0
 
         self.setDragMode(QGraphicsView.ScrollHandDrag)
-        #        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        #        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.installEventFilter(self)
 
         self.hudLayout = QVBoxLayout(self)
@@ -64,7 +60,7 @@ class PreView(QGraphicsView):
     def sizeHint(self):
         return QSize(200, 200)
 
-    def updateFilledCircle(self, s):
+    def updateFilledCircle(self, s: int):
         size = s * self.zoom
         pixmap = QPixmap(self.width(), self.height())
         pixmap.fill(Qt.transparent)
@@ -76,9 +72,7 @@ class PreView(QGraphicsView):
         brush = QBrush(p.link().color())
         painter.setBrush(brush)
         painter.setOpacity(0.4)
-        painter.drawEllipse(
-            QRect(old_div(self.width(), 2) - old_div(size, 2), old_div(self.height(), 2) - old_div(size, 2), size, size)
-        )
+        painter.drawEllipse(QRect(self.width() // 2 - size // 2, self.height() // 2 - size // 2, size, size))
         painter.end()
         # painter ellipse 2
         painter2 = QPainter()
@@ -87,9 +81,7 @@ class PreView(QGraphicsView):
         pen2 = QPen(Qt.green)
         pen2.setWidth(1)
         painter2.setPen(pen2)
-        painter2.drawEllipse(
-            QRect(old_div(self.width(), 2) - old_div(size, 2), old_div(self.height(), 2) - old_div(size, 2), size, size)
-        )
+        painter2.drawEllipse(QRect(self.width() // 2 - size // 2, self.height() // 2 - size // 2, size, size))
         painter2.end()
 
         self.ellipseLabel.setPixmap(QPixmap(pixmap))

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -432,7 +432,7 @@ class Operator(metaclass=OperatorMetaClass):
         assert self._executionCount > 0, "BUG: Can't decrement the execution count below zero!"
         with self._condition:
             self._executionCount -= 1
-            self._condition.notifyAll()
+            self._condition.notify_all()
 
     def propagateDirty(self, slot, subindex, roi):
         """This method is called when an output of another operator on
@@ -473,7 +473,7 @@ class Operator(metaclass=OperatorMetaClass):
                     return func(self, *args, **kwargs)
                 finally:
                     self._settingUp = False
-                    self._condition.notifyAll()
+                    self._condition.notify_all()
 
         wrapper.__wrapped__ = func  # Emulate python 3 behavior of @wraps
         return wrapper
@@ -499,7 +499,7 @@ class Operator(metaclass=OperatorMetaClass):
             self._setup_count += 1
 
             self._settingUp = False
-            self._condition.notifyAll()
+            self._condition.notify_all()
 
         try:
             # Determine new "ready" flags

--- a/lazyflow/operators/cacheMemoryManager.py
+++ b/lazyflow/operators/cacheMemoryManager.py
@@ -256,7 +256,7 @@ class _CacheMemoryManager(threading.Thread):
         """
         with self._condition:
             self._refresh_interval = t
-            self._condition.notifyAll()
+            self._condition.notify_all()
 
     def disable(self):
         """
@@ -274,7 +274,7 @@ class _CacheMemoryManager(threading.Thread):
         with self._disable_lock:
             self._disabled = False
         with self._condition:
-            self._condition.notifyAll()
+            self._condition.notify_all()
 
 
 _cache_memory_manager = _CacheMemoryManager()


### PR DESCRIPTION
One of our test configurations picked up Python 3.10 (which is fine for the "lirbary" usage). This resulted in some minor errors:

1. Threadings `condition.notifyAll` has been marked for deprecation in favor of `condition.notify_all`. In `TestCompatibilityChecks.test_access_opaque_slot_value_should_not_warn_or_raise` we check that no warning is raised. This was of course broken by the deprecation. Rather than adapting the test I preferred keeping up with Python
2. Python stopped implicitly converting types in function calls -> results in errors/segfaults in pyqt. Explicitly converted types or made sure e.g. integer value division is used (e.g. in draw methods of `featureTableWidget`).

fixes #2852 