### PR TITLE
Fix state update to inactivate applets in live update

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -110,6 +110,7 @@ class ObjectClassificationGui(LabelingGui):
     _knime_exporter = None
 
     def __init__(self, parentApplet, op):
+        self.parentApplet = parentApplet
         self.isInitialized = False  # Need this flag in objectClassificationApplet where initialization is terminated with label selection
         self.__cleanup_fns = []
         # Tell our base class which slots to monitor
@@ -270,6 +271,7 @@ class ObjectClassificationGui(LabelingGui):
 
         self.labelMode = not val
         self.op.FreezePredictions.setValue(not val)
+        self.parentApplet.appletStateUpdateRequested()
 
     @pyqtSlot()
     def handleInteractiveModeClicked(self):

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -82,7 +82,7 @@ class TableExporter(ExportingOperator):
             return None, None
 
     def format_path(self, lane_index: int, path_format_string: str) -> str:
-        """ Takes the format string for the output file, fills in the most important placeholders, and returns it """
+        """Takes the format string for the output file, fills in the most important placeholders, and returns it"""
         assert self._path_formatter_factory is not None, "Path formatter factory is not set"
 
         path_formatter = self._path_formatter_factory.for_lane(lane_index)
@@ -230,7 +230,7 @@ class OpObjectClassification(Operator, MultiLaneOperatorABC):
     SuggestedLabelNames = InputSlot(stype=Opaque, value=[])
     LabelInputs = InputSlot(stype=Opaque, rtype=List, optional=True, level=1)
 
-    FreezePredictions = InputSlot(stype="bool", value=False)
+    FreezePredictions = InputSlot(stype="bool", value=True)
     EnableLabelTransfer = InputSlot(stype="bool", value=False)
 
     # for reading from disk
@@ -271,6 +271,7 @@ class OpObjectClassification(Operator, MultiLaneOperatorABC):
 
     # Use a slot for storing the export settings in the project file.
     ExportSettings = OutputSlot()
+
     # Override functions ExportingOperator mixin
     def execute(self, slot, subindex, roi, result):
         assert slot is self.ExportSettings, "Should be no need to execute this slot: {}".format(slot.name)

--- a/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
+++ b/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
@@ -18,10 +18,7 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from __future__ import division
-from builtins import range
 import sys
-import warnings
 import tempfile
 import unittest
 
@@ -32,7 +29,6 @@ import h5py
 from lazyflow.graph import Graph
 from lazyflow.operators.opReorderAxes import OpReorderAxes
 
-from ilastik.applets import objectExtraction
 from ilastik.applets.objectExtraction.opObjectExtraction import OpObjectExtraction
 from ilastik.applets.objectClassification.opObjectClassification import OpObjectClassification
 from ilastik.applets.blockwiseObjectClassification import OpBlockwiseObjectClassification
@@ -209,6 +205,8 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
 
         opObjectClassification.SelectedFeatures.setValue(self.testingFeatures)
         opObjectClassification.ComputedFeatureNames.connect(self.objExtraction.Features)
+
+        opObjectClassification.FreezePredictions.setValue(False)
 
         # STEP 2: simulate labeling
 


### PR DESCRIPTION
Previously, in OC, one could activate all applets while on live update. This allowed to change the graph while training and could lead to #1040.

Also fixes downstream unreadiness in case of an untrained classifier.

Fixes #1040

<details><summary>previously - live update active</summary>

![image](https://github.com/user-attachments/assets/0a9231e3-f4a8-4ff7-b6bc-84aa54166afd)


</details>

<details><summary>with this PR - live update active</summary>

![image](https://github.com/user-attachments/assets/d28ed052-d59e-4754-ab1e-51b4eb57fdfe)


</details>

#### Todos

- []  ~~ensure errors during batch processing don't block the UI~~ --> will do this separately as it affects all workflows


