### PR TITLE
Use vigra.analysis.unique instead of numpy.unique

### DIFF
--- a/bin/train_headless.py
+++ b/bin/train_headless.py
@@ -29,10 +29,11 @@ Note: This script does not make any attempt to be efficient with RAM usage.
       (The entire label volume is loaded at once.)  As a result, each image volume you
       train with must be significantly smaller than the available RAM on your machine.
 """
-from __future__ import print_function
-from builtins import range
+
 import os
 import numpy as np
+import vigra
+
 
 def main():
     # Cmd-line args to this script.
@@ -204,7 +205,7 @@ def generate_trained_project_file(
             label_volume = label_volume[..., None]
 
         # Auto-calculate the max label value
-        label_classes.update(np.unique(label_volume))
+        label_classes.update(vigra.analysis.unique(label_volume))
 
         print("Applying label volume to lane #{}".format(lane))
         entire_volume_slicing = roiToSlice(*roiFromShape(label_volume.shape))

--- a/ilastik/applets/labeling/labelingImport.py
+++ b/ilastik/applets/labeling/labelingImport.py
@@ -135,7 +135,7 @@ def import_labeling_layer(labelLayer, labelingSlots, parent_widget=None):
             readData = req.result
 
             # Can't use return_counts feature because that requires numpy >= 1.9
-            # unique_read_labels, readLabelCounts = numpy.unique(readData, return_counts=True)
+            # unique_read_labels, readLabelCounts = vigra.analysis.unique(readData, return_counts=True)
 
             # This does the same as the above, albeit slower, and probably with more ram.
             bincounts = chunked_bincount(readData)
@@ -551,14 +551,14 @@ class LabelImportOptionsDlg(QDialog):
     def _updatePosition(self):
         writeAxes = self._writeSeedsSlot.meta.getAxisKeys()
 
-        for (k, v) in list(self._insert_position_boxes.items()):
+        for k, v in list(self._insert_position_boxes.items()):
             insertBox, _ = v
             self.imageOffsets[writeAxes.index(k)] = insertBox.value()
 
     def _updateMappingEnabled(self):
         max_labels, _ = self._labelInfo
 
-        for (k, v) in list(self._insert_mapping_boxes.items()):
+        for k, v in list(self._insert_mapping_boxes.items()):
             enabledBox, mapToBox = v
             enabled = enabledBox.isChecked()
             if enabled:
@@ -580,6 +580,6 @@ class LabelImportOptionsDlg(QDialog):
         self.buttonBox.button(QDialogButtonBox.Ok).setEnabled(enableOk)
 
     def _updateMapping(self):
-        for (k, v) in list(self._insert_mapping_boxes.items()):
+        for k, v in list(self._insert_mapping_boxes.items()):
             _, mapToBox = v
             self.labelMapping[k] = mapToBox.value()

--- a/ilastik/plugins_default/tracking_h5_event_export.py
+++ b/ilastik/plugins_default/tracking_h5_event_export.py
@@ -1,8 +1,9 @@
-from builtins import range
 import os
 import numpy as np
 import h5py
 from functools import partial
+
+import vigra
 from lazyflow.request import Request, RequestPool
 
 from ilastik.plugins import TrackingExportFormatPlugin
@@ -50,7 +51,7 @@ else:
                 seg = dest_file.create_group("segmentation")
                 seg.create_dataset("labels", data=labelImage, compression="gzip")
                 meta = dest_file.create_group("objects/meta")
-                ids = np.unique(labelImage)
+                ids = vigra.analysis.unique(labelImage)
                 ids = ids[ids > 0]
                 valid = np.ones(ids.shape)
                 meta.create_dataset("id", data=ids, dtype=np.uint32)
@@ -73,9 +74,9 @@ else:
 
                 if div is not None and len(div) > 0:
                     ds = tg.create_dataset("Splits", data=div, dtype=np.int32)
-                    ds.attrs[
-                        "Format"
-                    ] = "ancestor (previous file), descendant (current file), descendant (current file)"
+                    ds.attrs["Format"] = (
+                        "ancestor (previous file), descendant (current file), descendant (current file)"
+                    )
 
                 if mer is not None and len(mer) > 0:
                     ds = tg.create_dataset("Mergers", data=mer, dtype=np.int32)
@@ -95,7 +96,7 @@ else:
         exportsToFile = False
 
         def checkFilesExist(self, filename):
-            """ Check whether the files we want to export are already present """
+            """Check whether the files we want to export are already present"""
             return os.path.exists(filename)
 
         def export(self, filename, hypothesesGraph, pluginExportContext):

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -26,6 +26,7 @@ from functools import partial
 from collections import defaultdict
 from typing import List
 import numpy
+import vigra
 
 # PyQt
 from PyQt5 import uic
@@ -523,7 +524,7 @@ class CarvingGui(LabelingGui):
             try:
                 for obj, obj_path, obj_n in zip(object_names, obj_filepaths, range(n_objects)):
                     object_volume = get_label_volume_from_mst(mst, obj)
-                    unique_ids = len(numpy.unique(object_volume))
+                    unique_ids = len(vigra.analysis.unique(object_volume))
 
                     if unique_ids <= 1:
                         logger.info(f"No voxels found for {obj}, skipping")

--- a/ilastik/workflows/voxelSegmentation/opSlic.py
+++ b/ilastik/workflows/voxelSegmentation/opSlic.py
@@ -6,6 +6,7 @@ a cache can be used to force every request to be taken from a global result.
 See the __main__ section, below.
 It also includes a brief demonstration of lazyflow's OperatorWrapper mechanism.
 """
