### PR TITLE
Easier problem reporting

### DIFF
--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -33,7 +33,6 @@ from ilastik.config import cfg as ilastik_config, runtime_cfg
 from ilastik.utility.commandLineProcessing import OptionalFlagAction
 
 logger = logging.getLogger(__name__)
-STARTUP_MARKER = "[Startup]"  # Used to identify the startup message in the log file
 
 
 def _argparser() -> argparse.ArgumentParser:
@@ -181,9 +180,9 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     _init_excepthooks(parsed_args)
 
     if ilastik_config.getboolean("ilastik", "debug"):
-        message = f"{STARTUP_MARKER} Starting ilastik in debug mode from {ilastik_dir}"
+        message = f"Starting ilastik in debug mode from {ilastik_dir}"
     else:
-        message = f"{STARTUP_MARKER} Starting ilastik from {ilastik_dir}"
+        message = f"Starting ilastik from {ilastik_dir}"
     logger.info(message)
     print(message)  # always print the startup message
 

--- a/ilastik/app.py
+++ b/ilastik/app.py
@@ -33,6 +33,7 @@ from ilastik.config import cfg as ilastik_config, runtime_cfg
 from ilastik.utility.commandLineProcessing import OptionalFlagAction
 
 logger = logging.getLogger(__name__)
+STARTUP_MARKER = "[Startup]"  # Used to identify the startup message in the log file
 
 
 def _argparser() -> argparse.ArgumentParser:
@@ -180,13 +181,11 @@ def main(parsed_args, workflow_cmdline_args=[], init_logging=True):
     _init_excepthooks(parsed_args)
 
     if ilastik_config.getboolean("ilastik", "debug"):
-        message = 'Starting ilastik in debug mode from "%s".' % ilastik_dir
-        logger.info(message)
-        print(message)  # always print the startup message
+        message = f"{STARTUP_MARKER} Starting ilastik in debug mode from {ilastik_dir}"
     else:
-        message = 'Starting ilastik from "%s".' % ilastik_dir
-        logger.info(message)
-        print(message)  # always print the startup message
+        message = f"{STARTUP_MARKER} Starting ilastik from {ilastik_dir}"
+    logger.info(message)
+    print(message)  # always print the startup message
 
     # Headless launch
     if parsed_args.headless:
@@ -366,7 +365,7 @@ def _prepare_lazyflow_config(parsed_args):
                         f"limited to {total_ram_mb} MB. Remember "
                         "to specify RAM in MB, not GB."
                     )
-                ram = total_ram_mb * 1024 ** 2
+                ram = total_ram_mb * 1024**2
                 fmt = Memory.format(ram)
                 logger.info("Configuring lazyflow RAM limit to {}".format(fmt))
                 Memory.setAvailableRam(ram)

--- a/ilastik/ilastik_logging/__init__.py
+++ b/ilastik/ilastik_logging/__init__.py
@@ -21,5 +21,5 @@ from __future__ import absolute_import
 # 		   http://ilastik.org/license.html
 ###############################################################################
 from . import default_config
-from .default_config import DEFAULT_LOGFILE_PATH, get_logfile_path
+from .default_config import DEFAULT_LOGFILE_PATH, get_logfile_path, get_session_logfile_path
 from .loggingHelpers import updateFromConfigFile, startUpdateInterval, stopUpdates

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -20,21 +20,27 @@
 ###############################################################################
 
 import os
+import re
 import logging.config
 import warnings
 from datetime import datetime
 from typing import Optional
+from pathlib import Path
 
 import appdirs
 from . import loggingHelpers
 from ilastik.config import cfg as ilastik_config
 
 SESSION_FILEHANDLER_NAME = "session_file"
+SESSION_LOGFILE_NAME = "log_%Y%m%d_%H%M%S.txt"
+SESSION_LOGFILE_NAME_PATTERN = r"log_\d{8}_\d{6}\.txt"  # For deleting old ones, must correspond to _NAME
 SESSION_LOGFILE_PATH = os.path.join(
-    appdirs.user_log_dir(appname="ilastik", appauthor=False), datetime.now().strftime("log_%Y%m%d_%H%M%S.txt")
+    appdirs.user_log_dir(appname="ilastik", appauthor=False), datetime.now().strftime(SESSION_LOGFILE_NAME)
 )
