### PR TITLE
Support selecting/loading arbitrary URIs within an OME-Zarr store

### DIFF
--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -177,12 +177,11 @@ class MultiscaleDatasetBrowser(QDialog):
             return
 
         self.selected_uri = uri
+        scale_info_text = "\n".join(
+            [f"  - {key}: {' / '.join(map(str, shape.values()))}" for key, shape in rv.multiscales.items()]
+        )
         self.result_text_box.setText(
-            f"URL: {self.selected_uri}\n"
-            f"Data format: {rv.NAME}\n"
-            f"Number of scales: {len(rv.multiscales)}\n"
-            f"Raw dataset shape: {rv.get_shape(rv.highest_resolution_key)}\n"
-            f"Lowest scale shape: {rv.get_shape(rv.lowest_resolution_key)}\n"
+            f"URL: {self.selected_uri}\nData format: {rv.NAME}\nAvailable scales:\n" + scale_info_text
         )
         # This check-button might have been triggered by pressing Enter.
         # The timer prevents triggering the now enabled OK button by the same keypress.

--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -170,8 +170,8 @@ class MultiscaleDatasetBrowser(QDialog):
             elif isinstance(e, ConnectionError):
                 msg = "Connection error, please check that the server is online and the URL is correct."
             else:
-                msg = "Error while trying to read a dataset at this address."
-            msg += f"\n\nFull error message:\n{e}"
+                msg = "Couldn't load a multiscale dataset at this address."
+            msg += f"\n\nMore detail:\n{e}"
             logger.error(e, exc_info=True)
             self.result_text_box.setText(msg)
             return

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -561,7 +561,13 @@ class MultiscaleUrlDatasetInfo(DatasetInfo):
     @property
     def default_output_dir(self) -> Path:
         if self.url.startswith("file:"):
-            return uri_to_Path(self.url).absolute().parent
+            if self.working_scale != DEFAULT_SCALE_KEY and self.working_scale in self.url:
+                # self.url points directly to a scale, move to root
+                # so that root.parent is outside the multiscale store
+                multiscale_root = self.url[: self.url.index(self.working_scale)].rstrip("/")
+            else:
+                multiscale_root = self.url
+            return uri_to_Path(multiscale_root).absolute().parent
         return super().default_output_dir
 
     def to_json_data(self) -> Dict:

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -850,11 +850,7 @@ class OpDataSelection(Operator):
             if data_provider.meta.scales:
                 datasetInfo.laneShape = data_provider.meta.shape
                 datasetInfo.scales = data_provider.meta.scales
-                datasetInfo.working_scale = self.ActiveScale.value
-                if datasetInfo.working_scale == DEFAULT_SCALE_KEY:
-                    # datasetInfo.working_scale may be saved to the project file, so we want a real key here
-                    # if we didn't already load one from the file.
-                    datasetInfo.working_scale = data_provider.meta.lowest_scale
+                datasetInfo.working_scale = data_provider.meta.active_scale
 
             output_order = self._get_output_axis_order(data_provider)
             # Export applet assumes this OpReorderAxes exists.

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -37,6 +37,7 @@ from lazyflow.operators.ioOperators import (
     OpRESTfulPrecomputedChunkedVolumeReader,
     OpImageReader,
 )
+from lazyflow.utility.io_util.OMEZarrStore import scale_key_from_path
 from lazyflow.utility.jsonConfig import JsonConfigParser
 from lazyflow.utility.pathHelpers import lsH5N5, isUrl, isRelative, splitPath, PathComponents
 from .opOMEZarrMultiscaleReader import OpOMEZarrMultiscaleReader
@@ -304,9 +305,9 @@ class OpInputDataReader(Operator):
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.
         # We pass this down to the loader so that it can avoid loading scale metadata unnecessarily.
         reader = OpOMEZarrMultiscaleReader(parent=self, metadata_only_mode=self.parent is None)
-        if path.internalPath and self.parent:
+        if path.internalPath:
             # Headless/batch
-            reader.Scale.setValue(path.internalPath.lstrip("/"))
+            reader.Scale.setValue(scale_key_from_path(path.internalPath.lstrip("/")))
         else:
             reader.Scale.connect(self.ActiveScale)
         reader.BaseUri.setValue(path.externalPath)

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -19,6 +19,8 @@
 # This information is also available on the ilastik web site at:
 #          http://ilastik.org/license/
 ###############################################################################
