### PR TITLE
Fixes for 1.4.1b17 release

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,11 +27,14 @@ outputs:
       run:
         - python >=3.7
         - numpy >1.12
+        # aiohttp to enable zarr.storage.FSStore
         - aiohttp
         - appdirs
         - cachetools
+        - certifi
         - dpct
         - fastfilters
+        # fsspec to enable zarr.storage.FSStore
         - fsspec
         - future
         - greenlet

--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -172,6 +172,7 @@ class MultiscaleDatasetBrowser(QDialog):
             else:
                 msg = "Error while trying to read a dataset at this address."
             msg += f"\n\nFull error message:\n{e}"
+            logger.error(e, exc_info=True)
             self.result_text_box.setText(msg)
             return
 

--- a/lazyflow/operators/opLabelVolume.py
+++ b/lazyflow/operators/opLabelVolume.py
@@ -141,7 +141,7 @@ class OpLabelVolume(Operator):
 
         if self._opLabel is None:
             self._opLabel = self._labelOps[method](parent=self)
-            if method is "vigra":
+            if method == "vigra":
                 self._opLabel.BypassModeEnabled.connect(self.BypassModeEnabled)
 
         if input_dtype == np.uint16:
@@ -351,7 +351,6 @@ except ImportError as e:
 
     class OpBlockedConnectedComponents(object):
         pass
-
 
 else:
     _blockedarray_module_available = True

--- a/lazyflow/utility/pipeline.py
+++ b/lazyflow/utility/pipeline.py
@@ -77,7 +77,7 @@ class Pipeline(abc.Sequence):
         op = opfunc(**self._op_init_kwargs)
 
         if self:
-            if "Input" is slots:
+            if "Input" in slots:
                 raise ValueError('slot with the name "Input" cannot be manually assigned for non-first operator')
             if not hasattr(op, "Input"):
                 raise ValueError(f'new operator {op} does not have a slot with the name "Input"')

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,13 @@
+import os
+import platform
+import ssl
+
+from ilastik_scripts.ilastik_startup import fix_ssl
+
+
+def test_startup_ssl_paths():
+    fix_ssl()
+    WIN = platform.system() == "Windows"  # On Windows the cert file/folder don't seem to be needed
+    default_file = ssl.get_default_verify_paths().openssl_cafile
+    fixed_file = os.environ.get("SSL_CERT_FILE", "")
+    assert WIN or os.path.isfile(default_file) or os.path.isfile(fixed_file)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -6,8 +6,15 @@ from ilastik_scripts.ilastik_startup import fix_ssl
 
 
 def test_startup_ssl_paths():
+    """
+    The point of this test is to ensure that correct paths to SSL certs are available during runtime.
+    The problem of broken paths only exists in the packaged ilastik installers/bundles though,
+    so this test is effectively useless unless we run it on the installed packages.
+    Leaving it as a reminder that we should be running tests on the packages after build,
+    and as additional documentation for why fix_ssl exists.
+    """
     fix_ssl()
     WIN = platform.system() == "Windows"  # On Windows the cert file/folder don't seem to be needed
-    default_file = ssl.get_default_verify_paths().openssl_cafile
-    fixed_file = os.environ.get("SSL_CERT_FILE", "")
-    assert WIN or os.path.isfile(default_file) or os.path.isfile(fixed_file)
+    default_file_exists = os.path.isfile(ssl.get_default_verify_paths().openssl_cafile)
+    override_file_exists = os.path.isfile(os.environ.get("SSL_CERT_FILE", ""))
+    assert WIN or default_file_exists or override_file_exists


### PR DESCRIPTION
This PR originally was about fixing a SyntaxWarning message (see below), which I was going to just leave here until b18. Then discovered that `zarr.storage.FSStore` can't connect to remote servers in b17 on Linux and Mac due to issues with the SSL cert path, so b17 is unreleasable. Pushing the fix for that here instead and we'll just take the SyntaxWarning fixes along.

Original description: 
![image](https://github.com/ilastik/ilastik/assets/63287233/07b1d586-f523-4813-9b14-539e3176d3ab)

This is not a great UX... (not to mention one of these was clearly a typo)