### PR TITLE
Ome zarr via zgroup file

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -542,20 +542,24 @@ class DataSelectionGui(QWidget):
         datasetNames = DatasetInfo.getPossibleInternalPathsFor(filePath.absolute())
         if len(datasetNames) == 0:
             raise RuntimeError(f"File {filePath} has no image datasets")
+        keep_selected_as_default = False
         if len(datasetNames) == 1:
             selected_dataset = datasetNames.pop()
+            keep_selected_as_default = True
         else:
             auto_inner_paths = self._get_previously_used_inner_paths(roleIndex).intersection(set(datasetNames))
             if len(auto_inner_paths) == 1:
                 selected_dataset = auto_inner_paths.pop()
             else:
                 # Ask the user which dataset to choose
-                dlg = SubvolumeSelectionDlg(datasetNames, self)
+                dlg = SubvolumeSelectionDlg(datasetNames, self, offer_remember_dataset=True)
                 if dlg.exec_() != QDialog.Accepted:
                     raise DataSelectionGui.UserCancelledError()
                 selected_index = dlg.combo.currentIndex()
+                keep_selected_as_default = dlg.checkbox.isChecked()
                 selected_dataset = str(datasetNames[selected_index])
-        self._add_default_inner_path(roleIndex=roleIndex, inner_path=selected_dataset)
+        if keep_selected_as_default:
+            self._add_default_inner_path(roleIndex=roleIndex, inner_path=selected_dataset)
         return filePath / selected_dataset.lstrip("/")
 
     def _get_custom_axistags_from_previous_lane(self, role: Union[str, int], info: DatasetInfo) -> Optional[AxisTags]:

--- a/ilastik/widgets/ImageFileDialog.py
+++ b/ilastik/widgets/ImageFileDialog.py
@@ -37,7 +37,9 @@ class ImageFileDialog(QFileDialog):
         filePaths = []
         for selected_file in self.selectedFiles():
             path = Path(selected_file)
-            if path.name.lower() == "attributes.json" and any(p.suffix.lower() == ".n5" for p in path.parents):
+            if (path.name.lower() == "attributes.json" and any(p.suffix.lower() == ".n5" for p in path.parents)) or (
+                path.name.lower() == ".zgroup" and any(p.suffix.lower() == ".zarr" for p in path.parents)
+            ):
                 # For the n5 extension the attributes.json file has to be selected in the file dialog.
                 # However we need just the *.n5 directory-file.
                 filePaths.append(path.parent)

--- a/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
+++ b/ilastik/widgets/hdf5SubvolumeSelectionDialog.py
@@ -28,6 +28,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QCheckBox,
 )
 
 from PyQt5.QtCore import Qt
@@ -40,7 +41,7 @@ class SubvolumeSelectionDlg(QDialog):
     A window to ask the user to choose between multiple HDF5 datasets in a single file.
     """
 
-    def __init__(self, datasetNames, parent):
+    def __init__(self, datasetNames, parent, offer_remember_dataset=False):
         super().__init__(parent)
         label = QLabel(
             "Your HDF5/N5 File contains multiple image volumes.\nPlease select the one you would like to open."
@@ -50,6 +51,9 @@ class SubvolumeSelectionDlg(QDialog):
         for name in datasetNames:
             self.combo.addItem(name)
 
+        if offer_remember_dataset:
+            self.checkbox = QCheckBox("Always use this dataset in this file (until next ilastik restart)")
+
         buttonbox = QDialogButtonBox(Qt.Horizontal, parent=self)
         buttonbox.setStandardButtons(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttonbox.accepted.connect(self.accept)
@@ -58,6 +62,8 @@ class SubvolumeSelectionDlg(QDialog):
         layout = QVBoxLayout()
         layout.addWidget(label)
         layout.addWidget(self.combo)
+        if offer_remember_dataset:
+            layout.addWidget(self.checkbox)
         layout.addWidget(buttonbox)
 
         self.setLayout(layout)

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -371,7 +371,7 @@ def lsH5N5(h5N5FileObject, minShape=2, maxShape=5):
             return
         if len(obj.shape) not in range(minShape, maxShape + 1):
             return
-        if isinstance(h5N5FileObject, z5py.N5File):
+        if isinstance(h5N5FileObject, (z5py.N5File, z5py.ZarrFile)):
             # make sure we get a path with forward slashes on windows
             objectName = pathlib.Path(objectName).as_posix()
         listOfDatasets.append({"name": objectName, "object": obj})

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -43,6 +43,7 @@ class PathComponents(object):
     HDF5_EXTS = [".ilp", ".h5", ".hdf5"]
     N5_EXTS = [".n5"]
     NPZ_EXTS = [".npz"]
+    ZARR_EXTS = [".zarr"]
 
     def __init__(self, totalPath, cwd=None):
         """