+from pathlib import Path
+
 from lazyflow.graph import Operator, InputSlot, OutputSlot
 from lazyflow.operators import OpBlockedArrayCache, OpMetadataInjector, OpSubRegion
 from .opNpyFileReader import OpNpyFileReader
@@ -38,7 +40,7 @@ from lazyflow.operators.ioOperators import (
     OpImageReader,
 )
 from lazyflow.utility.jsonConfig import JsonConfigParser
-from lazyflow.utility.pathHelpers import lsH5N5, isRelative, splitPath, PathComponents
+from lazyflow.utility.pathHelpers import lsH5N5, isRelative, splitPath, PathComponents, isUrl
 from .opOMEZarrMultiscaleReader import OpOMEZarrMultiscaleReader
 
 from .opStreamingUfmfReader import OpStreamingUfmfReader
@@ -80,7 +82,7 @@ class OpInputDataReader(Operator):
     category = "Input"
 
     videoExts = ["ufmf", "mmf"]
-    h5_n5_Exts = ["h5", "hdf5", "ilp", "n5", "zarr"]
+    h5_n5_Exts = ["h5", "hdf5", "ilp", "n5"]
     n5Selection = [
         "json",
         "zgroup",
@@ -295,9 +297,10 @@ class OpInputDataReader(Operator):
             return ([], None)
 
     def _attemptOpenAsOmeZarrUri(self, filePath):
-        # Local file system paths with .zarr are handled in _attemptOpenAsH5N5
         if PathComponents(filePath).extension != ".zarr":
             return ([], None)
+        if not isUrl(filePath):
+            filePath = Path(filePath).as_uri()
         if not (filePath.startswith("http") or filePath.startswith("file")):
             return ([], None)
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -296,20 +296,15 @@ class OpInputDataReader(Operator):
 
     def _attemptOpenAsOmeZarrUri(self, filePath):
         # Local file system paths with .zarr are handled in _attemptOpenAsH5N5
-        path = PathComponents(filePath)
-        if path.extension != ".zarr":
+        if PathComponents(filePath).extension != ".zarr":
             return ([], None)
         if not (filePath.startswith("http") or filePath.startswith("file")):
             return ([], None)
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.
         # We pass this down to the loader so that it can avoid loading scale metadata unnecessarily.
         reader = OpOMEZarrMultiscaleReader(parent=self, metadata_only_mode=self.parent is None)
-        if path.internalPath:
-            # Headless/batch
-            reader.Scale.setValue(path.internalPath.lstrip("/"))
-        else:
-            reader.Scale.connect(self.ActiveScale)
-        reader.BaseUri.setValue(path.externalPath)
+        reader.Scale.connect(self.ActiveScale)
+        reader.Uri.setValue(filePath)
         return [reader], reader.Output
 
     def _attemptOpenAsRESTfulPrecomputedChunkedVolume(self, filePath):

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -37,9 +37,8 @@ from lazyflow.operators.ioOperators import (
     OpRESTfulPrecomputedChunkedVolumeReader,
     OpImageReader,
 )
-from lazyflow.utility.io_util.OMEZarrStore import scale_key_from_path
 from lazyflow.utility.jsonConfig import JsonConfigParser
-from lazyflow.utility.pathHelpers import lsH5N5, isUrl, isRelative, splitPath, PathComponents
+from lazyflow.utility.pathHelpers import lsH5N5, isRelative, splitPath, PathComponents
 from .opOMEZarrMultiscaleReader import OpOMEZarrMultiscaleReader
 
 from .opStreamingUfmfReader import OpStreamingUfmfReader
@@ -134,7 +133,7 @@ class OpInputDataReader(Operator):
         FilePath: Optional[str] = None,
         SequenceAxis: Optional[str] = None,
         SubVolumeRoi: Optional[Tuple[int, int]] = None,
-        ActiveScale: Optional[InputSlot] = None,
+        ActiveScale: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -307,7 +306,7 @@ class OpInputDataReader(Operator):
         reader = OpOMEZarrMultiscaleReader(parent=self, metadata_only_mode=self.parent is None)
         if path.internalPath:
             # Headless/batch
-            reader.Scale.setValue(scale_key_from_path(path.internalPath.lstrip("/")))
+            reader.Scale.setValue(path.internalPath.lstrip("/"))
         else:
             reader.Scale.connect(self.ActiveScale)
         reader.BaseUri.setValue(path.externalPath)

--- a/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
+++ b/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
@@ -39,7 +39,7 @@ class OpOMEZarrMultiscaleReader(Operator):
 
     name = "OpOMEZarrMultiscaleReader"
 
-    Uri = InputSlot()  # May point either to an OME-Zarr multiscale root, or to a specific scale
+    Uri = InputSlot()  # May point to any path within an OME-Zarr group
     Scale = InputSlot(optional=True)  # Selected through GUI
 
     Output = OutputSlot()

--- a/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
@@ -37,7 +37,6 @@ from lazyflow.utility.helpers import get_default_axisordering, bigintprod
 from lazyflow.utility.io_util.OMEZarrStore import (
     get_axistags_for_dataset as get_ome_zarr_axistags,
     OMEZarrMultiscaleMeta,
-    scale_key_from_path,
     get_multiscale_for_dataset,
 )
 from lazyflow.utility.io_util.multiscaleStore import Multiscales
@@ -148,14 +147,14 @@ class OpStreamingH5N5Reader(Operator):
         if isinstance(self._h5N5File, z5py.ZarrFile):
             # Add OME-Zarr metadata to slot so that it can be ported over to an export
             multiscale_spec = get_multiscale_for_dataset(self._h5N5File.attrs, internalPath.lstrip("/"))
-            scale_keys = [scale_key_from_path(dataset["path"]) for dataset in multiscale_spec["datasets"]]
+            scale_keys = [dataset["path"] for dataset in multiscale_spec["datasets"]]
             scale_tagged_shapes = [
                 OrderedDict(zip(axistags.keys(), self._h5N5File[dataset["path"]].shape))
                 for dataset in multiscale_spec["datasets"]
             ]
             scales: Multiscales = OrderedDict(zip(scale_keys, scale_tagged_shapes))
             self.OutputImage.meta.scales = scales
-            self.OutputImage.meta.active_scale = scale_key_from_path(internalPath)
+            self.OutputImage.meta.active_scale = internalPath
             self.OutputImage.meta.lowest_scale = scale_keys[-1]
             self.OutputImage.meta.ome_zarr_meta = OMEZarrMultiscaleMeta.from_multiscale_spec(multiscale_spec)
 

--- a/lazyflow/operators/ioOperators/opStreamingH5N5SequenceReaderM.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5SequenceReaderM.py
@@ -256,7 +256,7 @@ class OpStreamingH5N5SequenceReaderM(Operator):
         pathComponents = [PathComponents(p.strip()) for p in pathStrings]
         assert len(pathComponents) > 0
 
-        known_exts = OpStreamingH5N5Reader.H5EXTS + OpStreamingH5N5Reader.N5EXTS + OpStreamingH5N5Reader.ZARREXTS
+        known_exts = OpStreamingH5N5Reader.H5EXTS + OpStreamingH5N5Reader.N5EXTS
         if not all(p.extension in known_exts for p in pathComponents):
             raise OpStreamingH5N5SequenceReaderM.WrongFileTypeError(globString)
 

--- a/lazyflow/operators/ioOperators/opStreamingH5N5SequenceReaderS.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5SequenceReaderS.py
@@ -254,7 +254,7 @@ class OpStreamingH5N5SequenceReaderS(Operator):
         pathComponents = [PathComponents(p.strip()) for p in pathStrings]
         assert len(pathComponents) > 0
 
-        known_exts = OpStreamingH5N5Reader.H5EXTS + OpStreamingH5N5Reader.N5EXTS + OpStreamingH5N5Reader.ZARREXTS
+        known_exts = OpStreamingH5N5Reader.H5EXTS + OpStreamingH5N5Reader.N5EXTS
         if not all(p.extension in known_exts for p in pathComponents):
             raise OpStreamingH5N5SequenceReaderS.WrongFileTypeError(globString)
 

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -369,7 +369,7 @@ class OMEZarrStore(MultiscaleStore):
     """
 
     NAME = "OME-Zarr"
-    URI_HINT = 'URL contains "zarr"'
+    URI_HINT = 'URL contains ".zarr"'
 
     def __init__(self, uri: str, target_scale: Optional[str] = None, single_scale_mode: bool = False):
         self._ome_spec, self.base_uri, self.scale_sub_path = _introspect_for_multiscales_root(uri)
@@ -442,7 +442,7 @@ class OMEZarrStore(MultiscaleStore):
 
     @staticmethod
     def is_uri_compatible(uri: str) -> bool:
-        return "zarr" in uri
+        return ".zarr" in uri
 
     def get_chunk_size(self, scale_key=DEFAULT_SCALE_KEY):
         scale_key = scale_key if scale_key != DEFAULT_SCALE_KEY else self.lowest_resolution_key

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -233,12 +233,7 @@ def _axistags_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> vigra.AxisTags
     return vigra.defaultAxistags("".join(axis_keys))
 
 
-def get_axistags_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> vigra.AxisTags:
-    multiscale = get_multiscale_for_dataset(ome_spec, dataset_subpath)
-    return _axistags_from_multiscale(multiscale)
-
-
-def get_multiscale_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> OME_ZARR_MULTISCALE:
+def _get_multiscale_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> OME_ZARR_MULTISCALE:
     for multiscale in ome_spec["multiscales"]:
         if any(d["path"] == dataset_subpath for d in multiscale["datasets"]):
             return multiscale
@@ -346,7 +341,7 @@ class OMEZarrStore(MultiscaleStore):
             )
             logger.warning(warn)
         multiscale_spec = (
-            get_multiscale_for_dataset(self._ome_spec, selected_scale)
+            _get_multiscale_for_dataset(self._ome_spec, selected_scale)
             if selected_scale
             else self._ome_spec["multiscales"][0]
         )

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -371,7 +371,7 @@ def lsH5N5(h5N5FileObject, minShape=2, maxShape=5):
             return
         if len(obj.shape) not in range(minShape, maxShape + 1):
             return
-        if isinstance(h5N5FileObject, (z5py.N5File, z5py.ZarrFile)):
+        if isinstance(h5N5FileObject, z5py.N5File):
             # make sure we get a path with forward slashes on windows
             objectName = pathlib.Path(objectName).as_posix()
         listOfDatasets.append({"name": objectName, "object": obj})
@@ -401,7 +401,7 @@ def globH5N5(fileObject, globString):
           matches occurred.
         - None if fileObject is not a h5 or n5 file object
     """
-    if isinstance(fileObject, (h5py.File, z5py.N5File, z5py.ZarrFile)):
+    if isinstance(fileObject, (h5py.File, z5py.N5File)):
         pathlist = [x["name"] for x in lsH5N5(fileObject)]
     else:
         return None

--- a/tests/test_ilastik/test_workflows/test_DatasetInfo.py
+++ b/tests/test_ilastik/test_workflows/test_DatasetInfo.py
@@ -203,15 +203,12 @@ def test_h5_stack_via_star_file_glob_and_stared_internal_path(h5_stack_dir, empt
     assert info.filePath == expected_filepath
 
 
-@pytest.fixture(params=["n5", "zarr"])
-def z5_stack_dir(request, stack_path):
-    sub_path = stack_path / request.param  # Include param so tests can find out which case they are running
+@pytest.fixture
+def z5_stack_dir(stack_path):
+    sub_path = stack_path / "n5"
     for i in range(3):
-        with z5py.File(str(sub_path / f"2d_apoptotic_binary_{i}.{request.param}"), "w") as f:
+        with z5py.File(str(sub_path / f"2d_apoptotic_binary_{i}.n5"), "w") as f:
             raw = (numpy.random.rand(1, 10, 20, 1, 1) * 255).astype(numpy.uint8)
-            # Provide OME-NGFF metadata (shouldn't interfere with N5, reader enforces for Zarr)
-            f.attrs["multiscales"] = [{"datasets": [{"path": "volume/data"}], "axes": "zyxct", "version": "0.3"}]
-            f.create_group("volume")  # Needed for zarr (see z5py#231)
             f.create_dataset("volume/data", data=raw)
     return sub_path
 

--- a/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
+++ b/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
@@ -246,6 +246,14 @@ def ome_zarr_store_on_disc(tmp_path) -> str:
     chunk_size = [3, 64, 64]
     zattrs = {
         "multiscales": [
+            {  # Additional multiscales entry to test that the correct one (the other one) is used
+                "version": "0.4",
+                "axes": [
+                    {"type": "space", "name": "y"},
+                    {"type": "space", "name": "x"},
+                ],
+                "datasets": [{"path": "wrong/s0"}],
+            },
             {
                 "name": "some.zarr",
                 "type": "Sample",
@@ -272,7 +280,7 @@ def ome_zarr_store_on_disc(tmp_path) -> str:
                     },
                 ],
                 "coordinateTransformations": [],
-            }
+            },
         ]
     }
     (zarr_dir / ".zattrs").write_text(json.dumps(zattrs))

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -486,7 +486,7 @@ class TestOpInputDataReaderWithOMEZarr:
         expected_uris = [(labels_dir / "nuclei").as_uri(), (labels_dir / "Cells").as_uri()]
         with pytest.raises(NotAnOMEZarrMultiscale) as e:
             reader.FilePath.setValue(str(labels_dir))
