### PR TITLE
Start QApplication with non-empty argv

### DIFF
--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -58,7 +58,7 @@ def startShellGui(workflow_cmdline_args, preinit_funcs, postinit_funcs):
     if ilastik.config.cfg.getboolean("ilastik", "debug"):
         QApplication.setAttribute(Qt.AA_DontUseNativeMenuBar, True)
 
-    app = QApplication([])
+    app = QApplication(["ilastik"])
     _applyStyleSheet(app)
 
     splash = getSplashScreen()


### PR DESCRIPTION
This will set WM_CLASS on X11 (hopefully wayland, too). abcdesktop had problems without it being set (clicking the task bar icon would resulted in new instances of ilastik spinning up instead of showing the current one).

fixes #2872 