+
 import logging
 
 import numpy
@@ -43,7 +44,7 @@ class OpSlic(Operator):
 
     def setupOutputs(self):
         self.Output.meta.assignFrom(self.Input.meta)
-        self.Output.meta.dtype = numpy.uint16
+        self.Output.meta.dtype = numpy.uint32
 
         tagged_shape = self.Input.meta.getTaggedShape()
         assert "c" in tagged_shape, "We assume the image has an explicit channel axis."
@@ -91,7 +92,7 @@ class OpSlic(Operator):
         # (not, say 3 unrelated image features).
 
         # slic_sp has no channel axis, so insert that axis before copying to 'result'
-        result[:] = slic_sp[..., None]
+        result[:] = slic_sp[..., None].astype("uint32")
         # import IPython; IPython.embed()
 
         return result

--- a/ilastik/workflows/voxelSegmentation/utils.py
+++ b/ilastik/workflows/voxelSegmentation/utils.py
@@ -3,6 +3,7 @@ import logging
 import time
 
 from lazyflow.request import Request, RequestPool
+from lazyflow.utility import vigra_bincount
 import numpy as np
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ def get_supervoxel_labels(labels, supervoxel_mask):
     supervoxel_labels = np.ndarray((N_supervoxels,))
 
     for supervoxel in range(N_supervoxels):
-        counts = np.bincount(labels[supervoxel_mask == supervoxel].ravel())
+        counts = vigra_bincount(labels[supervoxel_mask == supervoxel].ravel())
 
         # Little trick to avoid labelling a supervoxel as unlabelled if only a small part of it has been labelled
         if len(counts) == 1:  # or max(counts[1:]) == 0:
@@ -68,7 +69,7 @@ def slic_to_mask(slic_segmentation, supervoxel_values):
         nonlocal slices_out
         shape = slice_.shape + (supervoxel_values.shape[-1],)
         slice_out = np.zeros(shape, dtype=supervoxel_values.dtype)
-        for (i, v) in enumerate(supervoxel_values):
+        for i, v in enumerate(supervoxel_values):
             slice_out[slice_ == i, :] = v[:]
         slices_out.append(slice_out)
 

