### PR TITLE
Fix dark mode (for mac)

### DIFF
--- a/ilastik/applets/dataSelection/dataLaneSummaryTableModel.py
+++ b/ilastik/applets/dataSelection/dataLaneSummaryTableModel.py
@@ -63,7 +63,7 @@ def rowOfButtonsProxy(model_cls):
 
             Skip vertical header for the last row, which is used for buttons.
             """
-            if orientation == Qt.Vertical:
+            if role == Qt.DisplayRole and orientation == Qt.Vertical:
                 if section >= super(ProxyModel, self).rowCount():
                     return ""
             return super(ProxyModel, self).headerData(section, orientation, role)

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -169,7 +169,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         laneIndex = index.row()
 
         UninitializedDisplayData = {
-            DatasetColumn.Nickname: "<empty>",
+            DatasetColumn.Nickname: "",
             DatasetColumn.Location: "",
             DatasetColumn.InternalID: "",
             DatasetColumn.TaggedShape: "",

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
@@ -162,9 +162,8 @@ class InlineAddButtonDelegate(QItemDelegate):
         # This method will be called every time a particular cell is in
         # view and that view is changed in some way. We ask the delegates
         # parent (in this case a table view) if the index in question (the
-        # table cell) corresponds to an empty row (indicated by '<empty>'
-        # in the data field), and create a button if there isn't one
-        # already associated with the cell.
+        # table cell) corresponds to an empty row, we create a button if
+        # there isn't one already associated with the cell.
         parent_view = self.parent()
         button = parent_view.indexWidget(index)
         if index.row() < parent_view.model().rowCount() - 1 and parent_view.model().isEmptyRow(index.row()):

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -43,7 +43,7 @@ from volumina import colortables
 
 # ilastik
 from ilastik.utility import bind, log_exception
-from ilastik.utility.gui import ThunkEventHandler, threadRouted
+from ilastik.utility.gui import ThunkEventHandler, is_qt_dark_mode, threadRouted
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
 
 from ilastik.applets.labeling.labelingImport import import_labeling_layer
@@ -210,8 +210,7 @@ class LabelingGui(LayerViewerGui):
 
         # We own the applet bar ui
         self._labelControlUi = _labelControlUi
-        _labelControlUi.setStyleSheet(
-            """
+        stylesheet_light = """
             QToolButton#suggestFeaturesButton { padding: 2px; height: 24px; }
             QToolButton#liveUpdateButton {
                 padding: 5px; height: 24px; border-style: solid; border-width: 1px; border-radius: 4px;
@@ -220,8 +219,21 @@ class LabelingGui(LayerViewerGui):
             QToolButton#liveUpdateButton:pressed { border-color: #557755; background-color: #779977; }
             QToolButton#liveUpdateButton:checked { border-color: #aaccaa; background-color: #cceecc; }
             QToolButton#liveUpdateButton:checked:hover { border-color: #b0d0b0; background-color: #d0f0d0; }
-            """
-        )
+        """
+
+        stylesheet_dark = """
+            QToolButton#suggestFeaturesButton { padding: 2px; height: 24px; }
+            QToolButton#liveUpdateButton {
+                padding: 5px; height: 24px; border-style: solid; border-width: 1px; border-radius: 4px;
+                border-color: #97b6b7; background-color: #638182; }
+            QToolButton#liveUpdateButton:hover { border-color: #befcfe; background-color: #7ab5b8; }
+            QToolButton#liveUpdateButton:pressed { border-color: #a0acbd; background-color: #637a95; }
+            QToolButton#liveUpdateButton:checked { border-color: #aaa6cb; background-color: #757295; }
+            QToolButton#liveUpdateButton:checked:hover { border-color: #f1edff; background-color: #aaa6cb; }
+        """
+
+        stylesheet = stylesheet_dark if is_qt_dark_mode() else stylesheet_light
+        _labelControlUi.setStyleSheet(stylesheet)
 
         # Initialize the label list model
         model = LabelListModel()

--- a/ilastik/shell/gui/aboutDialog.py
+++ b/ilastik/shell/gui/aboutDialog.py
@@ -18,7 +18,6 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
-import sys
 import os
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
@@ -27,12 +26,9 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QHBoxLayout,
     QLabel,
-    QPushButton,
-    QTextEdit,
     QVBoxLayout,
 )
 from PyQt5.QtCore import Qt
-from functools import partial
 
 
 import ilastik
@@ -41,11 +37,11 @@ import ilastik
 about_text = f"""
     <p>ilastik version {ilastik.__version__}</p>
     <p>ilastik development has started in 2010 in the
-    <a href="https://hci.iwr.uni-heidelberg.de/mip">group of Prof. Fred Hamprecht
+    <a href="https://sciai-lab.org/members/fred-hamprecht.html">group of Prof. Fred Hamprecht
     </a>at University of Heidelberg.</p>
 
     <p>In 2018 the ilastik development team has moved with Anna Kreshuk to her
-    <a href="https://www.embl.de/research/units/cbb/kreshuk/">
+    <a href="https://www.embl.org/groups/kreshuk/">
     newly established lab</a>
     at European Molecular Biology Laboratory Heidelberg.
     More information can be found at