+KEEP_SESSION_LOGS = 10
 DEFAULT_FILEHANDLER_NAME = "rotating_file"
-DEFAULT_LOGFILE_PATH = os.path.join(appdirs.user_log_dir(appname="ilastik", appauthor=False), "log.txt")
+DEFAULT_LOG_NAME = "log.txt"
+DEFAULT_LOGFILE_PATH = os.path.join(appdirs.user_log_dir(appname="ilastik", appauthor=False), DEFAULT_LOG_NAME)
 
 
 class OutputMode(object):
@@ -61,6 +67,16 @@ def get_session_logfile_path() -> Optional[str]:
         if isinstance(handler, logging.FileHandler) and handler.name == SESSION_FILEHANDLER_NAME:
             return handler.baseFilename
     return None
+
+
+def _delete_old_session_logs(logfile_path: str):
+    """Delete all but the last KEEP_SESSION_LOGS log files."""
+    log_dir = Path(logfile_path).parent
+    if not log_dir.exists():
+        return
+    log_files = sorted([f for f in os.listdir(log_dir) if re.match(SESSION_LOGFILE_NAME_PATTERN, f)], reverse=True)
+    for log_file in log_files[KEEP_SESSION_LOGS:]:
+        os.remove(str(log_dir / log_file))
 
 
 def get_default_config(
@@ -196,6 +212,7 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
 
     if output_mode != OutputMode.CONSOLE:
         os.makedirs(os.path.dirname(logfile_path), exist_ok=True)
+        _delete_old_session_logs(logfile_path)
 
     # Preserve pre-existing handlers
     original_root_handlers = list(logging.getLogger().handlers)

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -195,7 +195,7 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
         output_mode = OutputMode.CONSOLE
 
     if output_mode != OutputMode.CONSOLE:
-        os.makedirs(os.path.dirname(DEFAULT_LOGFILE_PATH), exist_ok=True)
+        os.makedirs(os.path.dirname(logfile_path), exist_ok=True)
 
     # Preserve pre-existing handlers
     original_root_handlers = list(logging.getLogger().handlers)

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -160,8 +160,8 @@ def get_default_config(
                 "level": "DEBUG",
                 "class": "logging.handlers.RotatingFileHandler",
                 "filename": SESSION_LOGFILE_PATH,
-                "maxBytes": 50e6,  # 20 MB
-                "backupCount": 5,
+                "maxBytes": 1048576,  # 1 MiB
+                "backupCount": 1,
                 "formatter": "verbose",
                 "encoding": "utf-8",
             },

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -91,6 +91,7 @@ from ilastik.shell.headless.headlessShell import HeadlessShell
 
 from ilastik.shell.gui.aboutDialog import AboutDialog
 from ilastik.shell.gui.licenseDialog import LicenseDialog
+from ilastik.shell.gui.reportIssueDialog import ReportIssueDialog
 
 from ilastik.widgets.appletDrawerToolBox import AppletDrawerToolBox, AppletBarManager
 from ilastik.widgets.filePathButton import FilePathButton
@@ -750,25 +751,14 @@ class IlastikShell(QMainWindow):
         self.openProjectFile(path)
 
     def _createHelpMenu(self):
-        def _sendEmailToDevs():
-            body = (
-                "Please describe the issue you are experiencing and adapt the email subject.\n"
-                "A file browser should have opened at the location of the ilastik log file. "
-                "Please attach this file to the email.\n"
-                "If you are able to reproduce the issue, even better would be if you close ilastik, "
-                "delete the log file, restart ilastik, repeat the error, and then attach the new log file."
-                "\n\n--\nAdditional diagnostics (please include this in your email):\n"
-                f"ilastik version: {ilastik.__version__}\n"
-                f"OS: {platform.platform()}\n"
-            )
+        def _openReportIssueDialog():
+            workflow_text = ""
             if self.workflow:
-                body += (
+                workflow_text = (
                     f"Active workflow: {self.workflow.workflowName}\n"
-                    f"Active applet: ({self.workflow.applets[self.currentAppletIndex].name})"
+                    f"Active applet: {self.workflow.applets[self.currentAppletIndex].name}\n"
                 )
-            subject = "ilastik issue report"
-            QDesktopServices.openUrl(QUrl(f"mailto:team@ilastik.org?subject={subject}&body={body}"))
-            open_file_browser(ilastik.ilastik_logging.default_config.get_logfile_path())
+            ReportIssueDialog(self, workflow_text)
 
         menu = QMenu("&Help", self)
         menu.setObjectName("help_menu")
@@ -778,8 +768,8 @@ class IlastikShell(QMainWindow):
         readTheDocsAction.triggered.connect(
             partial(QDesktopServices.openUrl, QUrl("https://ilastik.org/documentation/"))
         )
-        emailDevsAction = menu.addAction("&Report issue by email")
-        emailDevsAction.triggered.connect(_sendEmailToDevs)
+        emailDevsAction = menu.addAction("&Report issue")
+        emailDevsAction.triggered.connect(_openReportIssueDialog)
         licenseAction = menu.addAction("License")
         licenseAction.triggered.connect(partial(LicenseDialog, self))
         return menu

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -750,14 +750,36 @@ class IlastikShell(QMainWindow):
         self.openProjectFile(path)
 
     def _createHelpMenu(self):
+        def _sendEmailToDevs():
+            body = (
+                "Please describe the issue you are experiencing and adapt the email subject.\n"
+                "A file browser should have opened at the location of the ilastik log file. "
+                "Please attach this file to the email.\n"
+                "If you are able to reproduce the issue, even better would be if you close ilastik, "
+                "delete the log file, restart ilastik, repeat the error, and then attach the new log file."
+                "\n\n--\nAdditional diagnostics (please include this in your email):\n"
+                f"ilastik version: {ilastik.__version__}\n"
+                f"OS: {platform.platform()}\n"
+            )
+            if self.workflow:
+                body += (
+                    f"Active workflow: {self.workflow.workflowName}\n"
+                    f"Active applet: ({self.workflow.applets[self.currentAppletIndex].name})"
+                )
+            subject = "ilastik issue report"
+            QDesktopServices.openUrl(QUrl(f"mailto:team@ilastik.org?subject={subject}&body={body}"))
+            open_file_browser(ilastik.ilastik_logging.default_config.get_logfile_path())
+
         menu = QMenu("&Help", self)
         menu.setObjectName("help_menu")
         aboutIlastikAction = menu.addAction("&About ilastik")
         aboutIlastikAction.triggered.connect(partial(AboutDialog.createAndShowModal, self))
         readTheDocsAction = menu.addAction("&Documentation")
         readTheDocsAction.triggered.connect(
-            partial(QDesktopServices.openUrl, QUrl("http://ilastik.org/documentation/"))
+            partial(QDesktopServices.openUrl, QUrl("https://ilastik.org/documentation/"))
         )
+        emailDevsAction = menu.addAction("&Report issue by email")
+        emailDevsAction.triggered.connect(_sendEmailToDevs)
         licenseAction = menu.addAction("License")
         licenseAction.triggered.connect(partial(LicenseDialog, self))
         return menu

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -758,7 +758,7 @@ class IlastikShell(QMainWindow):
                     f"Active workflow: {self.workflow.workflowName}\n"
                     f"Active applet: {self.workflow.applets[self.currentAppletIndex].name}\n"
                 )
-            ReportIssueDialog(self, workflow_text)
+            ReportIssueDialog.createAndShowModal(self, workflow_text)
 
         menu = QMenu("&Help", self)
         menu.setObjectName("help_menu")

--- a/ilastik/shell/gui/reportIssueDialog.py
+++ b/ilastik/shell/gui/reportIssueDialog.py
@@ -1,0 +1,94 @@
+import os
+
+import ilastik
+import platform
+import sys
+import webbrowser
+from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QTextEdit, QPushButton, QHBoxLayout, QSizePolicy
+from urllib.parse import quote
+
+
+def _get_log_since_last_startup() -> str:
+    """
+    Reads the log up to maximum 1 MB from the end and returns the text since the last startup, or the entire 1 MB.
+    We don't want people emailing us more than 1MB of log...
+    """
+    log_path = ilastik.ilastik_logging.default_config.get_logfile_path()
+    marker = b"Starting ilastik"
+    text_size_limit = 1048576  # 1 MB
+    file_size = int(os.path.getsize(log_path))
+    with open(log_path, "rb") as log_file:
+        position = max(0, file_size - text_size_limit)
+        log_file.seek(position)
+        log_text = log_file.read()
+    if marker in log_text:
+        return b"".join(log_text.rpartition(marker)[1:]).decode()
+    else:
+        return log_text.decode()
+
+
+class ReportIssueDialog(QDialog):
+    def __init__(self, parent=None, workflow_report_text=""):
+        super().__init__(parent=parent)
+
+        self.setWindowTitle("Report issue")
+        self.setFixedSize(600, 300)
+
+        main_layout = QVBoxLayout()
+
+        # Create and add the instruction label
+        instruction_label = QLabel()
+        instruction_label.setText(
+            "<p>Sorry you ran into a problem! Please copy the information below, and include it when you "
+            "report your issue.</p>"
+            '<p>The best place to get help is the community forum, using the "ilastik" tag '
+            '(<a href="https://forum.image.sc/tag/ilastik">https://forum.image.sc/tag/ilastik</a>).<br>'
+            "Alternatively, you can report the issue on GitHub ("
+            '<a href="https://github.com/ilastik/ilastik/issues/">https://github.com/ilastik/ilastik/issues/</a>'
+            ') or email us at <a href="mailto:team@ilastik.org">team@ilastik.org</a>.</p>'
+        )
+        instruction_label.setOpenExternalLinks(True)
+        instruction_label.setWordWrap(True)
+        main_layout.addWidget(instruction_label)
+
+        report = (
+            f"ilastik version: {ilastik.__version__}\n"
+            f"OS: {platform.platform()}\n"
+            f"{workflow_report_text}"
+            "Log since last startup:\n"
+            f"```\n{_get_log_since_last_startup()}\n```"
+        )
+        self.report_text = QTextEdit()
+        self.report_text.setPlainText(report)
+        self.report_text.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Minimum)
+        main_layout.addWidget(self.report_text)
+
+        button_layout = QHBoxLayout()
+        copy_button = QPushButton("Copy to Clipboard")
+        copy_button.clicked.connect(self.copy_to_clipboard)
+        button_layout.addWidget(copy_button)
+        email_button = QPushButton("Open in Email App")
+        email_button.clicked.connect(self.open_in_email_app)
+        button_layout.addWidget(email_button)
+        close_button = QPushButton("Close")
+        close_button.clicked.connect(self.close)
+        button_layout.addWidget(close_button)
+        main_layout.addLayout(button_layout)
+
+        # Set the layout to the dialog
+        self.setLayout(main_layout)
+        self.show()
+
+    def copy_to_clipboard(self):
+        clipboard = QApplication.clipboard()
+        clipboard.setText(self.report_text.toPlainText())
+
+    def open_in_email_app(self):
+        body = (
+            "Please describe the issue you are experiencing and adapt the email subject.\n"
+            "\n\n--\nAuto-generated report:\n"
+        )
+        body += self.report_text.toPlainText()
+        subject = "ilastik issue report"
+        mailto_url = f"mailto:team@ilastik.org?subject={subject}&body={quote(body)}"
+        webbrowser.open(mailto_url)

