### PR TITLE
Object classification: Restore default feature selection from previous verisons

### DIFF
--- a/ilastik/applets/objectExtraction/featureSelectionWithHelp.ui
+++ b/ilastik/applets/objectExtraction/featureSelectionWithHelp.ui
@@ -104,7 +104,10 @@
      <item>
       <widget class="QPushButton" name="allButLocationButton">
        <property name="text">
-        <string>All excl. Location</string>
+        <string>Default selection</string>
+       </property>
+       <property name="ToolTip">
+        <string>Default feature plugins, excluding features that relate to absolute pixel coordinates.</string>
        </property>
       </widget>
      </item>

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -18,18 +18,13 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from future import standard_library
-
-standard_library.install_aliases()
-from builtins import range
-from PyQt5.QtWidgets import QTreeWidgetItem, QMessageBox, QHeaderView
-from PyQt5.QtGui import QColor, QResizeEvent, QMouseEvent
+from PyQt5.QtWidgets import QTreeWidgetItem, QMessageBox
+from PyQt5.QtGui import QColor, QMouseEvent
 from PyQt5 import uic
 from PyQt5.QtCore import Qt, QEvent
 
 from lazyflow.rtype import SubRegion
 import os
-import sys
 from collections import defaultdict, Counter
 from copy import deepcopy
 
@@ -51,7 +46,6 @@ from ilastik.applets.objectExtraction.opObjectExtraction import default_features
 import vigra
 import numpy
 
-from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QDialog, QFileDialog
 
 import pickle as pickle


### PR DESCRIPTION
with the inclusion of the sphericaltexture plugin, the "All excl. location" button behavior changed - it would also include
those new features. Here we change the behavior of the button to include only the default features, as they were present in previous versions.

Timing-wise the sphericaltexture features are about a factor of 10x
slower to compute than our other features - so these should be selected
only if useful for the task (tbd by users).

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
