### PR TITLE
Add wait cursor when tiktorch server is started

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1631,6 +1631,7 @@ class IlastikShell(QMainWindow):
 
         try:
             assert self.projectManager is None, "Expected projectManager to be None."
+            QApplication.setOverrideCursor(Qt.WaitCursor)
             self.projectManager = ProjectManager(
                 self,
                 workflow_class,
@@ -1645,6 +1646,8 @@ class IlastikShell(QMainWindow):
             # no project will be loaded, free the file resource
             hdf5File.close()
             return
+        finally:
+            QApplication.restoreOverrideCursor()
 
         try:
             # Add all the applets from the workflow


### PR DESCRIPTION
Closes #2721

I did some refactoring as well, as I was navigating through the code.

I could potentially add a little bit more logic to make the cursor busy only for the neural network workflows, where the tiktorch server is needed, but I skipped it, since it is a very lightweight process, and it won't cause harm even for the simpler, faster workflows that don't introduce latency (shoud maybe do it though?).

Manually tested by introducing latency at the creation of the project manager with `time.sleep()`:

```python
 import time
 time.sleep(2)
 self.projectManager = ProjectManager(self, workflow_class, self._workflow_cmdline_args, project_creation_args)
```