--- a/ilastik/shell/gui/reportIssueDialog.py
+++ b/ilastik/shell/gui/reportIssueDialog.py
@@ -1,30 +1,32 @@
 import os
-
-import ilastik
 import platform
-import sys
 import webbrowser
+from ilastik import __version__ as ilastik_version
+from ilastik import ilastik_logging
+from ilastik.app import STARTUP_MARKER
 from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout, QLabel, QTextEdit, QPushButton, QHBoxLayout, QSizePolicy
 from urllib.parse import quote
+
+FORUM_URI = "https://forum.image.sc/tag/ilastik"
+TEAM_EMAIL = "team@ilastik.org"
 
 
 def _get_log_since_last_startup() -> str:
     """
-    Reads the log up to maximum 1 MB from the end and returns the text since the last startup, or the entire 1 MB.
+    Reads the log up to maximum 500 KiB from the end and returns the text since the last startup, or the entire 500 KiB.
     We don't want people emailing us more than 1MB of log...
     """
-    log_path = ilastik.ilastik_logging.default_config.get_logfile_path()
-    marker = b"Starting ilastik"
-    text_size_limit = 1048576  # 1 MB
+    log_path = ilastik_logging.default_config.get_logfile_path()
+    text_size_limit = 524288  # 500 KiB
+    pre_marker_padding = 1024
     file_size = int(os.path.getsize(log_path))
     with open(log_path, "rb") as log_file:
         position = max(0, file_size - text_size_limit)
         log_file.seek(position)