-        assert "Available label URLs" in str(e.value), str(e.value)
+        assert "labels directory" in str(e.value), str(e.value)
         assert all(expected in str(e.value) for expected in expected_uris), str(e.value)
 
     def test_load_well_options(self, tmp_path, parent):
@@ -501,7 +501,7 @@ class TestOpInputDataReaderWithOMEZarr:
         requested_uri = (well_dir / "suB").as_uri()
         with pytest.raises(NotAnOMEZarrMultiscale) as e:
             reader.FilePath.setValue(str(requested_uri))
-        assert "Available acquisition URLs" in str(e.value), str(e.value)
+        assert "well directory" in str(e.value), str(e.value)
         assert all(expected in str(e.value) for expected in expected_uris), str(e.value)
 
     def test_load_plate_options(self, tmp_path, parent):
@@ -515,5 +515,5 @@ class TestOpInputDataReaderWithOMEZarr:
         requested_uri = (plate_dir / "A").as_uri()
         with pytest.raises(NotAnOMEZarrMultiscale) as e:
             reader.FilePath.setValue(str(requested_uri))
-        assert "Available well URLs" in str(e.value), str(e.value)
+        assert "plate directory" in str(e.value), str(e.value)
         assert all(expected in str(e.value) for expected in expected_uris), str(e.value)