@@ -78,7 +79,7 @@ class PathComponents(object):
         totalPath = totalPath.replace("\\", "/")
 
         # For hdf5/n5 paths, split into external, extension, and internal paths
-        for x in self.HDF5_EXTS + self.NPZ_EXTS + self.N5_EXTS:
+        for x in self.HDF5_EXTS + self.NPZ_EXTS + self.N5_EXTS + self.ZARR_EXTS:
             if totalPath.find(x) > extIndex:
                 extIndex = totalPath.find(x)
                 ext = x
@@ -400,7 +401,7 @@ def globH5N5(fileObject, globString):
           matches occurred.
         - None if fileObject is not a h5 or n5 file object
     """
-    if isinstance(fileObject, (h5py.File, z5py.N5File)):
+    if isinstance(fileObject, (h5py.File, z5py.N5File, z5py.ZarrFile)):
         pathlist = [x["name"] for x in lsH5N5(fileObject)]
     else:
         return None


### PR DESCRIPTION
This is an archive PR to keep this implementation for reference, as a record of which bits of the code need to be touched (spoiler: way too many).

This is the simplest way to support loading OME-Zarr datasets via the "Add separate Image(s)" button. We already support the similar N5 format through `z5py`, and z5py also supports Zarr through an effectively identical interface. Analogous to N5, where the user has to choose the `attributes.json` file in the top-level folder of the dataset, this implementation allows the user to choose the `.zgroup` file in the top-level folder of the Zarr dataset.

There are problems we need to accept or solve if we want to implement Zarr support this way:

1. Main reason for shelving this for now: Files named starting with `.` are by default hidden on Mac and Linux. Very inconvenient for users, and in Zarr, all files are like this (`.zgroup`, `.zarray`, `.zattrs`). The only workaround would be to change the entire flow to a file-or-directory picker dialog.
2. After the user chooses the file/directory, they are then asked to choose a dataset (internal path) within it. The `datasetNames`, which we feed to the `SubvolumeSelectionDlg` and present to the user, currently have to be identical to the actual internal path, but in OME-Zarr, the internal path is typically just called `"0" ... "5"` or `"s0" ... "s5"`. To make an informed choice, we would need to display the internal path plus e.g. the shape of the dataset at that path. This change would be in `DataSelectionGui._get_dataset_full_path`, and requires refactoring or duplicating `DatasetInfo.getPossibleInternalPathsFor` to obtain display strings including dataset shape, or moving file handle logic into the Gui so that it can use `pathHelpers.lsH5N5`.
3. Dealing with the above point 2 becomes so ugly that I would rather refactor this path handling logic. It's currently spread/duplicated across DataSelectionGui, DatasetInfo classes (backend) and pathHelpers, but honestly I think it belongs into a dedicated class. Reason: DatasetInfo's main purpose is to deal with "accepted" datasets and act as a DTO between backend and frontend. PathHelpers are mainly for dealing with path shenanigans like globbing. The logic we are talking about here is about file introspection, which is a different kind of concern and involves dealing with file handles instead of paths. It's also frontend/user logic, so the class handling this should belong to the gui.
4. It's not really nice to have OME-Zarr feeding into two very different UX paths depending on which way you add the dataset. Through the "Add web dataset" pathway, the user gets the dataset with the combobox to select the scale, but through the "Add separate File(s)" pathway, they choose the internal path (=scale) and then the dataset is locked to this. We would instead want to detect when the user selected an OME-Zarr dataset and shunt it into the "web dataset" pathway by putting together the `file://...` url for the user.