-        log_text = log_file.read()
-    if marker in log_text:
-        return b"".join(log_text.rpartition(marker)[1:]).decode()
-    else:
-        return log_text.decode()
+        log_text = log_file.read().decode()
+    # Go back a bit further than the marker to catch pre-startup log messages
+    before_marker = max(0, log_text.rfind(STARTUP_MARKER) - pre_marker_padding)
+    return log_text[before_marker:]
 
 
 class ReportIssueDialog(QDialog):
@@ -39,23 +41,21 @@ class ReportIssueDialog(QDialog):
         # Create and add the instruction label
         instruction_label = QLabel()
         instruction_label.setText(
-            "<p>Sorry you ran into a problem! Please copy the information below, and include it when you "
-            "report your issue.</p>"
-            '<p>The best place to get help is the community forum, using the "ilastik" tag '
-            '(<a href="https://forum.image.sc/tag/ilastik">https://forum.image.sc/tag/ilastik</a>).<br>'
-            "Alternatively, you can report the issue on GitHub ("
-            '<a href="https://github.com/ilastik/ilastik/issues/">https://github.com/ilastik/ilastik/issues/</a>'
-            ') or email us at <a href="mailto:team@ilastik.org">team@ilastik.org</a>.</p>'
+            "<p>Sorry you ran into a problem! Please include the information below when you report your issue.</p>"
+            f'<p>The best place to get help is the <a href="{FORUM_URI}">community forum</a>. '
+            "Most posts get responses very quickly there, and others can benefit from the advice you receive!</p>"
+            f'<p>Alternatively, you can email us at <a href="mailto:{TEAM_EMAIL}">{TEAM_EMAIL}</a>. '
+            "We'll do our best to get back to you quickly.</p>"
         )
         instruction_label.setOpenExternalLinks(True)
         instruction_label.setWordWrap(True)
         main_layout.addWidget(instruction_label)
 
         report = (
-            f"ilastik version: {ilastik.__version__}\n"
+            f"ilastik version: {ilastik_version}\n"
             f"OS: {platform.platform()}\n"
             f"{workflow_report_text}"
-            "Log since last startup:\n"
+            "Log since last startup (please shorten to relevant parts if this seems very long):\n"
             f"```\n{_get_log_since_last_startup()}\n```"
         )
         self.report_text = QTextEdit()