@@ -93,9 +89,9 @@ class AboutDialog(QDialog):
         main_layout.addWidget(btn_box)
 
         self.setLayout(main_layout)
-        self.setStyleSheet("background-color: white;")
+        self.setStyleSheet(f"AboutDialog {{background-color: {QApplication.palette().light().color().name()}; }}")
         self.setWindowTitle("About ilastik")
-        self.setFixedSize(splash_pixmap.width() * 2.5, splash_pixmap.height() * 1.05)
+        self.setFixedSize(splash_pixmap.width() * 3.0, splash_pixmap.height() * 1.25)
 
     @classmethod
     def createAndShowModal(cls, parent=None):

--- a/ilastik/utility/gui/__init__.py
+++ b/ilastik/utility/gui/__init__.py
@@ -18,8 +18,24 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
+from PyQt5.QtWidgets import QApplication
+
 
 from .roi import roi2rect
 from .threadRouter import ThreadRouter, threadRouted, threadRoutedWithRouter
 from .thunkEvent import ThunkEvent, ThunkEventHandler
 from .widgets import enable_when_ready, silent_qobject
+
+
+def is_qt_dark_mode() -> bool:
+    """
+    One of the methods reported working to determine dark/light mode during runtime
+    with Qt5.
+
+    ref: https://stackoverflow.com/questions/75457687/detect-dark-application-style
+
+    Note: This might break users using custom themes.
+
+    Returns True if in dark mode, False if light mode
+    """
+    return QApplication.palette().windowText().color().value() > QApplication.palette().window().color().value()

--- a/ilastik/widgets/labelListView.py
+++ b/ilastik/widgets/labelListView.py
@@ -1,9 +1,7 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -20,7 +18,6 @@ from __future__ import absolute_import
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
 import os
 from functools import partial
 

--- a/ilastik/widgets/listView.py
+++ b/ilastik/widgets/listView.py
@@ -75,7 +75,7 @@ class ListView(QStackedWidget):
         table = self._table
         table.setStyleSheet(
             """
-            QTableView { padding-left: 3px; background-color: white; }
+            QTableView { padding-left: 3px; }
             QTableView::item { padding: 4px; }
             """
         )  # item.padding does not affect all four sides of table cells


### PR DESCRIPTION
Wow, how much time can one spend on choosing colors for a button...

Motivation (gallery of horror): I personally don't use dark mode, but almost every user I support (on osx) does. And it was really ugly:

<details><summary>About dialog</summary>
<img width="634" alt="Screenshot 2024-08-19 at 16 41 00" src="https://github.com/user-attachments/assets/f784fed3-ddb1-413d-8bef-297dd92ad030">
</details>

<details><summary>Feature Selection</summary>
<img width="826" alt="Screenshot 2024-08-19 at 16 41 09" src="https://github.com/user-attachments/assets/9a90e7c5-60b6-4da7-bfd9-649d94d69b00">
</details>

<details><summary>Pixel Classification Training</summary>
<img width="326" alt="Screenshot 2024-08-19 at 16 41 21" src="https://github.com/user-attachments/assets/65737be9-52c4-4ca2-8793-9d35ee4b0841">
</details>

Dealing with dark mode in qt5 seems also to be challenging to do properly (see [here](https://stackoverflow.com/questions/75457687/detect-dark-application-style)). This PR adds some band aids to at least make ilastik usable in  dark mode:


<details><summary>About dialog</summary>
<img width="739" alt="Screenshot 2024-08-19 at 16 42 05" src="https://github.com/user-attachments/assets/7ab69012-14c6-44a8-99fe-4a727872f147">
</details>

<details><summary>Feature Selection</summary>
<img width="826" alt="Screenshot 2024-08-19 at 16 42 12" src="https://github.com/user-attachments/assets/386a034c-717c-4cfe-b356-af8b52de0139">
</details>

<details><summary>Pixel Classification Training</summary>
<img width="322" alt="Screenshot 2024-08-19 at 16 42 21" src="https://github.com/user-attachments/assets/5794bafa-c809-4036-8067-8c7bed871e37">

</details>

_Some_ of these changes adapt dynamically to switching the theme (not all unfortunately).


### Updates:

* 🚀 now also partially addresses  #2886: `QFont::fromString: Invalid description '(empty)'` crap is gone!
* apparently, in data selection, for roles that have no data associated with a lane yet, we would print the string `<empty>` below the in-line "Add" button. This was barely visible in light mode, but in dark mode, the string would be printed on top of the button :shrug:
<details><summary>light mode zoomed in (before)</summary> 
<img src="https://github.com/user-attachments/assets/e965e817-d74f-4010-87ab-10785315a6d6">
 </details>
   <details><summary>dark mode (before)</summary>
<img width="180" alt="image" src="https://github.com/user-attachments/assets/2f45959e-27db-4c3b-b578-23a8ac3697b9">
</details>
   <details><summary>dark mode (after)</summary> 
<img width="131" alt="image" src="https://github.com/user-attachments/assets/12434fed-d563-4858-89c1-820ef113b633">
 </details>

Todo:
- [x] check windows (thx at @btbest, see https://github.com/ilastik/ilastik/pull/2898#issuecomment-2298234191)
- [x] Fix dark mode in volumina export dialog https://github.com/ilastik/volumina/pull/314