### PR TITLE
Delay setupLayers to LayerGui being shown

### DIFF
--- a/ilastik/applets/layerViewer/layerViewerGui.py
+++ b/ilastik/applets/layerViewer/layerViewerGui.py
@@ -150,6 +150,7 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
 
         self._stopped = False
         self._initialized = False
+        self._need_update = True
         self.__cleanup_fns = []
 
         self.threadRouter = ThreadRouter(self)  # For using @threadRouted
@@ -211,7 +212,6 @@ class LayerViewerGui(with_metaclass(LayerViewerGuiMetaclass, QWidget)):
 
     def _after_init(self):
         self._initialized = True
-        self.updateAllLayers()
 
     def setNeedUpdate(self, slot=None):
         self._need_update = True

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -613,6 +613,8 @@ class CarvingGui(LabelingGui):
     def _update_colors(self):
         """Update colors of objects in 3D viewport"""
         op = self.topLevelOperatorView
+        if not self._shownObjects3D.items():
+            return
         ctable = self._doneSegmentationLayer.colorTable
 
         for name, label in self._shownObjects3D.items():


### PR DESCRIPTION
Issue: when switching to dataexport one sometimes raises an exception like (against current `volumina` main):

<details><summary>Exception</summary>

```pytb
ERROR 2024-05-07 16:55:14,802 excepthooks 93120 6118469632 Unhandled exception in thread: 'Worker #0'
ERROR 2024-05-07 16:55:14,803 excepthooks 93120 6118469632 Traceback (most recent call last):
  File ".../ilastik/lazyflow/request/request.py", line 383, in _execute
    self._result = self.fn()
  File ".../ilastik/lazyflow/slot.py", line 868, in __call__
    result_op = self.operator.call_execute(self.slot.top_level_slot, self.slot.subindex, self.roi, destination)
  File ".../ilastik/lazyflow/operator.py", line 592, in call_execute
    return self.execute(slot, subindex, roi, result, **kwargs)
  File ".../ilastik/lazyflow/operators/opReorderAxes.py", line 171, in execute
    self.Input(*in_roi).writeInto(result_input_view).wait()
  File ".../ilastik/lazyflow/slot.py", line 1292, in __call__
    return self.get(roi)
  File ".../ilastik/lazyflow/slot.py", line 817, in get
    raise Slot.SlotNotReadyError(msg)
lazyflow.slot.Slot.SlotNotReadyError: Can't get data from slot <class 'lazyflow.operators.opReorderAxes.OpReorderAxes'>.Input yet. It isn't ready. First upstream problem slot is: reorder_lazyflow_source_to_volumina/reorder_lazyflow_source_to_volumina.Input []:    {_ready : False, shape : None, has_mask : None, _dirty : False}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File ".../ilastik/lazyflow/request/request.py", line 383, in _execute
    self._result = self.fn()
  File ".../volumina/volumina/tiling/tileprovider.py", line 403, in _fetch_layer_tile
    img = ims_req.wait()
  File ".../volumina/volumina/pixelpipeline/imagesources/grayscale.py", line 59, in wait
    return self.toImage()
  File ".../volumina/volumina/pixelpipeline/imagesources/grayscale.py", line 65, in toImage
    a = self._arrayreq.wait()
  File ".../volumina/volumina/pixelpipeline/slicesources.py", line 51, in wait
    return self._sp(self._ar.wait())
  File ".../volumina/volumina/pixelpipeline/datasources/minmaxsource.py", line 17, in wait
    rawData = self._rawRequest.wait()
  File ".../volumina/volumina/pixelpipeline/datasources/cachesource.py", line 28, in wait
    res = self._rq.wait()
  File ".../volumina/volumina/pixelpipeline/datasources/lazyflowsource.py", line 46, in wrapper
    return func(*args, **kwargs)
  File ".../volumina/volumina/pixelpipeline/datasources/lazyflowsource.py", line 68, in wait
    a = self._req.wait()
  File ".../ilastik/lazyflow/request/request.py", line 564, in wait
    return self._wait(timeout)
  File ".../ilastik/lazyflow/request/request.py", line 592, in _wait
    self._wait_within_request(current_request)
  File ".../ilastik/lazyflow/request/request.py", line 721, in _wait_within_request
    raise RequestError(self.fn) from exc_value
lazyflow.request.request.RequestError: Failed to request data from `reorder_lazyflow_source_to_volumina.Output`
```
</details>

I could verify that the involved `OpReorderAxis` is not connected anymore once this fires.
I am not 100% sure what happens, but it looks like the LayerViewerGui is shown (with a valid layerstack) and data is being requested. However, `showEvent` in turn triggers another `setupLayers` call. Volumina might be requesting data during `updateAllLayers` calls. This could result in layers being deleted during requests - the reorder ops in volumina are cleaned- up and are not connected to anything anymore - the requests are out though.

Not sure the fix here is _the_ fix, but so far I couldn't find any undesirable side effects, and it makes sense to be a bit more lazy and create layers only once the UI is shown.

ref: https://github.com/ilastik/volumina/pull/307 (would not be visible without it)


<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