@@ -64,10 +64,10 @@ class ReportIssueDialog(QDialog):
         main_layout.addWidget(self.report_text)
 
         button_layout = QHBoxLayout()
-        copy_button = QPushButton("Copy to Clipboard")
-        copy_button.clicked.connect(self.copy_to_clipboard)
+        copy_button = QPushButton("Copy and open forum")
+        copy_button.clicked.connect(self.copy_and_go_to_forum)
         button_layout.addWidget(copy_button)
-        email_button = QPushButton("Open in Email App")
+        email_button = QPushButton("Open in email app")
         email_button.clicked.connect(self.open_in_email_app)
         button_layout.addWidget(email_button)
         close_button = QPushButton("Close")
@@ -79,16 +79,17 @@ class ReportIssueDialog(QDialog):
         self.setLayout(main_layout)
         self.show()
 
-    def copy_to_clipboard(self):
+    def copy_and_go_to_forum(self):
         clipboard = QApplication.clipboard()
         clipboard.setText(self.report_text.toPlainText())
+        webbrowser.open(FORUM_URI)
 
     def open_in_email_app(self):
+        subject = "[Bugreport] --Summarise your issue here--"
         body = (
             "Please describe the issue you are experiencing and adapt the email subject.\n"
             "\n\n--\nAuto-generated report:\n"
         )
         body += self.report_text.toPlainText()