--- a/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
@@ -1,0 +1,33 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+# 		   http://ilastik.org/license/
+###############################################################################
+import pytest
+
+from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore
+
+
+def test_OMEZarrStore_handles_wrapped_connection_error():
+    # zarr.storage.FSStore raises a ClientConnectorError wrapped in a KeyError
+    # when the web connection fails. We handle this by re-raising as ConnectionError.
+    # Check that it hasn't changed in the zarr library.
+    nonsense_host = "nonexistent-address.zarr.foobar123"
+    with pytest.raises(ConnectionError, match=nonsense_host):
+        OMEZarrStore(f"https://{nonsense_host}")


### PR DESCRIPTION
This revamps URI handling in the OME-Zarr loader. With this, we should be able to handle any URI that points to any sub-path within an OME-Zarr store, as long as some parent contains a `zattrs` that conforms to either the `plate`, `well`, `labels` or `multiscales` spec of the OME-Zarr standard

_AND_... as long as the URI contains ".zarr" somewhere. This still eliminates stores that don't follow the naming convention (looking at you, [webknossos](https://zarr.webknossos.org/)), and I want to change this requirement. But I think this will have to be kept for another PR, as it'll take some playing around to see what's the nicest way of doing it.

But, if the address is within an OME-Zarr store, the loader now introspects the given path and its parents until it hits the first conforming spec, and then does what I figured is the most sensible thing in each case:

- Plate/well/labels: List the available sub-paths to the user so that they can choose
- Multiscale root: Load the multiscale with the default scale selected (lowest res)
- Individual scale of a multiscale set: Load the multiscale with the specified scale pre-selected

Since the web-reader can now handle all of these nicely, I decided to remove the OME-Zarr loading changes from the H5N5 reader and instead convert file paths with the ".zarr" extension to URIs and pass them through the web-reader. Sooner or later, having different capabilities depending on whether you pass a file path or a URI would cause some confusion; and keeping them synced isn't simple either. In the current state, we do lose one feature that file paths (going through h5n5reader/z5py) did support: globbing in headless mode.