### PR TITLE
Stop using mamba

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -21,14 +21,14 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          miniforge-version: latest
+          conda-solver: libmamba
       - name: install xvfb/deps
         run: |
           sudo apt-get update
           sudo apt-get install -yy libgl1-mesa-dev xvfb curl
       - name: install common conda dependencies
-        run: mamba install -n base -c conda-forge mamba boa setuptools_scm -y
+        run: conda install -n base -c conda-forge boa setuptools_scm -y
       - uses: actions/cache@v4
         with:
           path: |
@@ -84,15 +84,15 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          miniforge-version: latest
+          conda-solver: libmamba
       - name: install xvfb/deps
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -yy mesa-utils libgl1-mesa-dev xvfb curl
       - name: install common conda dependencies
-        run: mamba install -n base -c conda-forge boa setuptools_scm -y
+        run: conda install -n base -c conda-forge boa setuptools_scm -y
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          miniforge-version: latest
+          conda-solver: libmamba
       - name: install build dependencies
         run: |
           conda install -n base -c conda-forge boa setuptools_scm anaconda-client -y

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The following text equips you with knowledge that makes contributing to ilastik 
 
 ## Development Environment
 
-1. Download and install [Git][git], [GitHub CLI][github-cli], and _the latest 64-bit_ [Mambaforge][mambaforge].
+1. Download and install [Git][git], [GitHub CLI][github-cli], and _the latest 64-bit_ [Miniforge][miniforge].
    - Windows: all following commands should be executed in the _Anaconda Prompt_ from the Start Menu.
    - Linux: Git might be already preinstalled, GitHub CLI might be available in your system package manager.
    - macOS: Git is already preinstalled, GitHub CLI is available in [Homebrew][homebrew].
@@ -29,10 +29,12 @@ The following text equips you with knowledge that makes contributing to ilastik 
    gh repo clone ilastik
    ```
 
-1. If you have an existing [Miniconda][miniconda] installation, you can use it for ilastik development, but install [Mamba][mamba] and configure conda to use [strict channel priority][strict-channel-priority]:
+1. If you have an existing [Miniconda][miniconda] installation, you can use it for ilastik development, but configure conda to use [strict channel priority][strict-channel-priority]. If your conda version is older than 23.10.0, make sure install `mamba`, and for all following steps, run the commands with "`mamba`" instead of "`conda`" (or consider updating conda instead):
 
    ```
    conda config --set channel_priority strict
+
+   conda --version  # If below 23.10.0, install mamba, and use mamba instead of conda for all further steps:
    conda install --name base --channel conda-forge mamba
    ```
 
@@ -40,9 +42,9 @@ The following text equips you with knowledge that makes contributing to ilastik 
 
    ```
    # from within the ilastik folder
-   mamba deactivate
-   mamba env remove --name ilastik
-   mamba env create --name ilastik --file dev/environment-dev.yml
+   conda deactivate
+   conda env remove --name ilastik
+   conda env create --name ilastik --file dev/environment-dev.yml
    ```
 
 1. Install repositories as packages in development mode:
@@ -71,7 +73,7 @@ The following text equips you with knowledge that makes contributing to ilastik 
 1. Launch ilastik:
 
    ```
-   mamba activate ilastik
+   conda activate ilastik
    cd ilastik
    python ilastik_scripts/ilastik_startup.py
    ```
@@ -157,11 +159,10 @@ But please run those tools on the code you are contributing :)
 [git]: https://git-scm.com/
 [github-cli]: https://cli.github.com/
 [miniconda]: https://docs.conda.io/en/latest/miniconda.html
-[mambaforge]: https://github.com/conda-forge/miniforge#mambaforge
 [homebrew]: https://brew.sh/
 [conda-build]: https://docs.conda.io/projects/conda-build/en/latest/
 [conda-develop]: https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html
-[mamba]: https://mamba.readthedocs.io/en/latest/
+[miniforge]: https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3
 [ilastik]: https://github.com/ilastik/ilastik
 [volumina]: https://github.com/ilastik/volumina
 [github-flow]: https://guides.github.com/introduction/flow/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,10 @@ The following text equips you with knowledge that makes contributing to ilastik 
    gh repo clone ilastik
    ```
 
-1. If you have an existing [Miniconda][miniconda] installation, you can use it for ilastik development, but configure conda to use [strict channel priority][strict-channel-priority]. If your conda version is older than 23.10.0, make sure install `mamba`, and for all following steps, run the commands with "`mamba`" instead of "`conda`" (or consider updating conda instead):
+1. If you have an existing conda installation, you can use it for ilastik development, but configure it to use [strict channel priority][strict-channel-priority].
 
    ```
    conda config --set channel_priority strict
-
-   conda --version  # If below 23.10.0, install mamba, and use mamba instead of conda for all further steps:
-   conda install --name base --channel conda-forge mamba
    ```
 
 1. Create a new environment and install dependencies:
@@ -158,7 +155,6 @@ But please run those tools on the code you are contributing :)
 
 [git]: https://git-scm.com/
 [github-cli]: https://cli.github.com/