-        subject = "ilastik issue report"
-        mailto_url = f"mailto:team@ilastik.org?subject={subject}&body={quote(body)}"
+        mailto_url = f"mailto:{TEAM_EMAIL}?subject={subject}&body={quote(body)}"
         webbrowser.open(mailto_url)

--- a/ilastik/shell/gui/reportIssueDialog.py
+++ b/ilastik/shell/gui/reportIssueDialog.py
@@ -42,7 +42,11 @@ def _get_current_session_log_or_hint() -> str:
     with open(log_path, "r") as log_file:
         log_text = log_file.read()
     if len(log_text) > LOG_LENGTH_THRESHOLD:
-        return 'Session log is too long to include here. Please use the "Open log folder" button to locate the log.'
+        return (
+            "Session log is too long to include here. "
+            'Please use the "Open log folder" button to locate the log file '
+            "and attach it to your forum thread or email."
+        )
     return log_text
 
 
@@ -102,7 +106,6 @@ class ReportIssueDialog(QDialog):
 
         # Set the layout to the dialog
         self.setLayout(main_layout)
-        self.show()
 
     def copy_and_go_to_forum(self):
         clipboard = QApplication.clipboard()
@@ -116,5 +119,10 @@ class ReportIssueDialog(QDialog):
             "\n\n--\nAuto-generated report:\n"
         )
         body += self.report_text.toPlainText()
-        mailto_url = f"mailto:{TEAM_EMAIL}?subject={subject}&body={quote(body)}"
+        mailto_url = f"mailto:{TEAM_EMAIL}?subject={quote(subject)}&body={quote(body)}"
         webbrowser.open(mailto_url)
+
+    @classmethod
+    def createAndShowModal(cls, parent=None, workflow_report_text=""):
+        dialog = cls(parent=parent, workflow_report_text=workflow_report_text)
+        dialog.exec()

--- a/tests/test_ilastik/test_logging/test_default_config.py
+++ b/tests/test_ilastik/test_logging/test_default_config.py
@@ -1,0 +1,36 @@
+import pytest
+import re
+
+from ilastik.ilastik_logging.default_config import (
+    _delete_old_session_logs,
+    SESSION_LOGFILE_NAME_PATTERN,
+    KEEP_SESSION_LOGS,
+    DEFAULT_LOG_NAME,
+)
+from pathlib import Path
+from typing import List
+
+
+@pytest.fixture
+def session_logs(tmp_path) -> List[Path]:
+    def create_log_file(i: int) -> Path:
+        file_path = tmp_path / f"log_{i:08}_{i:06}.txt"
+        assert re.match(SESSION_LOGFILE_NAME_PATTERN, file_path.name)
+        file_path.touch()
+        return file_path
+
+    n_files = KEEP_SESSION_LOGS + 3
+    paths = [create_log_file(i) for i in range(n_files)]
+    return paths
+
+
+def test_delete_old_session_logs(tmp_path, session_logs):
+    default_log = tmp_path / DEFAULT_LOG_NAME
+    non_log_file = tmp_path / "not_a_logfile.png"
+    default_log.touch()
+    non_log_file.touch()
+    expected_remaining_files = sorted(session_logs[-KEEP_SESSION_LOGS:] + [default_log, non_log_file])
+
+    _delete_old_session_logs(log_dir=tmp_path)
+    remaining_files = sorted(tmp_path.iterdir())
+    assert remaining_files == expected_remaining_files

