### PR TITLE
Fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       TEST_ENV_NAME: test-env
       VOLUMINA_SHOW_3D_WIDGET: 0
     docker:
-    - image: condaforge/mambaforge
+    - image: condaforge/miniforge3
     steps:
     - restore_cache:
         name: restoring dependency cache
@@ -57,8 +57,8 @@ jobs:
         # due to an incompatibility of mamba with conda 4.13, one currently cannot update conda first
         command: >
             conda config --set always_yes yes --set changeps1 no --set channel_priority strict &&
-            mamba update -n base -c conda-forge --all &&
-            mamba install -n base -c conda-forge conda-build boa
+            conda update -n base -c conda-forge --all &&
+            conda install -n base -c conda-forge conda-build boa
     - run:
         name: install apt dependencies
         command: >
@@ -68,16 +68,16 @@ jobs:
         name: create ilastik conda environment
         command: >
             cd ${ILASTIK_ROOT}/ilastik-meta &&
-            mamba env create --name ${TEST_ENV_NAME} --file ilastik/dev/environment-dev.yml &&
-            mamba install --name ${TEST_ENV_NAME} --freeze-installed -c ilastik-forge -c conda-forge mpi4py pytest-cov volumina &&
-            mamba run -n ${TEST_ENV_NAME} pip install -e ilastik
+            conda env create --name ${TEST_ENV_NAME} --file ilastik/dev/environment-dev.yml &&
+            conda install --name ${TEST_ENV_NAME} --freeze-installed -c ilastik-forge -c conda-forge mpi4py pytest-cov volumina &&
+            conda run -n ${TEST_ENV_NAME} pip install -e ilastik
 
     - run:
         name: run ilastik tests
         command: >
             cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
             mkdir test-results &&
-            xvfb-run --server-args="-screen 0 1024x768x24" mamba run -n ${TEST_ENV_NAME} pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
+            xvfb-run --server-args="-screen 0 1024x768x24" conda run -n ${TEST_ENV_NAME} pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
             bash <(curl -s https://codecov.io/bash)
     - store_test_results:
         path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,21 @@ jobs:
             conda run -n ${TEST_ENV_NAME} pip install -e ilastik
 
     - run:
+        name: start xvfb
+        command: >
+          Xvfb :42 -screen 0 1024x768x24
+        background: true
+    - run:
+        name: wait for xvfb to be ready
+        command: while [ ! -e /tmp/.X11-unix/X42 ]; do sleep 0.1; done
+    - run:
         name: run ilastik tests
+        environment:
+            DISPLAY: :42
         command: >
             cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
             mkdir test-results &&
-            echo "before tests" &&
-            xvfb-run --server-args="-screen 0 1024x768x24" conda run -n ${TEST_ENV_NAME} pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
-            echo "after tests" &&
+            conda run -n ${TEST_ENV_NAME} pytest -v --run-legacy-gui --cov-report=xml --cov=lazyflow --cov=ilastik --junitxml=test-results/junit.xml &&
             bash <(curl -s https://codecov.io/bash)
     - store_test_results:
         path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ jobs:
         name: restoring dependency cache
         keys:
         # This branch if available
-        - v1.4.14-dep-{{ .Branch }}-{{ epoch }}
+        - v1.4.15-dep-{{ .Branch }}-{{ epoch }}
         # Default branch if not
-        - v1.4.14-dep-main-
+        - v1.4.15-dep-main-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1.4.14-dep-
+        - v1.4.15-dep-
     - restore_cache:
         name: restore ilastik-repo cache
         key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
@@ -77,13 +77,15 @@ jobs:
         command: >
             cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
             mkdir test-results &&
+            echo "before tests" &&
             xvfb-run --server-args="-screen 0 1024x768x24" conda run -n ${TEST_ENV_NAME} pytest --cov-report=xml --cov=lazyflow --cov=ilastik --run-legacy-gui --junitxml=test-results/junit.xml &&
+            echo "after tests" &&
             bash <(curl -s https://codecov.io/bash)
     - store_test_results:
         path: test-results
     - save_cache:
         name: store dependency cache
-        key: v1.4.14-dep-{{ .Branch }}-{{ epoch }}
+        key: v1.4.15-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - /opt/conda/pkgs
 


### PR DESCRIPTION
CircleCI tests started hanging. Root cause could not be determined, but something must have changed that made `xvfb-run` hang. Switched to starting Xvfb manually now and waiting until it's ready in hopes of more reliable runs in the future.

- [x] check what's up with coverage, why 10% less suddenly?! --> accidentally removed UI tests :)