### PR TITLE
Oc plugins via entrypoints

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -39,7 +39,7 @@ from functools import partial
 from ilastik.config import cfg as ilastik_config
 from ilastik.utility import bind
 from ilastik.utility.gui import ThreadRouter, threadRouted
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 from lazyflow.request import Request, RequestPool
 

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -38,7 +38,7 @@ from functools import partial
 from itertools import chain
 from ilastik.applets.objectExtraction.opObjectExtraction import max_margin
 
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 from ilastik.utility.gui import threadRouted
 from ilastik.utility import log_exception
 from ilastik.config import cfg as ilastik_config

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -42,11 +42,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# ilastik
-try:
-    from ilastik.plugins import pluginManager
-except:
-    logger.warning("could not import pluginManager")
+from ilastik.plugins.manager import pluginManager
+
 
 from ilastik.applets.base.applet import DatasetConstraintError
 

--- a/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
+++ b/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
@@ -25,7 +25,7 @@ import numpy
 from PyQt5 import uic
 from PyQt5.QtCore import Qt, QEvent
 from PyQt5.QtWidgets import QDialog, QFileDialog, QMessageBox
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 try:
     from lazyflow.graph import Operator, InputSlot, OutputSlot

--- a/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportApplet.py
@@ -30,7 +30,8 @@ from ilastik.applets.dataExport.dataExportApplet import DataExportApplet
 from ilastik.applets.dataExport.opDataExport import DataExportPathFormatter
 from ilastik.applets.dataExport.dataExportSerializer import DataExportSerializer
 from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBaseDataExport
-from ilastik.plugins import pluginManager, TrackingExportFormatPlugin
+from ilastik.plugins.manager import pluginManager
+from ilastik.plugins import TrackingExportFormatPlugin
 from ilastik.utility import OpMultiLaneWrapper
 from lazyflow.slot import InputSlot
 
@@ -271,7 +272,7 @@ class TrackingBaseDataExportApplet(DataExportApplet):
         return True
 
     def getPartiallyFormattedName(self, lane_index: int, path_format_string: str) -> str:
-        """ Takes the format string for the output file, fills in the most important placeholders, and returns it """
+        """Takes the format string for the output file, fills in the most important placeholders, and returns it"""
         path_formatter = DataExportPathFormatter(
             dataset_info=self.topLevelOperator.RawDatasetInfo[lane_index].value,
             working_dir=self.topLevelOperator.WorkingDirectory.value,

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -22,7 +22,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QPushButton, QVBoxLayout, QMessageBox
 from PyQt5.QtGui import QColor
 from ilastik.utility.exportingOperator import ExportingGui
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 from ilastik.applets.dataExport.dataExportGui import DataExportGui, DataExportLayerViewerGui
 from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBaseDataExport
 import volumina.colortables as colortables

--- a/ilastik/applets/tracking/conservation/conservationTrackingGui.py
+++ b/ilastik/applets/tracking/conservation/conservationTrackingGui.py
@@ -18,7 +18,7 @@ from ilastik.utility.gui.titledMenu import TitledMenu
 from ilastik.utility.ipcProtocol import Protocol
 from ilastik.shell.gui.ipcManager import IPCFacade
 from ilastik.config import cfg as ilastik_config
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 
 from lazyflow.request.request import Request

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -7,7 +7,8 @@ import numpy as np
 import os
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 
-from ilastik.plugins import PluginExportContext, TrackingExportFormatPlugin
+from ilastik.plugins import TrackingExportFormatPlugin
+from ilastik.plugins.manager import PluginExportContext
 from lazyflow.rtype import List
 from lazyflow.stype import Opaque
 

--- a/ilastik/plugins/__init__.py
+++ b/ilastik/plugins/__init__.py
@@ -1,0 +1,22 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from .types import ObjectFeaturesPlugin as ObjectFeaturesPlugin
+from .types import TrackingExportFormatPlugin as TrackingExportFormatPlugin

--- a/ilastik/plugins/manager.py
+++ b/ilastik/plugins/manager.py
@@ -1,0 +1,53 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+import os
+from collections import namedtuple
+
+from yapsy.PluginManager import PluginManager
+
+from ilastik.config import cfg
+
+from .types import ObjectFeaturesPlugin, TrackingExportFormatPlugin
+
+# these directories are searched for plugins
+plugin_paths = cfg.get("ilastik", "plugin_directories")
+plugin_paths = list(os.path.expanduser(d) for d in plugin_paths.split(",") if len(d) > 0)
+plugin_paths.append(os.path.join(os.path.split(__file__)[0], "plugins_default"))
+
+# Helper class used to pass the necessary context information to the export plugin
+PluginExportContext = namedtuple(
+    "PluginExportContext", ["objectFeaturesSlot", "labelImageSlot", "rawImageSlot", "additionalPluginArgumentsSlot"]
+)
+
+###############
+# the manager #
+###############
+
+pluginManager = PluginManager()
+pluginManager.setPluginPlaces(plugin_paths)
+
+pluginManager.setCategoriesFilter(
+    {"ObjectFeatures": ObjectFeaturesPlugin, "TrackingExportFormats": TrackingExportFormatPlugin}
+)
+
+pluginManager.collectPlugins()
+for pluginInfo in pluginManager.getAllPlugins():
+    pluginManager.activatePluginByName(pluginInfo.name)

--- a/ilastik/plugins/manager.py
+++ b/ilastik/plugins/manager.py
@@ -19,7 +19,13 @@
 #          http://ilastik.org/license.html
 ###############################################################################
 import os
+import sys
 from collections import namedtuple
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 from yapsy.PluginManager import PluginManager
 
@@ -30,7 +36,11 @@ from .types import ObjectFeaturesPlugin, TrackingExportFormatPlugin
 # these directories are searched for plugins
 plugin_paths = cfg.get("ilastik", "plugin_directories")
 plugin_paths = list(os.path.expanduser(d) for d in plugin_paths.split(",") if len(d) > 0)
-plugin_paths.append(os.path.join(os.path.split(__file__)[0], "plugins_default"))
+plugin_paths.append(os.path.join(os.path.split(os.path.split(__file__)[0])[0], "plugins_default"))
+
+# Add directories from registered entrypoints
+for ep in entry_points(group="ilastik.objectfeatures"):
+    plugin_paths.append(os.path.split(ep.load().__file__)[0])
 
 # Helper class used to pass the necessary context information to the export plugin
 PluginExportContext = namedtuple(

--- a/ilastik/plugins/types.py
+++ b/ilastik/plugins/types.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -18,21 +18,8 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
-from ilastik.config import cfg
-
-from yapsy.IPlugin import IPlugin
-from yapsy.PluginManager import PluginManager
-
-import os
-from collections import namedtuple
-from functools import partial
 import numpy
-
-# these directories are searched for plugins
-plugin_paths = cfg.get("ilastik", "plugin_directories")
-plugin_paths = list(os.path.expanduser(d) for d in plugin_paths.split(",") if len(d) > 0)
-plugin_paths.append(os.path.join(os.path.split(__file__)[0], "plugins_default"))
+from yapsy.IPlugin import IPlugin
 
 ##########################
 # different plugin types #
@@ -65,7 +52,6 @@ class ObjectFeaturesPlugin(IPlugin):
         return []
 
     def compute_global(self, image, labels, features, axes):
-
         """calculate the requested features.
 
         :param image: np.ndarray
@@ -158,7 +144,7 @@ class TrackingExportFormatPlugin(IPlugin):
         super(TrackingExportFormatPlugin, self).__init__(*args, **kwargs)
 
     def checkFilesExist(self, filename: str) -> bool:
-        """ Check whether the files we want to export (when appending the base filename) are already present """
+        """Check whether the files we want to export (when appending the base filename) are already present"""
         return False
 
     def export(self, filename, hypothesesGraph, pluginExportContext):
@@ -206,24 +192,3 @@ class TrackingExportFormatPlugin(IPlugin):
             long_name = name
 
         return long_name
-
-
-# Helper class used to pass the necessary context information to the export plugin
-PluginExportContext = namedtuple(
-    "PluginExportContext", ["objectFeaturesSlot", "labelImageSlot", "rawImageSlot", "additionalPluginArgumentsSlot"]
-)
-
-###############
-# the manager #
-###############
-
-pluginManager = PluginManager()
-pluginManager.setPluginPlaces(plugin_paths)
-
-pluginManager.setCategoriesFilter(
-    {"ObjectFeatures": ObjectFeaturesPlugin, "TrackingExportFormats": TrackingExportFormatPlugin}
-)
-
-pluginManager.collectPlugins()
-for pluginInfo in pluginManager.getAllPlugins():
-    pluginManager.activatePluginByName(pluginInfo.name)

--- a/ilastik/plugins/types.py
+++ b/ilastik/plugins/types.py
@@ -176,6 +176,8 @@ class TrackingExportFormatPlugin(IPlugin):
         :param name: The feature name string
         :returns: the long name of the feature
         """
+        from ilastik.plugins.manager import pluginManager
+
         all_props = None
 
         if category == "Default features":

--- a/ilastik/utility/exportFile.py
+++ b/ilastik/utility/exportFile.py
@@ -13,10 +13,8 @@ from typing import Iterator, List, Tuple
 
 
 logger = logging.getLogger(__name__)
-try:
-    from ilastik.plugins import pluginManager
-except:
-    logger.warning("could not import pluginManager")
+
+from ilastik.plugins.manager import pluginManager
 
 
 class Default(object):

--- a/ilastik/workflows/counting/__init__.py
+++ b/ilastik/workflows/counting/__init__.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 import logging
 
 logger = logging.getLogger(__name__)
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 try:
     from .countingWorkflow import *

--- a/ilastik/workflows/objectClassification/__init__.py
+++ b/ilastik/workflows/objectClassification/__init__.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 # 		   http://ilastik.org/license.html
 ###############################################################################
 # to ensure that plugin system is available
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 import logging
 

--- a/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/conservation/conservationTrackingWorkflow.py
@@ -14,7 +14,7 @@ from lazyflow.operators.opReorderAxes import OpReorderAxes
 from ilastik.applets.tracking.base.trackingBaseDataExportApplet import TrackingBaseDataExportApplet
 from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBaseDataExport
 from ilastik.applets.batchProcessing import BatchProcessingApplet
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 from ilastik.config import cfg as ilastik_config
 from ilastik.workflows.tracking.common import DIVISION_CLASSIFIER_LABEL_NAMES
 import logging

--- a/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
+++ b/ilastik/workflows/tracking/structured/structuredTrackingWorkflow.py
@@ -39,7 +39,7 @@ from ilastik.applets.tracking.base.trackingBaseDataExportApplet import TrackingB
 from ilastik.applets.trackingFeatureExtraction.trackingFeatureExtractionApplet import TrackingFeatureExtractionApplet
 from ilastik.applets.tracking.base.opTrackingBaseDataExport import OpTrackingBaseDataExport
 from ilastik.applets.batchProcessing import BatchProcessingApplet
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 from ilastik.workflows.tracking.common import DIVISION_CLASSIFIER_LABEL_NAMES
 
 import logging

--- a/tests/test_ilastik/test_applets/objectExtraction/testOperators.py
+++ b/tests/test_ilastik/test_applets/objectExtraction/testOperators.py
@@ -29,7 +29,7 @@ import vigra
 from lazyflow.graph import Graph
 from lazyflow.operators import OpLabelVolume
 from ilastik.applets.objectExtraction.opObjectExtraction import OpAdaptTimeListRoi, OpRegionFeatures, OpObjectExtraction
-from ilastik.plugins import pluginManager
+from ilastik.plugins.manager import pluginManager
 
 import warnings
 


### PR DESCRIPTION
ilastik object features can be added via a (`yapsy`-based) plugin system. The usual way would be to put them into the user plugins folder. However, some plugins will have requirements wrt dependencies. In order to better track those, they should be added as conda package, configured with the appropriate dependencies. This will enable us to include them in the distribution, along with all necessary dependencies.


- [x] add example plugin
- [x] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests.
- n/a Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.

CC: @oanegros 