--- a/tests/test_ilastik/test_shell/test_report_issue_dialog.py
+++ b/tests/test_ilastik/test_shell/test_report_issue_dialog.py
@@ -1,6 +1,8 @@
+from unittest import mock
+
 import pytest
 
-from ilastik.shell.gui.reportIssueDialog import _mask_file_paths, FILE_PATH_MASK
+from ilastik.shell.gui.reportIssueDialog import _mask_file_paths, FILE_PATH_MASK, ReportIssueDialog, FORUM_URI
 
 
 @pytest.mark.parametrize(
@@ -25,3 +27,34 @@ from ilastik.shell.gui.reportIssueDialog import _mask_file_paths, FILE_PATH_MASK
 )
 def test_mask_file_paths(input_log, masked_log):
     assert _mask_file_paths(input_log) == masked_log
+
+
+@pytest.fixture
+def dialog(qtbot):
+    dlg = ReportIssueDialog()
+    dlg.show()
+    qtbot.addWidget(dlg)
+    qtbot.waitExposed(dlg)
+    return dlg
+
+
+@pytest.fixture
+def mock_webbrowser(monkeypatch):
+    patch = mock.Mock()
+    monkeypatch.setattr("webbrowser.open", patch)
+    return patch
+
+
+def test_dialog_runs(dialog):
+    assert dialog.isVisible()
+
+
+def test_link_to_forum(dialog, mock_webbrowser):
+    dialog.copy_and_go_to_forum()
+    mock_webbrowser.assert_called_once_with(FORUM_URI)
+
+
+def test_link_to_mail(dialog, mock_webbrowser):
+    dialog.open_in_email_app()
+    mock_webbrowser.assert_called_once()
+    assert mock_webbrowser.call_args.args[0].startswith("mailto:")

--- a/tests/test_ilastik/test_shell/test_report_issue_dialog.py
+++ b/tests/test_ilastik/test_shell/test_report_issue_dialog.py
@@ -9,6 +9,7 @@ from ilastik.shell.gui.reportIssueDialog import _mask_file_paths, FILE_PATH_MASK
         ("", ""),
         ("some text/home/me/dir/file.tif", f"some text{FILE_PATH_MASK}"),
         ("some/slash\nand/another", "some/slash\nand/another"),
+        ("some/slash and/another", "some/slash and/another"),
         ("backslashes C:\\\\might\\\\be\\\\doubled", f"backslashes {FILE_PATH_MASK}"),
         ("textC:\\dir with space\\", f"text{FILE_PATH_MASK}"),
         ("textC:\\space in file.tif", f"text{FILE_PATH_MASK} in file.tif"),  # don't think we can catch this

--- a/tests/test_ilastik/test_shell/test_report_issue_dialog.py
+++ b/tests/test_ilastik/test_shell/test_report_issue_dialog.py
@@ -1,23 +1,6 @@
 import pytest
 