-[miniconda]: https://docs.conda.io/en/latest/miniconda.html
 [homebrew]: https://brew.sh/
 [conda-build]: https://docs.conda.io/projects/conda-build/en/latest/
 [conda-develop]: https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html

--- a/Readme.md
+++ b/Readme.md
@@ -37,10 +37,10 @@ If you don't have a dataset to work with, download one of the example projects t
 ### Conda installation (experimental)
 
 ilastik is also available as a conda package on our `ilastik-forge` conda channel.
-We recommend using [mamba][mamba] instead of conda, for faster installation:
+You can install it from the commandline using [conda][conda]:
 
 ```bash
-mamba create -n ilastik --override-channels -c pytorch -c ilastik-forge -c conda-forge ilastik
+conda create -n ilastik --override-channels -c pytorch -c ilastik-forge -c conda-forge ilastik
 
 # activate ilastik environment and start ilastik
 conda activate ilastik
@@ -99,4 +99,4 @@ For more complex changes, see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 [imagesc-search]: https://forum.image.sc/search
 [issues]: https://github.com/ilastik/ilastik/issues
 [edit-files-on-github]: https://docs.github.com/en/free-pro-team@latest/github/managing-files-in-a-repository/editing-files-in-another-users-repository
-[mamba]: https://github.com/mamba-org/mamba
+[conda]: https://github.com/conda-forge/miniforge?tab=readme-ov-file#miniforge3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,12 @@ install:
         }
   - cmd: set PATH=%MINIFORGE%;%MINIFORGE%\Scripts;%MINIFORGE%\Library\bin;%PATH%
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority strict
-  - cmd: conda update -n base -c conda-forge conda mamba
-  - cmd: mamba install -n base -c conda-forge setuptools_scm
+  - cmd: conda update -n base -c conda-forge conda
+  - cmd: conda install -n base -c conda-forge setuptools_scm
   - |
-    mamba env create --name %ENV_NAME% --file dev\environment-dev.yml
-    mamba install --name %ENV_NAME% --freeze-installed -c ilastik-forge -c conda-forge volumina
-    mamba run -n %ENV_NAME% pip install -e .
+    conda env create --name %ENV_NAME% --file dev\environment-dev.yml
+    conda install --name %ENV_NAME% --freeze-installed -c ilastik-forge -c conda-forge volumina
+    conda run -n %ENV_NAME% pip install -e .
   - conda clean -p
 
 build: off

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -116,7 +116,7 @@ outputs:
       run:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
-        - pytorch >=1.6
+        - pytorch >=1.6,!=2.4.1
         - tiktorch 23.11.0*
         - torchvision
         - volumina
@@ -168,7 +168,7 @@ outputs:
       run:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
-        - pytorch >=1.6
+        - pytorch >=1.6,!=2.4.1
         - tiktorch 23.11.0*
         - torchvision
         - pytorch-cuda

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -53,7 +53,7 @@ dependencies:
   # can be changed to request gpu versions
   # pytorch 2.4.* will work for all platforms except osx-64, where currently the
   # latest version is 2.2.2
-  - pytorch 2.4.*
+  - pytorch 2.4.*,!=2.4.1
   - cpuonly  # comment out for pytorch with cuda
   # mamba does not "respect" track_features, which is the idea behind cpuonly,
   # with ilastik-pytorch-version-helper-cpu we help mamba on linux and windows

--- a/notebooks/Readme.md
+++ b/notebooks/Readme.md
@@ -12,26 +12,26 @@ notebooks/
 ├── ...
 ```
 
-We use _mamba/(conda)_ for Python-based projects and recommend it for scientific Python development.
-It is assumed that you have already installed _mamba_ and are familiar with using a Terminal.
+We use _conda_ for Python-based projects and recommend it for scientific Python development.
+It is assumed that you have already installed _conda_ and are familiar with using a Terminal.
 
 In order to run the notebook type the following in a Terminal/Command Line:
 
-Note: mamba has to be configured with [_strict channel priority_](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority) in order to produce consistent environments.
+Note: conda has to be configured with [_strict channel priority_](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority) in order to produce consistent environments.
 
 
 ```bash
 # make sure to use strict channel priority - this setting is global but in general a good idea
-mamba config --set channel_priority strict
+conda config --set channel_priority strict
 
 # create n environment - make sure to choose an appropriate <environment_name>
-$ mamba env create -n <environment_name> -f environment.yml
+$ conda env create -n <environment_name> -f environment.yml
 # this will produce a lot of output
 
-$ mamba activate <environment_name>
+$ conda activate <environment_name>
 
 # start the notebook server in the current folder
 $ jupyter notebook --notebook-dir .
 
-# to close the server hit `ctrl + c` in the terminal shut down the server by confirming with `y` 
+# to close the server hit `ctrl + c` in the terminal shut down the server by confirming with `y`
 ```


### PR DESCRIPTION
mamba is officially deprecated since July, and now it throws ugly warnings when you use it.

More places where this should be replaced, and contributing.md to be updated, but already pushing to test CI