--- a/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
@@ -118,11 +118,12 @@ class ParallelVigraRfLazyflowClassifierFactory(LazyflowVectorwiseClassifierFacto
         tree_counts = list(map(int, tree_counts))
         tree_counts[:] = (tree_count for tree_count in tree_counts if tree_count != 0)
 
-        # Save for future reference
-        known_labels = numpy.unique(y)
-
         X = numpy.asarray(X, numpy.float32)
         y = numpy.asarray(y, numpy.uint32)
+
+        # Save for future reference
+        known_labels = vigra.analysis.unique(y)
+
         if y.ndim == 1:
             y = y[:, numpy.newaxis]
 
@@ -136,9 +137,9 @@ class ParallelVigraRfLazyflowClassifierFactory(LazyflowVectorwiseClassifierFacto
             idx = random.sample(list(range(X.shape[0])), row_num)
             X = X[idx, :]
             y = y[idx]
-            assert (numpy.unique(y) == known_labels).all(), (
+            assert (vigra.analysis.unique(y) == known_labels).all(), (
                 "Sampled labels are not representative of the complete set: some label values are missing!\n"
-                "Sampled labels include {}, but complete set has {}".format(numpy.unique(y), known_labels)
+                "Sampled labels include {}, but complete set has {}".format(vigra.analysis.unique(y), known_labels)
             )
 
         # Create N forests to train

--- a/tests/test_ilastik/test_applets/conservationTracking/testConservationTrackingHeadless.py
+++ b/tests/test_ilastik/test_applets/conservationTracking/testConservationTrackingHeadless.py
@@ -114,7 +114,9 @@ class TestConservationTrackingHeadless(object):
             shape = f["exported_data"].shape
             assert shape == self.EXPECTED_SHAPE, "Exported data has wrong shape: {}".format(shape)
             data = f["exported_data"][()]
-            assert len(np.unique(data)) == self.EXPECTED_NUM_LINEAGES + 1  # background also shows up, hence + 1
+            assert (
+                len(vigra.analysis.unique(data)) == self.EXPECTED_NUM_LINEAGES + 1
+            )  # background also shows up, hence + 1
 
     @timeLogged(logger)
     def testCSVExport(self):
@@ -178,7 +180,7 @@ class TestConservationTrackingHeadless(object):
         # check that ids are starting at 1 and are consecutive
         assert np.all(np.sort(a[:, 0]) == np.arange(1, 6))
         # check that parent IDs are present in tracks or zero
-        parents = np.unique(a[:, 3])
+        parents = vigra.analysis.unique(a[:, 3])
         for p in parents:
             assert p == 0 or p in a[:, 0], "Parent is invalid track ID"
 
@@ -191,7 +193,7 @@ class TestConservationTrackingHeadless(object):
         # check that the first frame contains consecutive trackIDs starting at 1, where 0 is background
         imagePath = os.path.join(self.input_data_path, "smallVideo-data_CellTrackingChallenge", "mask000.tif")
         image = vigra.impex.readImage(imagePath, dtype=np.uint32)
-        assert set(np.unique(image)) == set(
+        assert set(vigra.analysis.unique(image)) == set(
             range(image.max() + 1)
         ), "First frame does not contain consecutive IDs starting at 1!"
 

--- a/tests/test_ilastik/test_applets/thresholdTwoLevels/testOpLabeledThreshold.py
+++ b/tests/test_ilastik/test_applets/thresholdTwoLevels/testOpLabeledThreshold.py
@@ -55,7 +55,7 @@ class TestOpLabeledThreshold(object):
 
         result = op.Output[:].wait()
 
-        label_values = np.unique(result)[1:]
+        label_values = vigra.analysis.unique(result)[1:]
         assert len(label_values) == 1
 
         expected_result = np.where(data, label_values[0], 0)
@@ -81,10 +81,10 @@ class TestOpLabeledThreshold(object):
         result_yx = result[0, :, :, 0, 0]
         # print result_yx
 
-        label_values = np.unique(result)[1:]
+        label_values = vigra.analysis.unique(result)[1:]
         assert len(label_values) == 2
-        assert len(np.unique(result_yx[1:6, 1:5])) == 1
-        assert len(np.unique(result_yx[7:12, 1:5])) == 1
+        assert len(vigra.analysis.unique(result_yx[1:6, 1:5])) == 1
+        assert len(vigra.analysis.unique(result_yx[7:12, 1:5])) == 1
 
     def test_graphcut(self):
         if _has_graphcut:
@@ -106,7 +106,9 @@ class TestOpLabeledThreshold(object):
             result_yx = result[0, :, :, 0, 0]
             # print result_yx
 
-            label_values = np.unique(result)[1:]
+            label_values = vigra.analysis.unique(result)[1:]
             assert len(label_values) == 3
-            assert len(np.unique(result_yx[1:12, 1:5])) == 1  # Same as 'simple'
-            assert len(np.unique(result_yx[7:10, 6:9])) == 1  # Almost same as simple, but with the hole filled in.
+            assert len(vigra.analysis.unique(result_yx[1:12, 1:5])) == 1  # Same as 'simple'
+            assert (
+                len(vigra.analysis.unique(result_yx[7:10, 6:9])) == 1
+            )  # Almost same as simple, but with the hole filled in.

--- a/tests/test_ilastik/test_applets/voxelSegmentation/testOpSlic.py
+++ b/tests/test_ilastik/test_applets/voxelSegmentation/testOpSlic.py
@@ -28,7 +28,7 @@ def test_slic(input_data, graph):
         slic_pipeline.add(OpSlic, NumSegments=8)
         seg = slic_pipeline[-1].outputs["Output"][:].wait()
 
-    assert len(np.unique(seg)) == 8
+    assert len(vigra.analysis.unique(seg)) == 8
 
     assert np.all(seg[:10, :11, :13, 0] == 1)
     assert np.all(seg[:10, :11, 13:, 0] == 2)

--- a/tests/test_ilastik/test_workflows/carving/testCarvingTools.py
+++ b/tests/test_ilastik/test_workflows/carving/testCarvingTools.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy
 import fastfilters
+import vigra
 
 
 class TestCarvingTools(unittest.TestCase):
@@ -61,7 +62,7 @@ class TestCarvingTools(unittest.TestCase):
         x = numpy.random.rand(*shape).astype("float32")
         seg, _ = watershed_and_agglomerate(x, max_workers=4)
         # we check that there is a reasonable number of unique ids
-        ids = numpy.unique(seg)
+        ids = vigra.analysis.unique(seg)
         assert len(ids) > 5, f"Expected non trivial number of unique ids, got {len(ids)}"
         assert ids[0] == 1, f"Expected ids to start at 1, got {ids[0]}"
 

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -5,13 +5,11 @@ import shutil
 import sys
 import tempfile
 import threading
-import time
 import zipfile
 from pathlib import Path
-from typing import Optional
 
 import h5py
-import numpy
+import vigra
 import pytest
 from elf.evaluation import mean_segmentation_accuracy
 from PyQt5.QtCore import QTimer
@@ -261,7 +259,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             )
             mc_segmentation = opMulticut.Output[:].wait()
 
-            assert numpy.unique(mc_segmentation).shape == (5,)
+            assert vigra.analysis.unique(mc_segmentation).shape == (5,)
             assert mean_segmentation_accuracy(mc_segmentation, mc_segmentation_reference) > 0.98
 
             # Save the project
@@ -458,7 +456,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
             )
             mc_segmentation = opMulticut.Output[:].wait()
 
-            assert numpy.unique(mc_segmentation).shape == (3,)
+            assert vigra.analysis.unique(mc_segmentation).shape == (3,)
             assert mean_segmentation_accuracy(mc_segmentation, mc_segmentation_reference) > 0.98
 
             # Save the project

--- a/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
+++ b/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
@@ -31,6 +31,7 @@ from PyQt5.QtWidgets import QApplication
 
 import h5py
 import numpy
+import vigra
 
 from ilastik.workflows import ObjectClassificationWorkflowPrediction
 from ilastik.applets.dataSelection.opDataSelection import FilesystemDatasetInfo
@@ -205,7 +206,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
             # now get the object count
             n_objects_expected = 23  # including the background object
             output = op_threshold.Output[:].wait()
-            n_objects = len(numpy.unique(output))
+            n_objects = len(vigra.analysis.unique(output))
             assert (
                 n_objects == n_objects_expected
             ), f"Number of objects mismatch, expected {n_objects_expected}, got {n_objects}"


### PR DESCRIPTION
vigra.analysis.unique seems to still be 2x faster than numpy unique. Also replaced the last remaining numpy.bincounts.
Some additional black formatting...

Closes #1200

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