-from ilastik.app import STARTUP_MARKER
-from ilastik.shell.gui.reportIssueDialog import _get_log_since_last_startup, _mask_file_paths, FILE_PATH_MASK
-
-
-@pytest.mark.parametrize(
-    "full_log, expected_truncation",
-    [
-        ("", ""),
-        (f"{STARTUP_MARKER}\nsome\ntext_after", f"{STARTUP_MARKER}\nsome\ntext_after"),
-        (f"987654321{STARTUP_MARKER}", f"54321{STARTUP_MARKER}"),
-    ],
-)
-def test_get_log_since_last_startup(monkeypatch, tmp_path, full_log, expected_truncation):
-    log_path = tmp_path / "testlog.txt"
-    log_path.write_text(full_log)  # This might add \r before \n (OS-dependent)
-    monkeypatch.setattr("ilastik.ilastik_logging.default_config.get_logfile_path", lambda: log_path)
-    adjusted_for_CR = _get_log_since_last_startup(pre_marker_padding=5).replace("\r", "")
-    assert adjusted_for_CR == expected_truncation
+from ilastik.shell.gui.reportIssueDialog import _mask_file_paths, FILE_PATH_MASK
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ilastik/test_shell/test_report_issue_dialog.py
+++ b/tests/test_ilastik/test_shell/test_report_issue_dialog.py
@@ -1,0 +1,43 @@
+import pytest
+
+from ilastik.app import STARTUP_MARKER
+from ilastik.shell.gui.reportIssueDialog import _get_log_since_last_startup, _mask_file_paths, FILE_PATH_MASK
+
+
+@pytest.mark.parametrize(
+    "full_log, expected_truncation",
+    [
+        ("", ""),
+        (f"{STARTUP_MARKER}\nsome\ntext_after", f"{STARTUP_MARKER}\nsome\ntext_after"),
+        (f"987654321{STARTUP_MARKER}", f"54321{STARTUP_MARKER}"),
+    ],
+)
+def test_get_log_since_last_startup(monkeypatch, tmp_path, full_log, expected_truncation):
+    log_path = tmp_path / "testlog.txt"
+    log_path.write_text(full_log)  # This might add \r before \n (OS-dependent)
+    monkeypatch.setattr("ilastik.ilastik_logging.default_config.get_logfile_path", lambda: log_path)
+    adjusted_for_CR = _get_log_since_last_startup(pre_marker_padding=5).replace("\r", "")
+    assert adjusted_for_CR == expected_truncation
+
+
+@pytest.mark.parametrize(
+    "input_log, masked_log",
+    [
+        ("", ""),
+        ("some text/home/me/dir/file.tif", f"some text{FILE_PATH_MASK}"),
+        ("some/slash\nand/another", "some/slash\nand/another"),
+        ("backslashes C:\\\\might\\\\be\\\\doubled", f"backslashes {FILE_PATH_MASK}"),
+        ("textC:\\dir with space\\", f"text{FILE_PATH_MASK}"),
+        ("textC:\\space in file.tif", f"text{FILE_PATH_MASK} in file.tif"),  # don't think we can catch this
+        ("textC:/Users/me/file.tif", f"text{FILE_PATH_MASK}"),
+        ("textC:/dir with space/", f"text{FILE_PATH_MASK}"),
+        ("C:/dir actually\nsome other text with slash/", f"{FILE_PATH_MASK} actually\nsome other text with slash/"),
+        ("textC:/file with space.tif", f"text{FILE_PATH_MASK} with space.tif"),  # don't think we can catch this
+        (f"some text{FILE_PATH_MASK}", f"some text{FILE_PATH_MASK}"),
+        ("some-text/home-not a path", "some-text/home-not a path"),
+        ("text with https://url.com/should/ be replaced", f"text with https:/{FILE_PATH_MASK} be replaced"),
+        ("text with file:///C:/url/should/be replaced", f"text with file://{FILE_PATH_MASK} replaced"),
+    ],
+)
+def test_mask_file_paths(input_log, masked_log):
+    assert _mask_file_paths(input_log) == masked_log


### PR DESCRIPTION
This adds a "Report issue by email" menu action to the Help menu. It's intended to give us something shorter to tell people on the forum than the old "Please find the log with `Settings > Open Log folder`, delete it, reproduce the error, and then email us the log or upload it here on your forum post".

Now we would have to tell them, "Please go to `Help > Report issue by email` and attach the log as described there."

What the button actually does, is open the default email client with a blueprint email that includes version, OS, active workflow and applet, as well as open the log folder. The hope being that this makes it easier for the user to provide the basic info we need. (The reason it opens the log folder instead of pre-attaching the log file, is because that's not supported in `mailto:` links.)

What do you think @k-dominik? Can you think of something better we can do here? Or suggestions for better phrasing of the email template?

Next step could be to add crash detection, with a prompt on the startup after a crash that offers to email the devs about the crash.