### PR TITLE
Autocontext: Connect raw data directly in 2nd (or later) rounds

### DIFF
--- a/ilastik/applets/pixelClassification/opPixelClassification.py
+++ b/ilastik/applets/pixelClassification/opPixelClassification.py
@@ -71,6 +71,9 @@ class OpPixelClassification(Operator):
     PredictionMasks = InputSlot(
         level=1, optional=True
     )  # Routed to OpClassifierPredict.PredictionMask.  See there for details.
+    AutocontextInput = InputSlot(
+        level=1, optional=True
+    )  # Connected if in "autocontext mode", stacked input + preds from previous round - for display only
 
     LabelInputs = InputSlot(optional=True, level=1)  # Input for providing label data from an external source
 
@@ -435,7 +438,7 @@ class OpLabelPipeline(Operator):
             tagged_shape["t"] = 1
 
         # Aim for blocks that are roughly 20px
-        block_shape = determineBlockShape(list(tagged_shape.values()), 40 ** 3)
+        block_shape = determineBlockShape(list(tagged_shape.values()), 40**3)
         self.opLabelArray.blockShape.setValue(block_shape)
 
     def setInSlot(self, slot, subindex, roi, value):

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -169,9 +169,9 @@ class ClassifierSelectionDlg(QDialog):
             warnings.warn(f"Couldn't import sklearn. Scikit-learn classifiers not available. Error encountered at {e}")
 
         # Debug classifiers
-        classifiers[
-            "Parallel Random Forest with Variable Importance (VIGRA)"
-        ] = ParallelVigraRfLazyflowClassifierFactory(100, variable_importance_enabled=True)
+        classifiers["Parallel Random Forest with Variable Importance (VIGRA)"] = (
+            ParallelVigraRfLazyflowClassifierFactory(100, variable_importance_enabled=True)
+        )
         classifiers["(debug) Single-threaded Random Forest (VIGRA)"] = VigraRfLazyflowClassifierFactory(100)
         classifiers["(debug) Pixelwise Random Forest (VIGRA)"] = VigraRfPixelwiseClassifierFactory(100)
 
@@ -762,6 +762,13 @@ class PixelClassificationGui(LabelingGui):
                 ref_label.pmapColorChanged.connect(setLayerColor)
                 ref_label.nameChanged.connect(setPredLayerName)
                 layers.append(predictLayer)
+
+        if self.topLevelOperatorView.AutocontextInput.ready():
+            layer = self.createStandardLayerFromSlot(self.topLevelOperatorView.AutocontextInput)
+            layer.name = "Autocontext Input"
+            layer.visible = False
+            layers.append(layer)
+
         return layers
 
     def hasFeatures(self) -> bool:

--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -268,7 +268,7 @@ class NewAutocontextWorkflowBase(Workflow):
         downstreamFeatureApplets = self.featureSelectionApplets[1:]
         downstreamPcApplets = self.pcApplets[1:]
 
-        for (upstreamPcApplet, downstreamFeaturesApplet, downstreamPcApplet) in zip(
+        for upstreamPcApplet, downstreamFeaturesApplet, downstreamPcApplet in zip(
             upstreamPcApplets, downstreamFeatureApplets, downstreamPcApplets
         ):
 
@@ -292,7 +292,9 @@ class NewAutocontextWorkflowBase(Workflow):
             opStacker.AxisFlag.setValue("c")
 
             opDownstreamFeatures.InputImage.connect(opStacker.Output)
-            opDownstreamClassify.InputImages.connect(opStacker.Output)
+
+            opDownstreamClassify.InputImages.connect(opData.ImageGroup[self.DATA_ROLE_RAW])
+            opDownstreamClassify.AutocontextInput.connect(opStacker.Output)
             opDownstreamClassify.FeatureImages.connect(opDownstreamFeatures.OutputImage)
             opDownstreamClassify.CachedFeatureImages.connect(opDownstreamFeatures.CachedOutputImage)
 


### PR DESCRIPTION
Forgotten to push this...

This connects the raw data to the "overlay" layer in 2nd round of autocontext. This enables seeing the raw-data as is (all channels), as opposed to the raw data (that has preds stacked on top) and thus might not be interpreted correctly anymore.

Especially useful when viewing rgb like data.

fixes #2567 #2174  #1410
