### PR TITLE
Export to OME-Zarr

### DIFF
--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -224,7 +224,13 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         datasetInfo = datasetSlot.value
         if not datasetInfo.scales:
             return {}
-        return {key: _dims_to_display_string(dims, datasetInfo.axiskeys) for key, dims in datasetInfo.scales.items()}
+        # Reverse the scale list:
+        # Multiscale datasets always list scales from original (largest) to most-downscaled (smallest).
+        # We want to display them in the opposite order.
+        return {
+            key: _dims_to_display_string(dims, datasetInfo.axiskeys)
+            for key, dims in reversed(datasetInfo.scales.items())
+        }
 
     def is_scale_locked(self, laneIndex) -> bool:
         datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -18,7 +18,7 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from typing import List, Dict
+from typing import Dict
 
 from PyQt5.QtCore import Qt, QAbstractItemModel, QModelIndex
 from ilastik.utility import bind
@@ -37,11 +37,10 @@ class DatasetColumn:
     NumColumns = 6
 
 
-def _dims_to_display_string(dimensions: List[int], axiskeys: str) -> str:
-    """Generate labels to put into the scale combobox.
-    Scale dimensions must be in xyz and will be reordered to match axiskeys."""
-    input_axes = dict(zip("xyz", dimensions))
-    reordered_dimensions = [input_axes[axis] for axis in axiskeys if axis in input_axes]
+def _dims_to_display_string(dimensions: Dict[str, int], axiskeys: str) -> str:
+    """Generate labels to put into the scale combobox / to display in the table.
+    XYZ dimensions will be reordered to match axiskeys."""
+    reordered_dimensions = [dimensions[axis] for axis in axiskeys if axis in "xyz"]
     return ", ".join(str(size) for size in reordered_dimensions)
 
 
@@ -228,8 +227,8 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         # Multiscale datasets always list scales from original (largest) to most-downscaled (smallest).
         # We want to display them in the opposite order.
         return {
-            key: _dims_to_display_string(dims, datasetInfo.axiskeys)
-            for key, dims in reversed(datasetInfo.scales.items())
+            key: _dims_to_display_string(tagged_shape, datasetInfo.axiskeys)
+            for key, tagged_shape in reversed(datasetInfo.scales.items())
         }
 
     def is_scale_locked(self, laneIndex) -> bool:

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -223,9 +223,9 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         datasetInfo = datasetSlot.value
         if not datasetInfo.scales:
             return {}
-        # Reverse the scale list:
         # Multiscale datasets always list scales from original (largest) to most-downscaled (smallest).
-        # We want to display them in the opposite order.
+        # We display them in reverse order so that the default loaded scale (the smallest)
+        # is the first option in the drop-down box
         return {
             key: _dims_to_display_string(tagged_shape, datasetInfo.axiskeys)
             for key, tagged_shape in reversed(datasetInfo.scales.items())

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -128,7 +128,7 @@ class DatasetInfo(ABC):
         self.legacy_datasetId = self.generate_id()
         self.working_scale = working_scale
         self.scale_locked = scale_locked
-        self.scales = OrderedDict()  # {scale_key: scale_dimensions}, see MultiscaleStore.multiscales
+        self.scales = OrderedDict()  # {scale_key: tagged_scale_shape}, see MultiscaleStore.multiscales
 
     @property
     def shape5d(self) -> Shape5D:

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -153,7 +153,6 @@ class OpExportSlot(Operator):
             "compressed hdf5",
             "n5",
             "compressed n5",
-            "single-scale OME-Zarr",
         )
         if self.OutputFormat.value in hierarchical_formats and self.OutputInternalPath.value != "":
             path_format += "/" + self.OutputInternalPath.value

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -200,7 +200,6 @@ class OpExportSlot(Operator):
             "npy",
             "blockwise hdf5",
             "single-scale OME-Zarr",
-            "multi-scale OME-Zarr",
         ):
             return ""
 
@@ -415,6 +414,8 @@ class OpExportSlot(Operator):
             self.progressSignal(100)
 
     def _export_ome_zarr(self, compute_downscales: bool = False):
+        if compute_downscales:
+            raise NotImplementedError()
         self.progressSignal(0)
         try:
             write_ome_zarr(self.ExportPath.value, self.Input, self.progressSignal, compute_downscales)

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -150,14 +150,15 @@ class OpExportSlot(Operator):
             path_format += "." + file_extension
 
         # Provide the TOTAL path (including dataset name)
-        if self.OutputFormat.value in (
+        hierarchical_formats = (
             "hdf5",
             "compressed hdf5",
             "n5",
             "compressed n5",
             "single-scale OME-Zarr",
             "multi-scale OME-Zarr",
-        ):
+        )
+        if self.OutputFormat.value in hierarchical_formats and self.OutputInternalPath.value != "":
             path_format += "/" + self.OutputInternalPath.value
 
         roi = numpy.array(roiFromShape(self.Input.meta.shape))

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -412,8 +412,9 @@ class OpExportSlot(Operator):
 
     def _export_ome_zarr(self):
         self.progressSignal(0)
+        offset_meta = self.CoordinateOffset.value if self.CoordinateOffset.ready() else None
         try:
-            write_ome_zarr(self.ExportPath.value, self.Input, self.progressSignal)
+            write_ome_zarr(self.ExportPath.value, self.Input, offset_meta, self.progressSignal)
         finally:
             self.progressSignal(100)
 

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -90,7 +90,6 @@ class OpExportSlot(Operator):
         FormatInfo("n5", "n5", 0, 5),
         FormatInfo("compressed n5", "n5", 0, 5),
         FormatInfo("single-scale OME-Zarr", "zarr", 0, 5),
-        FormatInfo("multi-scale OME-Zarr", "zarr", 0, 5),
         FormatInfo("numpy", "npy", 0, 5),
         FormatInfo("dvid", "", 2, 5),
         FormatInfo("blockwise hdf5", "json", 0, 5),
@@ -108,7 +107,6 @@ class OpExportSlot(Operator):
         export_impls["n5"] = ("n5", self._export_h5n5)
         export_impls["compressed n5"] = ("n5", partial(self._export_h5n5, True))
         export_impls["single-scale OME-Zarr"] = ("zarr", self._export_ome_zarr)
-        export_impls["multi-scale OME-Zarr"] = ("zarr", partial(self._export_ome_zarr, True))
         export_impls["numpy"] = ("npy", self._export_npy)
         export_impls["dvid"] = ("", self._export_dvid)
         export_impls["blockwise hdf5"] = ("json", self._export_blockwise_hdf5)
@@ -156,7 +154,6 @@ class OpExportSlot(Operator):
             "n5",
             "compressed n5",
             "single-scale OME-Zarr",
-            "multi-scale OME-Zarr",
         )
         if self.OutputFormat.value in hierarchical_formats and self.OutputInternalPath.value != "":
             path_format += "/" + self.OutputInternalPath.value
@@ -414,12 +411,10 @@ class OpExportSlot(Operator):
             opExport.cleanUp()
             self.progressSignal(100)
 
-    def _export_ome_zarr(self, compute_downscales: bool = False):
-        if compute_downscales:
-            raise NotImplementedError()
+    def _export_ome_zarr(self):
         self.progressSignal(0)
         try:
-            write_ome_zarr(self.ExportPath.value, self.Input, self.progressSignal, compute_downscales)
+            write_ome_zarr(self.ExportPath.value, self.Input, self.progressSignal)
         finally:
             self.progressSignal(100)
 
@@ -468,7 +463,6 @@ class FormatValidity(object):
         "n5": ALL_DTYPES,
         "compressed n5": ALL_DTYPES,
         "single-scale OME-Zarr": ALL_DTYPES,
-        "multi-scale OME-Zarr": ALL_DTYPES,
     }
 
     # { extension : (min_ndim, max_ndim) }
@@ -490,7 +484,6 @@ class FormatValidity(object):
         "n5": (0, 5),
         "compressed n5": (0, 5),
         "single-scale OME-Zarr": (0, 5),
-        "multi-scale OME-Zarr": (0, 5),
     }
 
     # { extension : [allowed_num_channels] }
@@ -512,7 +505,6 @@ class FormatValidity(object):
         "n5": (),  # ditto
         "compressed n5": (),  # ditto
         "single-scale OME-Zarr": (),
-        "multi-scale OME-Zarr": (),
     }
 
     @classmethod

--- a/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
+++ b/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
@@ -59,6 +59,7 @@ class OpOMEZarrMultiscaleReader(Operator):
         self.Output.meta.dtype = self._store.dtype
         self.Output.meta.axistags = self._store.axistags
         self.Output.meta.scales = self._store.multiscales
+        self.Output.meta.active_scale = active_scale  # Used by export to correlate export with input scale
         # To feed back to DatasetInfo and hence the project file
         self.Output.meta.lowest_scale = self._store.lowest_resolution_key
         # Many public OME-Zarr datasets are chunked as full xy slices,

--- a/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
+++ b/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
@@ -64,6 +64,8 @@ class OpOMEZarrMultiscaleReader(Operator):
         # Many public OME-Zarr datasets are chunked as full xy slices,
         # so orthoviews lead to downloading the entire dataset.
         self.Output.meta.prefer_2d = True
+        # Add OME-Zarr metadata to slot so that it can be ported over to an export
+        self.Output.meta.ome_zarr_meta = self._store.ome_meta_for_export
 
     def execute(self, slot, subindex, roi, result):
         scale = self.Scale.value if self.Scale.ready() and self.Scale.value else self._store.lowest_resolution_key

--- a/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
+++ b/lazyflow/operators/ioOperators/opRESTfulPrecomputedChunkedVolumeReader.py
@@ -63,6 +63,7 @@ class OpRESTfulPrecomputedChunkedVolumeReaderNoCache(Operator):
         self.Output.meta.dtype = numpy.dtype(self._volume_object.dtype).type
         self.Output.meta.axistags = self._volume_object.axistags
         self.Output.meta.scales = self._volume_object.multiscales
+        self.Output.meta.active_scale = active_scale  # Used by export to correlate export with input scale
         # To feed back to DatasetInfo and hence the project file
         self.Output.meta.lowest_scale = self._volume_object.lowest_resolution_key
 

--- a/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
+++ b/lazyflow/operators/ioOperators/opStreamingH5N5Reader.py
@@ -168,6 +168,7 @@ class OpStreamingH5N5Reader(Operator):
             ]
             scales: Multiscales = OrderedDict(zip(scale_keys, scale_tagged_shapes))
             self.OutputImage.meta.scales = scales
+            self.OutputImage.meta.active_scale = scale_key_from_path(internalPath)
             self.OutputImage.meta.lowest_scale = scale_keys[-1]
             self.OutputImage.meta.ome_zarr_meta = OMEZarrMultiscaleMeta.from_multiscale_spec(multiscale_spec)
 

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1528,37 +1528,3 @@ class OutputSlot(Slot):
         super(OutputSlot, self).__init__(*args, **kwargs)
         self._type = "output"
         assert "optional" not in kwargs, '"optional" init arg cannot be used with OutputSlot'
-
-
-class SlotAsNDArray:
-    """Adapter class to provide a numpy-like interface to a Slot.
-    Primarily this means returning data, not Requests, when sliced.
-    As a consequence, this undoes the lazy-loading behavior of the Slot.
-    The intended use is to pass the slot to dask, which then handles the lazy-loading."""
-
-    @property
-    def ndim(self):
-        return len(self.shape)
-
-    @property
-    def dtype(self):
-        return self.slot.meta.dtype
-
-    @property
-    def shape(self):
-        return self.slot.meta.shape
-
-    def __init__(self, slot: Slot):
-        self.slot = slot
-
-    def __getitem__(self, key):
-        request = self.slot[key]
-        return request.wait()
-
-    def __array__(self):
-        # For typing only: Allows instances to match numpy.typing.ArrayLike
-        # If necessary, the implementation should probably just be `return self.slot.value`
-        raise NotImplementedError("Should never be directly converted to an array.")
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self.slot})"

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1528,3 +1528,37 @@ class OutputSlot(Slot):
         super(OutputSlot, self).__init__(*args, **kwargs)
         self._type = "output"
         assert "optional" not in kwargs, '"optional" init arg cannot be used with OutputSlot'
+
+
+class SlotAsNDArray:
+    """Adapter class to provide a numpy-like interface to a Slot.
+    Primarily this means returning data, not Requests, when sliced.
+    As a consequence, this undoes the lazy-loading behavior of the Slot.
+    The intended use is to pass the slot to dask, which then handles the lazy-loading."""
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def dtype(self):
+        return self.slot.meta.dtype
+
+    @property
+    def shape(self):
+        return self.slot.meta.shape
+
+    def __init__(self, slot: Slot):
+        self.slot = slot
+
+    def __getitem__(self, key):
+        request = self.slot[key]
+        return request.wait()
+
+    def __array__(self):
+        # For typing only: Allows instances to match numpy.typing.ArrayLike
+        # If necessary, the implementation should probably just be `return self.slot.value`
+        raise NotImplementedError("Should never be directly converted to an array.")
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.slot})"

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -184,10 +184,10 @@ class OMEZarrStore(MultiscaleStore):
             datasets = datasets[:1]  # One scale is enough to get dtype
         for scale in datasets:  # OME-Zarr spec requires datasets ordered from high to low resolution
             with Timer() as timer:
-                scale_key = scale["path"]
-                # Loading a ZarrArray at this path is necessary to obtain the scale dimensions for the GUI.
-                # As a bonus, this also validates all scale["path"] strings passed outside this class.
-                zarray = ZarrArray(store=self._store, path=scale_key)
+                scale_path = scale["path"]
+                scale_key = scale_path.split("/")[-1]
+                # Loading a ZarrArray at this path is necessary to obtain the scale dimensions for the GUI
+                zarray = ZarrArray(store=self._store, path=scale_path)
                 dtype = zarray.dtype.type
                 scale_metadata[scale_key] = OrderedDict(zip([tag.key for tag in axistags], zarray.shape))
                 self._scale_data[scale_key] = {
@@ -200,8 +200,8 @@ class OMEZarrStore(MultiscaleStore):
             dtype=dtype,
             axistags=axistags,
             multiscales=scale_metadata,
-            lowest_resolution_key=datasets[-1]["path"],
-            highest_resolution_key=datasets[0]["path"],
+            lowest_resolution_key=list(scale_metadata.keys())[-1],
+            highest_resolution_key=list(scale_metadata.keys())[0],
         )
 
     @staticmethod

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -127,7 +127,10 @@ def _get_zarr_cache_max_size() -> int:
     return math.floor(caches_max * permissible_fraction_max)
 
 
-def scale_key_from_path(scale_path):
+def scale_key_from_path(scale_path: str):
+    """Paths in this context are web-paths, i.e. URI components.
+    Backslashes would technically be valid characters in scale keys.
+    Please make sure not to accidentally pass Windows paths here..."""
     return scale_path.split("/")[-1]
 
 

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -178,7 +178,7 @@ class OMEZarrStore(MultiscaleStore):
         axistags = get_axistags_from_spec(multiscale_spec)
         datasets = multiscale_spec["datasets"]
         dtype = None
-        gui_scale_metadata = OrderedDict()  # Becomes slot metadata -> must be serializable (no ZarrArray allowed)
+        scale_metadata = OrderedDict()  # Becomes slot metadata -> must be serializable (no ZarrArray allowed)
         self._scale_data = {}
         if single_scale_mode:
             datasets = datasets[:1]  # One scale is enough to get dtype
@@ -189,7 +189,7 @@ class OMEZarrStore(MultiscaleStore):
                 # As a bonus, this also validates all scale["path"] strings passed outside this class.
                 zarray = ZarrArray(store=self._store, path=scale_key)
                 dtype = zarray.dtype.type
-                gui_scale_metadata[scale_key] = list(zarray.shape[-1:-4:-1])  # xyz
+                scale_metadata[scale_key] = OrderedDict(zip([tag.key for tag in axistags], zarray.shape))
                 self._scale_data[scale_key] = {
                     "zarray": zarray,
                     "chunks": zarray.chunks,
@@ -199,7 +199,7 @@ class OMEZarrStore(MultiscaleStore):
         super().__init__(
             dtype=dtype,
             axistags=axistags,
-            multiscales=gui_scale_metadata,
+            multiscales=scale_metadata,
             lowest_resolution_key=datasets[-1]["path"],
             highest_resolution_key=datasets[0]["path"],
         )

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -196,8 +196,6 @@ class OMEZarrStore(MultiscaleStore):
                     "shape": zarray.shape,
                 }
                 logger.info(f"Initializing scale {scale_key} took {timer.seconds()*1000} ms.")
-        # Reverse so that GUI displays from low to high resolution
-        gui_scale_metadata = OrderedDict(reversed(list(gui_scale_metadata.items())))
         super().__init__(
             dtype=dtype,
             axistags=axistags,

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -68,7 +68,7 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
                     "type": "object",
                     "properties": {
                         "key": {"type": "string"},
-                        "resolution": {"type": "array", "items": {"type": "number"}},
+                        "size": {"type": "array", "items": {"type": "number"}},
                     },
                 },
             },
@@ -98,11 +98,20 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
         # Scales are ordered from original to most-downscaled in Precomputed spec
         lowest_resolution_key = self._json_info["scales"][-1]["key"]
         highest_resolution_key = self._json_info["scales"][0]["key"]
-        gui_scale_metadata = OrderedDict([(scale["key"], scale["resolution"]) for scale in self._json_info["scales"]])
         self._scales = {scale["key"]: scale for scale in self._json_info["scales"]}
         self.n_channels = self._json_info["num_channels"]
+        scale_shapes = [
+            OrderedDict(zip("czyx", [self.n_channels] + scale["size"])) for scale in self._json_info["scales"]
+        ]
+        scale_metadata = OrderedDict(zip(self._scales.keys(), scale_shapes))
 
-        super().__init__(dtype, axistags, gui_scale_metadata, lowest_resolution_key, highest_resolution_key)
+        super().__init__(
+            dtype=dtype,
+            axistags=axistags,
+            multiscales=scale_metadata,
+            lowest_resolution_key=lowest_resolution_key,
+            highest_resolution_key=highest_resolution_key,
+        )
 
     @staticmethod
     def is_uri_compatible(uri: str) -> bool:

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -98,10 +98,7 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
         # Scales are ordered from original to most-downscaled in Precomputed spec
         lowest_resolution_key = self._json_info["scales"][-1]["key"]
         highest_resolution_key = self._json_info["scales"][0]["key"]
-        # Reverse so that the ScaleComboBox shows the options ordered from most-downscaled to original
-        gui_scale_metadata = OrderedDict(
-            [(scale["key"], scale["resolution"]) for scale in reversed(self._json_info["scales"])]
-        )
+        gui_scale_metadata = OrderedDict([(scale["key"], scale["resolution"]) for scale in self._json_info["scales"]])
         self._scales = {scale["key"]: scale for scale in self._json_info["scales"]}
         self.n_channels = self._json_info["num_channels"]
 

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -101,7 +101,7 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
         self._scales = {scale["key"]: scale for scale in self._json_info["scales"]}
         self.n_channels = self._json_info["num_channels"]
         scale_shapes = [
-            OrderedDict(zip("czyx", [self.n_channels] + scale["size"])) for scale in self._json_info["scales"]
+            OrderedDict(zip("czyx", [self.n_channels] + scale["size"][::-1])) for scale in self._json_info["scales"]
         ]
         scale_metadata = OrderedDict(zip(self._scales.keys(), scale_shapes))
 

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -20,12 +20,13 @@
 ###############################################################################
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from typing import List, Tuple
+from typing import Literal, Tuple
 
 import numpy
 import vigra
 
-
+# See MultiscaleStore docstring for details
+Multiscales = OrderedDict[str, OrderedDict[Literal["t", "c", "z", "y", "x"], int]]
 DEFAULT_SCALE_KEY = ""
 
 
@@ -44,17 +45,18 @@ class MultiscaleStore(metaclass=ABCMeta):
         self,
         dtype: numpy.dtype,
         axistags: vigra.AxisTags,
-        multiscales: OrderedDict[str, List[int]],
+        multiscales: Multiscales,
         lowest_resolution_key: str,
         highest_resolution_key: str,
     ):
         """
         :param dtype: The dataset's numpy dtype.
         :param axistags: vigra.AxisTags describing the dataset's axes.
-        :param multiscales: Dict of scale metadata for GUI/shell/project file.
+        :param multiscales: Dict of scales for GUI and OME-Zarr export, {key: tagged shape}
             Order from highest to lowest resolution (i.e. largest to smallest shape).
-            Keys should be absolute identifiers for each scale as found in the dataset.
-            Values are xyz dimensions (e.g. resolution or shape) of the image at each scale to inform user choice.
+            Keys: absolute identifiers for each scale as found in the dataset.
+            Values: tagged shape dicts ({axis: size}) of the image at each scale.
+            Axis order in shape dicts must match axistags.
         :param lowest_resolution_key: Key of the lowest-resolution scale within the multiscales dict.
             This acts as the default scale after load until the user selects a different one.
         :param highest_resolution_key: Used to infer the maximum dataset size, and for legacy HBP-mode projects.
@@ -64,10 +66,13 @@ class MultiscaleStore(metaclass=ABCMeta):
         self.multiscales = multiscales
         self.lowest_resolution_key = lowest_resolution_key
         self.highest_resolution_key = highest_resolution_key
-        keys = list(self.multiscales.keys())
+        scale_keys = list(self.multiscales.keys())
         assert (
-            self.highest_resolution_key == keys[0] and self.lowest_resolution_key == keys[-1]
+            self.highest_resolution_key == scale_keys[0] and self.lowest_resolution_key == scale_keys[-1]
         ), "Multiscales dict must be ordered from highest to lowest resolution (i.e. largest to smallest shape)"
+        assert all(
+            list(scale_shape.keys()) == axistags.keys() for scale_shape in self.multiscales.values()
+        ), "Multiscales values must be shape dicts for the given axistags"
 
     @abstractmethod
     def get_shape(self, scale_key: str) -> Tuple[int]:

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -52,7 +52,7 @@ class MultiscaleStore(metaclass=ABCMeta):
         :param dtype: The dataset's numpy dtype.
         :param axistags: vigra.AxisTags describing the dataset's axes.
         :param multiscales: Dict of scale metadata for GUI/shell/project file.
-            Order as the scales should appear when displayed to the user.
+            Order from highest to lowest resolution (i.e. largest to smallest shape).
             Keys should be absolute identifiers for each scale as found in the dataset.
             Values are xyz dimensions (e.g. resolution or shape) of the image at each scale to inform user choice.
         :param lowest_resolution_key: Key of the lowest-resolution scale within the multiscales dict.
@@ -65,9 +65,9 @@ class MultiscaleStore(metaclass=ABCMeta):
         self.lowest_resolution_key = lowest_resolution_key
         self.highest_resolution_key = highest_resolution_key
         keys = list(self.multiscales.keys())
-        assert (self.lowest_resolution_key == keys[0] and self.highest_resolution_key == keys[-1]) or (
-            self.lowest_resolution_key == keys[-1] and self.highest_resolution_key == keys[0]
-        ), "Lowest and highest resolution keys must be at the extremes of the multiscales dict."
+        assert (
+            self.highest_resolution_key == keys[0] and self.lowest_resolution_key == keys[-1]
+        ), "Multiscales dict must be ordered from highest to lowest resolution (i.e. largest to smallest shape)"
 
     @abstractmethod
     def get_shape(self, scale_key: str) -> Tuple[int]:

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -7,7 +7,7 @@ from typing import List, Tuple, Dict, Optional, OrderedDict
 
 import numpy
 import zarr
-from zarr.storage import FSStore
+from zarr.storage import FSStore, contains_array
 
 from ilastik import __version__ as ilastik_version
 from lazyflow.operators import OpReorderAxes
@@ -150,6 +150,9 @@ def _compute_and_write_scales(
     for i, scaling in enumerate(scalings):
         scale_path = f"{internal_path}/s{i}" if internal_path else f"s{i}"
         scaled_shape = _scale_tagged_shape(image_source_slot.meta.getTaggedShape(), scaling).values()
+        if contains_array(store, scale_path):
+            logger.warning(f"Deleting existing dataset at {external_path}/{scale_path}.")
+            del store[scale_path]
         zarrays.append(
             zarr.creation.empty(
                 scaled_shape, store=store, path=scale_path, chunks=chunk_shape, dtype=image_source_slot.meta.dtype

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -1,93 +1,76 @@
 import logging
-from typing import List, Literal
+from typing import List, Literal, Optional, Tuple
 
 import ngff_zarr
 import numpy
-
-from lazyflow.operators import OpReorderAxes
-from lazyflow.roi import determineBlockShape, roiToSlice, roiFromShape
-from lazyflow.slot import Slot, SlotAsNDArray
-from lazyflow.utility import BigRequestStreamer, OrderedSignal, PathComponents
+import zarr
 from zarr.storage import FSStore
 
+from lazyflow.operators import OpReorderAxes
+from lazyflow.roi import determineBlockShape
+from lazyflow.slot import Slot, SlotAsNDArray
+from lazyflow.utility import OrderedSignal, PathComponents
 from lazyflow.utility.io_util.OMEZarrStore import OME_ZARR_V_0_4_KWARGS
 
 logger = logging.getLogger(__name__)
 
 
-def write_ome_zarr(export_path: str, image_source_slot: Slot, progress_signal: OrderedSignal):
-    export_path = PathComponents(export_path)
+def _get_chunk_shape(image_source_slot) -> Tuple[int, ...]:
+    """Determine chunk shape for OME-Zarr storage based on image source slot.
+    Chunk size is 1 for t and c, and determined by ilastik default rules for zyx, with a target of 512KB per chunk."""
+    dtype = image_source_slot.meta.dtype
+    if isinstance(dtype, numpy.dtype):  # Extract raw type class
+        dtype = dtype.type
+    dtype_bytes = dtype().nbytes
+    tagged_maxshape = image_source_slot.meta.getTaggedShape()
+    tagged_maxshape["t"] = 1
+    tagged_maxshape["c"] = 1
+    chunk_shape = determineBlockShape(list(tagged_maxshape.values()), 512_000.0 / dtype_bytes)
+    return chunk_shape
+
+
+def write_ome_zarr(
+    export_path: str,
+    image_source_slot: Slot,
+    progress_signal: OrderedSignal,
+    downscale_method: Optional[ngff_zarr.methods.Methods] = None,
+):
+    pc = PathComponents(export_path)
+    external_path = pc.externalPath
+    internal_path = pc.internalPath
+
     op_reorder = OpReorderAxes(parent=image_source_slot.operator)
     op_reorder.AxisOrder.setValue("tczyx")  # OME-Zarr convention
     try:
         op_reorder.Input.connect(image_source_slot)
+        image_source = SlotAsNDArray(op_reorder.Output)
+        chunk_shape = _get_chunk_shape(op_reorder.Output)
         dims: List[Literal["t", "c", "z", "y", "x"]] = list(op_reorder.Output.meta.axistags.keys())
         scale = {k: 1.0 for k in dims}
         translation = {k: 0.0 for k in dims}
-        image_source = SlotAsNDArray(op_reorder.Output)
-        image = ngff_zarr.to_ngff_image(image_source, dims=dims, scale=scale, translation=translation)
+        image = ngff_zarr.to_ngff_image(
+            image_source, name=internal_path or "image", dims=dims, scale=scale, translation=translation
+        )
+        progress_signal(25)
+        multiscales = ngff_zarr.to_multiscales(image, scale_factors=2, chunks=chunk_shape, method=downscale_method)
         progress_signal(50)
-
-        multiscales = ngff_zarr.to_multiscales(image, scale_factors=2, chunks=64)
-        store = FSStore(export_path.externalPath, mode="w", **OME_ZARR_V_0_4_KWARGS)
-        ngff_zarr.to_ngff_zarr(store, multiscales)
-        print(export_path.externalPath)
-        print(multiscales)
+        store = FSStore(external_path, mode="w", **OME_ZARR_V_0_4_KWARGS)
+        ngff_zarr.to_ngff_zarr(store, multiscales, overwrite=False)
+        # Write ilastik metadata
+        for image in multiscales.images:
+            # ngff-zarr does not record the storage path in the image object, so we have to look it up.
+            # The only way we can know that a metadata entry corresponds to this image is the scale factor.
+            dataset = None
+            for d in multiscales.metadata.datasets:
+                scale_transforms = [t for t in d.coordinateTransformations if t.type == "scale"]
+                dataset_scale_factors = scale_transforms[0].scale  # Should only be one
+                if all(image_scale_factor in dataset_scale_factors for image_scale_factor in image.scale.values()):
+                    dataset = d
+                    break
+            assert dataset is not None, f"Could not find metadata for image, must be an error in to_ngff_zarr. {image=}"
+            za = zarr.Array(store, path=dataset.path)
+            za.attrs["axistags"] = op_reorder.Output.meta.axistags.toJSON()
+            za.attrs["display_mode"] = image_source_slot.meta.display_mode
+            za.attrs["drange"] = image_source_slot.meta.get("drange")
     finally:
         op_reorder.cleanUp()
-    return
-    # h5N5GroupName, datasetName = os.path.split(h5N5Path)
-    # if h5N5GroupName == "":
-    #     g = self.f
-    # else:
-    #     if h5N5GroupName in self.f:
-    #         g = self.f[h5N5GroupName]
-    #     else:
-    #         g = self.f.create_group(h5N5GroupName)
-
-    data_shape = image_source_slot.meta.shape
-    logger.info(f"Data shape: {data_shape}")
-
-    dtype = image_source_slot.meta.dtype
-    if isinstance(dtype, numpy.dtype):
-        # Make sure we're dealing with a type (e.g. numpy.float64),
-        # not a numpy.dtype
-        dtype = dtype.type
-    # Set up our chunk shape: Aim for a cube that's roughly 512k in size
-    dtypeBytes = dtype().nbytes
-
-    tagged_maxshape = image_source_slot.meta.getTaggedShape()
-    if "t" in tagged_maxshape:
-        # Assume that chunks should not span multiple t-slices,
-        # and channels are often handled separately, too.
-        tagged_maxshape["t"] = 1
-
-    if "c" in tagged_maxshape:
-        tagged_maxshape["c"] = 1
-
-    chunkShape = determineBlockShape(list(tagged_maxshape.values()), 512_000.0 / dtypeBytes)
-
-    # if datasetName in list(g.keys()):
-    #     del g[datasetName]
-    kwargs = {"shape": data_shape, "dtype": dtype, "chunks": chunkShape}
-
-    # self.d = g.create_dataset(datasetName, **kwargs)
-
-    progress_signal(0)
-
-    display_mode = image_source_slot.meta.display_mode
-    axistags = image_source_slot.meta.axistags.toJSON()
-    neuroglancer_axes = "".join(tag.key for tag in image_source_slot.meta.axistags)[::-1]
-    drange = image_source_slot.meta.get("drange")
-
-    def handle_block_result(roi, data):
-        slicing = roiToSlice(*roi)
-        if data.flags.c_contiguous:
-            self.d.write_direct(data.view(numpy.ndarray), dest_sel=slicing)
-        else:
-            self.d[slicing] = data
-
-    requester = BigRequestStreamer(image_source_slot, roiFromShape(data_shape))
-    requester.resultSignal.subscribe(handle_block_result)
-    requester.progressSignal.subscribe(progress_signal)
-    requester.execute()

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -351,7 +351,7 @@ def _write_ome_zarr_and_ilastik_metadata(
 
     axes = [{"name": a, "type": axis_types[a]} for a in export_axiskeys]
     datasets = _get_datasets_meta(export_meta, input_ome_meta, scalings_relative_to_raw_input)
-    ome_zarr_multiscale_meta = {"_creator": ilastik_signature, "version": "0.4", "axes": axes, "datasets": datasets}
+    ome_zarr_multiscale_meta = {"axes": axes, "datasets": datasets, "version": "0.4"}
 
     # Optional fields
     if multiscale_name:
@@ -374,6 +374,7 @@ def _write_ome_zarr_and_ilastik_metadata(
 
     store = FSStore(external_path, mode="w", **OME_ZARR_V_0_4_KWARGS)
     root = zarr.group(store, overwrite=False)
+    root.attrs["_creator"] = ilastik_signature
     root.attrs["multiscales"] = [ome_zarr_multiscale_meta]
     for image in export_meta.values():
         za = zarr.Array(store, path=image.path)

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -1,3 +1,24 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+# 		   http://ilastik.org/license/
+###############################################################################
 import dataclasses
 import logging
 from collections import OrderedDict as ODict
@@ -7,7 +28,7 @@ from typing import List, Tuple, Dict, OrderedDict, Optional, Literal
 
 import numpy
 import zarr
-from zarr.storage import FSStore, contains_array
+from zarr.storage import FSStore
 
 from ilastik import __version__ as ilastik_version
 from lazyflow.operators import OpReorderAxes

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -1,0 +1,93 @@
+import logging
+from typing import List, Literal
+
+import ngff_zarr
+import numpy
+
+from lazyflow.operators import OpReorderAxes
+from lazyflow.roi import determineBlockShape, roiToSlice, roiFromShape
+from lazyflow.slot import Slot, SlotAsNDArray
+from lazyflow.utility import BigRequestStreamer, OrderedSignal, PathComponents
+from zarr.storage import FSStore
+
+from lazyflow.utility.io_util.OMEZarrStore import OME_ZARR_V_0_4_KWARGS
+
+logger = logging.getLogger(__name__)
+
+
+def write_ome_zarr(export_path: str, image_source_slot: Slot, progress_signal: OrderedSignal):
+    export_path = PathComponents(export_path)
+    op_reorder = OpReorderAxes(parent=image_source_slot.operator)
+    op_reorder.AxisOrder.setValue("tczyx")  # OME-Zarr convention
+    try:
+        op_reorder.Input.connect(image_source_slot)
+        dims: List[Literal["t", "c", "z", "y", "x"]] = list(op_reorder.Output.meta.axistags.keys())
+        scale = {k: 1.0 for k in dims}
+        translation = {k: 0.0 for k in dims}
+        image_source = SlotAsNDArray(op_reorder.Output)
+        image = ngff_zarr.to_ngff_image(image_source, dims=dims, scale=scale, translation=translation)
+        progress_signal(50)
+
+        multiscales = ngff_zarr.to_multiscales(image, scale_factors=2, chunks=64)
+        store = FSStore(export_path.externalPath, mode="w", **OME_ZARR_V_0_4_KWARGS)
+        ngff_zarr.to_ngff_zarr(store, multiscales)
+        print(export_path.externalPath)
+        print(multiscales)
+    finally:
+        op_reorder.cleanUp()
+    return
+    # h5N5GroupName, datasetName = os.path.split(h5N5Path)
+    # if h5N5GroupName == "":
+    #     g = self.f
+    # else:
+    #     if h5N5GroupName in self.f:
+    #         g = self.f[h5N5GroupName]
+    #     else:
+    #         g = self.f.create_group(h5N5GroupName)
+
+    data_shape = image_source_slot.meta.shape
+    logger.info(f"Data shape: {data_shape}")
+
+    dtype = image_source_slot.meta.dtype
+    if isinstance(dtype, numpy.dtype):
+        # Make sure we're dealing with a type (e.g. numpy.float64),
+        # not a numpy.dtype
+        dtype = dtype.type
+    # Set up our chunk shape: Aim for a cube that's roughly 512k in size
+    dtypeBytes = dtype().nbytes
+
+    tagged_maxshape = image_source_slot.meta.getTaggedShape()
+    if "t" in tagged_maxshape:
+        # Assume that chunks should not span multiple t-slices,
+        # and channels are often handled separately, too.
+        tagged_maxshape["t"] = 1
+
+    if "c" in tagged_maxshape:
+        tagged_maxshape["c"] = 1
+
+    chunkShape = determineBlockShape(list(tagged_maxshape.values()), 512_000.0 / dtypeBytes)
+
+    # if datasetName in list(g.keys()):
+    #     del g[datasetName]
+    kwargs = {"shape": data_shape, "dtype": dtype, "chunks": chunkShape}
+
+    # self.d = g.create_dataset(datasetName, **kwargs)
+
+    progress_signal(0)
+
+    display_mode = image_source_slot.meta.display_mode
+    axistags = image_source_slot.meta.axistags.toJSON()
+    neuroglancer_axes = "".join(tag.key for tag in image_source_slot.meta.axistags)[::-1]
+    drange = image_source_slot.meta.get("drange")
+
+    def handle_block_result(roi, data):
+        slicing = roiToSlice(*roi)
+        if data.flags.c_contiguous:
+            self.d.write_direct(data.view(numpy.ndarray), dest_sel=slicing)
+        else:
+            self.d[slicing] = data
+
+    requester = BigRequestStreamer(image_source_slot, roiFromShape(data_shape))
+    requester.resultSignal.subscribe(handle_block_result)
+    requester.progressSignal.subscribe(progress_signal)
+    requester.execute()

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -178,7 +178,7 @@ def _compute_and_write_scales(
             logger.warning(f"Deleting existing dataset at {external_path}/{scale_path}.")
             del store[scale_path]
         zarrays.append(
-            zarr.creation.empty(
+            zarr.creation.zeros(
                 scaled_shape, store=store, path=scale_path, chunks=chunk_shape, dtype=image_source_slot.meta.dtype
             )
         )

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -135,7 +135,7 @@ def _compute_and_write_scales(
 ) -> List[ImageMetadata]:
     pc = PathComponents(export_path)
     external_path = pc.externalPath
-    internal_path = pc.internalPath
+    internal_path = pc.internalPath.lstrip("/") if pc.internalPath else None
     store = FSStore(external_path, mode="w", **OME_ZARR_V_0_4_KWARGS)
     chunk_shape = _get_chunk_shape(image_source_slot)
 
@@ -177,7 +177,7 @@ def _write_ome_zarr_and_ilastik_metadata(
 ):
     pc = PathComponents(export_path)
     external_path = pc.externalPath
-    multiscale_name = pc.internalPath
+    multiscale_name = pc.internalPath.lstrip("/") if pc.internalPath else None
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 1}
     axis_types = {"t": "time", "c": "channel", "z": "space", "y": "space", "x": "space"}
     axes = [{"name": tag.key, "type": axis_types[tag.key]} for tag in ilastik_meta["axistags"]]

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -46,8 +46,9 @@ from lazyflow.utility.io_util.OMEZarrStore import (
 logger = logging.getLogger(__name__)
 
 Shape = Tuple[int, ...]
-TaggedShape = OrderedDict[str, int]  # { axis: size }
-OrderedScaling = OrderedTranslation = OrderedDict[str, float]  # { axis: scaling }
+Axiskey = Literal["t", "z", "y", "x", "c"]
+TaggedShape = OrderedDict[Axiskey, int]  # { axis: size }
+OrderedScaling = OrderedTranslation = OrderedDict[Axiskey, float]  # { axis: scaling }
 ScalingsByScaleKey = OrderedDict[str, OrderedScaling]  # { scale_key: { axis: scaling } }
 
 SPATIAL_AXES = ["z", "y", "x"]
@@ -90,7 +91,7 @@ def _get_input_multiscale_matching_export(
 def _multiscale_shapes_to_factors(
     multiscales: multiscaleStore.Multiscales,
     base_shape: TaggedShape,
-    output_axiskeys: List[Literal["t", "c", "z", "y", "x"]],
+    output_axiskeys: List[Axiskey],
 ) -> List[OrderedScaling]:
     """Multiscales and base_shape may have arbitrary axes.
     Output are scaling factors relative to base_shape, with axes output_axiskeys.
@@ -208,7 +209,7 @@ def _get_input_dataset_transformations(
 
 def _update_export_scaling_from_input(
     absolute_scaling: OrderedScaling,
-    input_axiskeys: Optional[List[Literal["t", "c", "z", "y", "x"]]],
+    input_axiskeys: Optional[List[Axiskey]],
     input_scale: Optional[OMEZarrCoordinateTransformation],
     scale_key: str,
 ) -> OrderedScaling:
@@ -265,7 +266,7 @@ def _get_total_offset(
     absolute_scaling: OrderedScaling,
     image: ImageMetadata,
     export_offset: TaggedShape,
-    input_axiskeys: Optional[List[Literal["t", "c", "z", "y", "x"]]],
+    input_axiskeys: Optional[List[Axiskey]],
     input_translation: Optional[OMEZarrCoordinateTransformation],
 ) -> OrderedTranslation:
     # Translation may be a total of scale offset, export offset, and input offset (depending on availability)
@@ -336,7 +337,7 @@ def _get_datasets_meta(
 
 
 def _get_multiscale_transformations(
-    input_ome_meta: Optional[OMEZarrMultiscaleMeta], export_axiskeys: List[Literal["t", "c", "z", "y", "x"]]
+    input_ome_meta: Optional[OMEZarrMultiscaleMeta], export_axiskeys: List[Axiskey]
 ) -> Optional[List[Dict]]:
     """Extracts multiscale transformations from input OME-Zarr metadata, if available.
     Returns None or the transformations adjusted to export axes as OME-Zarr conforming dicts."""

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -874,11 +874,13 @@ class TestOpDataSelection_PrecomputedChunks:
         return op
 
     def test_load_precomputed_chunks_over_http(self, op):
+        # Default scale should be lowest resolution
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
+        # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscales)
         scale_keys = list(op.Image.meta.scales.keys())
-        op.ActiveScale.setValue(scale_keys[1])
+        op.ActiveScale.setValue(scale_keys[0])
         loaded_scale1 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale1, self.IMAGE_ORIGINAL.reshape((1, 1, 1, 20, 24)))
 
@@ -974,11 +976,13 @@ class TestOpDataSelection_OMEZarr:
         return op
 
     def test_ome_zarr_loads_via_FSStore_and_ZarrArray(self, op, mock_ome_zarr_data):
+        # Default scale should be lowest resolution
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
+        # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscales)
         scale_keys = list(op.Image.meta.scales.keys())
-        op.ActiveScale.setValue(scale_keys[1])
+        op.ActiveScale.setValue(scale_keys[0])
         loaded_scale1 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale1, self.IMAGE_ORIGINAL.reshape((1, 1, 1, 20, 24)))
 

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -21,7 +21,7 @@
 import json
 import os
 import shutil
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from unittest import mock
 from unittest.mock import Mock
 
@@ -878,6 +878,13 @@ class TestOpDataSelection_PrecomputedChunks:
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
+        assert op.Image.meta.scales == OrderedDict(
+            [
+                ("800_800_70", OrderedDict([("c", 1), ("z", 1), ("y", 20), ("x", 24)])),
+                ("1600_1600_70", OrderedDict([("c", 1), ("z", 1), ("y", 10), ("x", 12)])),
+            ]
+        )
+
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscales)
         scale_keys = list(op.Image.meta.scales.keys())
         op.ActiveScale.setValue(scale_keys[0])
@@ -979,6 +986,13 @@ class TestOpDataSelection_OMEZarr:
         # Default scale should be lowest resolution
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
+
+        assert op.Image.meta.scales == OrderedDict(
+            [
+                ("s0", OrderedDict([("z", 1), ("y", 20), ("x", 24)])),
+                ("s1", OrderedDict([("z", 1), ("y", 10), ("x", 12)])),
+            ]
+        )
 
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscales)
         scale_keys = list(op.Image.meta.scales.keys())

--- a/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
+++ b/tests/test_ilastik/test_workflows/testEdgeTrainingWithMulticutGui.py
@@ -272,7 +272,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
         self.exec_in_shell(impl)
 
     @pytest.mark.skipif(
-        platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
+        platform.system() == "Windows", reason="Test hangs, some issue with threading in self.waitForViews"
     )
     @pytest.mark.skipif(
         platform.system() == "Darwin",
@@ -344,7 +344,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
         self.exec_in_shell(impl)
 
     @pytest.mark.skipif(
-        platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
+        platform.system() == "Windows", reason="Test hangs, some issue with threading in self.waitForViews"
     )
     def test_05_train_rf_from_gt(self):
         """
@@ -414,7 +414,7 @@ class TestEdgeTrainingWithMulticutGui(ShellGuiTestCaseBase):
         self.exec_in_shell(impl)
 
     @pytest.mark.skipif(
-        platform.system() == "Windows" and os.environ.get("APPVEYOR"), reason="Test hangs on Appveyor ci"
+        platform.system() == "Windows", reason="Test hangs, some issue with threading in self.waitForViews"
     )
     def test_06_multicut_rf(self):
         """

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
@@ -81,7 +81,7 @@ class TestOpExportSlot(object):
         finally:
             opRead.cleanUp()
 
-    def test_ome_zarr_without_internal_path(self):
+    def test_ome_zarr(self):
         data = numpy.random.random((90, 100)).astype(numpy.float32)
         data = vigra.taggedView(data, vigra.defaultAxistags("yx"))
 
@@ -93,14 +93,12 @@ class TestOpExportSlot(object):
         opExport.Input.connect(opPiper.Output)
         opExport.OutputFormat.setValue("single-scale OME-Zarr")
         opExport.OutputFilenameFormat.setValue(self._tmpdir + "/test_export_x{x_start}-{x_stop}_y{y_start}-{y_stop}")
-        opExport.OutputInternalPath.setValue("")  # Overwrite the slot's default "exported_data"
         opExport.CoordinateOffset.setValue((10, 20))
 
         assert opExport.ExportPath.ready()
-        export_path_components = PathComponents(opExport.ExportPath.value)
         expected_export_path = Path(self._tmpdir) / "test_export_x20-120_y10-100.zarr"
-        assert Path(export_path_components.externalPath) == expected_export_path
-        assert export_path_components.internalPath is None
+        assert Path(opExport.ExportPath.value) == expected_export_path
+
         opExport.run_export()
 
         opRead = OpInputDataReader(graph=graph)
@@ -147,8 +145,7 @@ class TestOpExportSlot(object):
             }
         ]
         # Expected written meta is the same as input, but tczyx, only with the respective scale,
-        # and with "exported_data" as the name (internal path is mandatory due to
-        # OpExportData.OutputInternalPath having default="exported_data")
+        # and with no name
         expected_meta_s0 = [
             {
                 "axes": [
@@ -168,10 +165,9 @@ class TestOpExportSlot(object):
                             {"scale": [1.0, 1.0, 1.0, 0.2, 0.2], "type": "scale"},
                             {"translation": [0.0, 0.0, 0.0, 0.0, 0.0], "type": "translation"},
                         ],
-                        "path": "exported_data/s0",
+                        "path": "s0",
                     }
                 ],
-                "name": "exported_data",
                 "version": "0.4",
             }
         ]
@@ -194,10 +190,9 @@ class TestOpExportSlot(object):
                             {"scale": [1.0, 1.0, 1.0, 1.4, 1.4], "type": "scale"},
                             {"translation": [0.0, 0.0, 0.0, 7.62, 8.49], "type": "translation"},
                         ],
-                        "path": "exported_data/s1",
+                        "path": "s1",
                     }
                 ],
-                "name": "exported_data",
                 "version": "0.4",
             }
         ]

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpStreamingH5N5Reader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpStreamingH5N5Reader.py
@@ -63,11 +63,11 @@ def test_reader_loads_data_with_axistags(graph, h5n5_file, data):
         vigra.AxisInfo("c", vigra.AxisType.Channels),
         vigra.AxisInfo("t", vigra.AxisType.Time),
     )
-    h5n5_file.create_group("volume").create_dataset("tagged_data", data=data)
-    h5n5_file["volume/tagged_data"].attrs["axistags"] = axistags.toJSON()
+    h5n5_file.create_group("volume").create_dataset("data", data=data)
+    h5n5_file["volume/data"].attrs["axistags"] = axistags.toJSON()
     op = OpStreamingH5N5Reader(graph=graph)
     op.H5N5File.setValue(h5n5_file)
-    op.InternalPath.setValue("volume/tagged_data")
+    op.InternalPath.setValue("volume/data")
 
     assert op.OutputImage.meta.shape == data.shape
     assert op.OutputImage.meta.axistags == axistags

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -1,4 +1,5 @@
 import math
+from collections import OrderedDict
 from unittest import mock
 
 import numpy
@@ -8,7 +9,7 @@ import zarr
 
 from lazyflow.operators import OpArrayPiper
 from lazyflow.utility import Timer
-from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
+from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, _get_scalings
 
 
 @pytest.fixture(params=["ilastik default order", "2d", "3d", "2dc", "125MiB"])
@@ -82,3 +83,54 @@ def test_metadata_integrity(tmp_path, graph, data_array):
         assert written_array.shape == expected_shape
         assert numpy.count_nonzero(written_array) > numpy.prod(expected_shape) / 2, "did not write actual data"
     assert all([key in discovered_keys for key in store.keys()]), "store contains undocumented subpaths"
+
+
+@pytest.mark.parametrize(
+    "data_shape, expected_scalings",
+    [
+        # Criterion: 4 x chunk size, i.e.: 4 * math.prod(4, 179, 178) -- times 8 for scaling by 2 in 3D
+        ((1, 1, 4, 1009, 1010), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # Just under criterion to be scaled
+        ((1, 1, 4, 1011, 1010), [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0, 2.0]]),  # Just over criterion
+        ((1, 1, 1, 30, 30), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # Too small
+        ((1, 1, 2, 4040, 4040), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # No reduction to singleton or anisotropic scaling
+        ((1, 1, 1, 1430, 1430), [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0, 2.0]]),  # 2D scaling is fine
+    ],
+)
+def test_downscaling(tmp_path, graph, data_shape, expected_scalings):
+    data = vigra.VigraArray(data_shape, axistags=vigra.defaultAxistags("tczyx"))
+    data[...] = numpy.indices(data_shape).sum(0)
+    export_path = tmp_path / "test.zarr"
+    source_op = OpArrayPiper(graph=graph)
+    source_op.Input.setValue(data)
+    progress = mock.Mock()
+    with Timer() as timer:
+        write_ome_zarr(str(export_path), source_op.Output, progress)
+        duration = timer.seconds()
+
+    # Manual benchmarking
+    raw_size = math.prod(data.shape) * data.dtype.type().nbytes
+    print(";" f"{data.shape};" f"{data.dtype};" f"{raw_size};" f"{duration};" f"{duration / raw_size};")
+
+    store = zarr.open(str(export_path))
+    meta = store.attrs["multiscales"][0]
+    assert len(meta["datasets"]) == len(expected_scalings)
+
+    for i, scaling in enumerate(expected_scalings):
+        dataset = meta["datasets"][i]
+        scale_transforms = [
+            transform for transform in dataset["coordinateTransformations"] if transform["type"] == "scale"
+        ]
+        assert scale_transforms[0]["scale"] == scaling
+
+
+def test_downscaling_raises():
+    # Testing at the implementation level instead of top-level write_ome_zarr for simplicity.
+    # Would need to set up a data array with an insane shape without actually allocating RAM for it.
+    scaling_factor = 2
+    sanity_limit = 20
+    minimum_chunks_per_scale = 8
+    chunk_length = 100
+    insane_length = chunk_length * (scaling_factor**sanity_limit) * minimum_chunks_per_scale
+    insane_data_shape = OrderedDict({"t": 1, "c": 1, "z": 1, "y": 1, "x": insane_length})
+    with pytest.raises(ValueError, match="Too many scales"):
+        _get_scalings(insane_data_shape, (1, 1, 1, 1, chunk_length), None)

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -10,7 +10,7 @@ import zarr
 from lazyflow.operators import OpArrayPiper
 from lazyflow.roi import roiToSlice
 from lazyflow.utility.io_util import multiscaleStore
-from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, _get_scalings, _apply_scaling_method
+from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, _compute_new_scaling_factors, _apply_scaling_method
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ def test_downscaling_raises():
     insane_length = chunk_length * (scaling_factor**sanity_limit) * minimum_chunks_per_scale
     insane_data_shape = OrderedDict({"t": 1, "c": 1, "z": 1, "y": 1, "x": insane_length})
     with pytest.raises(ValueError, match="Too many scales"):
-        _get_scalings(insane_data_shape, (1, 1, 1, 1, chunk_length), compute_downscales=True)
+        _compute_new_scaling_factors(insane_data_shape, (1, 1, 1, 1, chunk_length), compute_downscales=True)
 
 
 @pytest.mark.skip("To be implemented after releasing single-scale export")

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -59,7 +59,8 @@ def test_metadata_integrity(tmp_path, graph, data_array):
     store = zarr.open(str(export_path))
     assert "multiscales" in store.attrs
     written_meta = store.attrs["multiscales"][0]
-    assert all(key in written_meta for key in ("datasets", "axes", "version"))
+    assert all([key in written_meta for key in ("datasets", "axes", "version")])  # Keys required by spec
+    assert all([value is not None for value in written_meta.values()])  # Should not write None anywhere
     assert written_meta["version"] == "0.4"
     assert [a["name"] for a in written_meta["axes"]] == list(expected_axiskeys)
     tagged_shape = dict(zip(data_array.axistags.keys(), data_array.shape))
@@ -72,6 +73,7 @@ def test_metadata_integrity(tmp_path, graph, data_array):
         written_array = store[dataset["path"]]
         assert "axistags" in written_array.attrs, f"no axistags for {dataset['path']}"
         assert vigra.AxisTags.fromJSON(written_array.attrs["axistags"]) == vigra.defaultAxistags(expected_axiskeys)
+        assert all([value is not None for value in written_array.attrs.values()])  # Should not write None anywhere
         reported_scalings = [
             transform for transform in dataset["coordinateTransformations"] if transform["type"] == "scale"
         ]

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -95,6 +95,7 @@ def test_writes_with_no_scaling(tmp_path, graph, data_shape, scaling_on):
     assert scale_transforms[0]["scale"] == [1.0, 1.0, 1.0, 1.0, 1.0]
 
 
+@pytest.mark.skip("To be implemented after releasing single-scale export")
 @pytest.mark.parametrize(
     "data_shape, computation_block_shape, expected_scalings",
     [
@@ -146,6 +147,7 @@ def test_downscaling(tmp_path, graph, data_shape, computation_block_shape, expec
             numpy.testing.assert_array_equal(store[dataset["path"]], downscaled_data)
 
 
+@pytest.mark.skip("To be implemented after releasing single-scale export")
 def test_downscaling_raises():
     # Testing at the implementation level instead of top-level write_ome_zarr for simplicity.
     # Would need to set up a data array with an insane shape without actually allocating RAM for it.
@@ -159,6 +161,7 @@ def test_downscaling_raises():
         _get_scalings(insane_data_shape, (1, 1, 1, 1, chunk_length), compute_downscales=True)
 
 
+@pytest.mark.skip("To be implemented after releasing single-scale export")
 def test_blockwise_downsampling_edge_cases():
     """Ensures that downsampling can handle blocks smaller than scaling step size,
     and starts that are not a multiple of block size (both of which can occur in the last block

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+import numpy
+import pytest
+import vigra
+import zarr
+
+from lazyflow.operators import OpArrayPiper
+from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
+
+
+@pytest.fixture(params=["ilastik default order", "2d", "3d", "2dc"])
+def data_array(request) -> vigra.VigraArray:
+    shapes = {
+        "ilastik default order": (1, 128, 128, 10, 1),
+        "2d": (128, 128),
+        "3d": (10, 128, 128),
+        "2dc": (128, 128, 3),
+    }
+    axis_order = {
+        "ilastik default order": "txyzc",
+        "2d": "yx",
+        "3d": "zyx",
+        "2dc": "yxc",
+    }
+    shape = shapes[request.param]
+    data = vigra.VigraArray(shape, axistags=vigra.defaultAxistags(axis_order[request.param]))
+    data[...] = numpy.indices(shape).sum(0)
+    return data
+
+
+def test_write_new_ome_zarr_on_disc(tmp_path, graph, data_array):
+    export_path = tmp_path / "test.zarr"
+    source_op = OpArrayPiper(graph=graph)
+    source_op.Input.setValue(data_array)
+    progress = mock.Mock()
+    write_ome_zarr(str(export_path), source_op.Output, progress)
+
+    assert export_path.exists()
+    store = zarr.open(str(export_path))
+    assert "multiscales" in store.attrs
+    m = store.attrs["multiscales"][0]
+    assert all(key in m for key in ("datasets", "axes", "version"))
+    assert m["version"] == "0.4"
+    assert [a["name"] for a in m["axes"]] == ["t", "c", "z", "y", "x"]
+    assert all(dataset["path"] in store for dataset in m["datasets"])

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -8,8 +8,9 @@ import vigra
 import zarr
 
 from lazyflow.operators import OpArrayPiper
+from lazyflow.roi import roiToSlice
 from lazyflow.utility import Timer
-from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, _get_scalings
+from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, _get_scalings, _apply_scaling_method
 
 
 @pytest.fixture(params=["ilastik default order", "2d", "3d", "2dc", "125MiB"])
@@ -79,29 +80,67 @@ def test_metadata_integrity(tmp_path, graph, data_array):
             transform for transform in dataset["coordinateTransformations"] if transform["type"] == "scale"
         ]
         assert len(reported_scalings) == 1
-        expected_shape = tuple(numpy.array(original_shape_reordered) // numpy.array(reported_scalings[0]["scale"]))
+        expected_shape = tuple(
+            math.ceil(orig / reported)
+            for orig, reported in zip(original_shape_reordered, reported_scalings[0]["scale"])
+        )
         assert written_array.shape == expected_shape
         assert numpy.count_nonzero(written_array) > numpy.prod(expected_shape) / 2, "did not write actual data"
     assert all([key in discovered_keys for key in store.keys()]), "store contains undocumented subpaths"
 
 
 @pytest.mark.parametrize(
-    "data_shape, expected_scalings",
+    "data_shape",
     [
         # Criterion: 4 x chunk size, i.e.: 4 * math.prod(4, 179, 178) -- times 8 for scaling by 2 in 3D
-        ((1, 1, 4, 1009, 1010), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # Just under criterion to be scaled
-        ((1, 1, 4, 1011, 1010), [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0, 2.0]]),  # Just over criterion
-        ((1, 1, 1, 30, 30), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # Too small
-        ((1, 1, 2, 4040, 4040), [[1.0, 1.0, 1.0, 1.0, 1.0]]),  # No reduction to singleton or anisotropic scaling
-        ((1, 1, 1, 1430, 1430), [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0, 2.0]]),  # 2D scaling is fine
+        (1, 1, 4, 1008, 1010),  # Just under criterion to be scaled
+        (1, 1, 1, 30, 30),  # Tiny
+        (1, 1, 2, 1432, 1432),  # No reduction to singleton or anisotropic scaling
     ],
 )
-def test_downscaling(tmp_path, graph, data_shape, expected_scalings):
+def test_writes_with_no_scaling(tmp_path, graph, data_shape):
     data = vigra.VigraArray(data_shape, axistags=vigra.defaultAxistags("tczyx"))
     data[...] = numpy.indices(data_shape).sum(0)
     export_path = tmp_path / "test.zarr"
     source_op = OpArrayPiper(graph=graph)
     source_op.Input.setValue(data)
+    progress = mock.Mock()
+
+    write_ome_zarr(str(export_path), source_op.Output, progress)
+
+    store = zarr.open(str(export_path))
+    meta = store.attrs["multiscales"][0]
+    assert len(meta["datasets"]) == 1
+    dataset = meta["datasets"][0]
+    numpy.testing.assert_array_equal(store[dataset["path"]], data)
+    scale_transforms = [transform for transform in dataset["coordinateTransformations"] if transform["type"] == "scale"]
+    assert scale_transforms[0]["scale"] == [1.0, 1.0, 1.0, 1.0, 1.0]
+
+
+@pytest.mark.parametrize(
+    "data_shape, computation_block_shape, expected_scalings",
+    [
+        # Criterion: 4 x chunk size = 4 * math.prod(50, 51, 50) -- times 8 for scaling by 2 in 3D
+        ((1, 1, 66, 250, 250), None, [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 2.0, 2.0, 2.0]]),
+        # 2D scaling: complements the (1, 1, 2, 1432, 1432) case in test_writes_with_no_scaling.
+        # Ensures that the xy dimensions are sufficient to be scaled (but z=2 suppresses it).
+        ((1, 1, 1, 1432, 1432), None, [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 2.0, 2.0]]),
+        (  # Provoke rounding difficulties due to blockwise scaling at 4x
+            (1, 1, 310, 361, 371),  # 371/4 = 92.75, so expected scaled shape in x is 93. 371/91 = 4 blocks + 7 pixels.
+            (1, 1, 310, 361, 91),  # 91/4 = 22.75, so 23 per block. Plus 7/4 = 1.75, so 2. Total of 94px blockwise.
+            [[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 2.0, 2.0, 2.0], [1.0, 1.0, 4.0, 4.0, 4.0]],
+        ),
+    ],
+)
+def test_downscaling(tmp_path, graph, data_shape, computation_block_shape, expected_scalings):
+    data = vigra.VigraArray(data_shape, axistags=vigra.defaultAxistags("tczyx"))
+    data[...] = numpy.indices(data_shape).sum(0)
+    export_path = tmp_path / "test.zarr"
+    source_op = OpArrayPiper(graph=graph)
+    source_op.Input.setValue(data)
+    # max_blockshape should not affect chunk size on disc or scaling decision,
+    # but computations and scaling are broken up into blocks.
+    source_op.Output.meta.max_blockshape = computation_block_shape
     progress = mock.Mock()
     with Timer() as timer:
         write_ome_zarr(str(export_path), source_op.Output, progress)
@@ -114,6 +153,7 @@ def test_downscaling(tmp_path, graph, data_shape, expected_scalings):
     store = zarr.open(str(export_path))
     meta = store.attrs["multiscales"][0]
     assert len(meta["datasets"]) == len(expected_scalings)
+    numpy.testing.assert_array_equal(store[meta["datasets"][0]["path"]], data)
 
     for i, scaling in enumerate(expected_scalings):
         dataset = meta["datasets"][i]
@@ -121,6 +161,16 @@ def test_downscaling(tmp_path, graph, data_shape, expected_scalings):
             transform for transform in dataset["coordinateTransformations"] if transform["type"] == "scale"
         ]
         assert scale_transforms[0]["scale"] == scaling
+        # Makes sure that the blockwise-scaled image is identical to downscaling the data at once
+        if scaling == [1.0, 1.0, 4.0, 4.0, 4.0]:
+            downscaled_data = data[:, :, ::4, ::4, ::4]
+            numpy.testing.assert_array_equal(store[dataset["path"]], downscaled_data)
+        elif scaling == [1.0, 1.0, 2.0, 2.0, 2.0]:
+            downscaled_data = data[:, :, ::2, ::2, ::2]
+            numpy.testing.assert_array_equal(store[dataset["path"]], downscaled_data)
+        elif scaling == [1.0, 1.0, 1.0, 2.0, 2.0]:
+            downscaled_data = data[:, :, :, ::2, ::2]
+            numpy.testing.assert_array_equal(store[dataset["path"]], downscaled_data)
 
 
 def test_downscaling_raises():
@@ -134,3 +184,27 @@ def test_downscaling_raises():
     insane_data_shape = OrderedDict({"t": 1, "c": 1, "z": 1, "y": 1, "x": insane_length})
     with pytest.raises(ValueError, match="Too many scales"):
         _get_scalings(insane_data_shape, (1, 1, 1, 1, chunk_length), None)
+
+
+def test_blockwise_downsampling_edge_cases():
+    """Ensures that downsampling can handle blocks smaller than scaling step size,
+    and starts that are not a multiple of block size (both of which can occur in the last block
+    along an axis).
+    Also ensures that the correct pixels are sampled when starting in the middle of a step (here x),
+    exactly at the start of a step (here y), and when no step start is within block (0 sampled along z)."""
+    # Tested at implementation level because passing odd scaling and data shapes is easier this way.
+    data_shape = (1, 1, 15, 15, 25)
+    step_size = 11
+    data = vigra.VigraArray(data_shape, axistags=vigra.defaultAxistags("tczyx"))
+    data[...] = numpy.indices(data_shape).sum(0)
+    roi = ([0, 0, 6, step_size, 24], [1, 1, 15, 15, 25])
+    block = data[roiToSlice(*roi)]
+    expected_scaled_roi = ([0, 0, 1, 1, 3], [1, 1, 2, 2, 3])
+    expected_scaled_block = data[:, :, ::step_size, ::step_size, ::step_size][roiToSlice(*expected_scaled_roi)]
+    scaling = OrderedDict([("t", 1), ("c", 1), ("z", step_size), ("y", step_size), ("x", step_size)])
+
+    scaled_block, scaled_roi = _apply_scaling_method(block, roi, scaling)
+
+    assert scaled_block.shape == expected_scaled_block.shape
+    numpy.testing.assert_array_equal(scaled_block, expected_scaled_block)
+    assert scaled_roi == expected_scaled_roi

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -50,6 +50,7 @@ def test_metadata_integrity(tmp_path, graph, shape, axes):
         assert dataset["path"] in store
         discovered_keys.append(dataset["path"])
         written_array = store[dataset["path"]]
+        assert written_array.fill_value is not None, "FIJI and z5py don't open zarrays without a fill_value"
         assert "axistags" in written_array.attrs, f"no axistags for {dataset['path']}"
         assert vigra.AxisTags.fromJSON(written_array.attrs["axistags"]) == vigra.defaultAxistags(expected_axiskeys)
         assert all([value is not None for value in written_array.attrs.values()])  # Should not write None anywhere

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -288,7 +288,12 @@ def test_port_ome_zarr_metadata_from_input(tmp_path, tiny_5d_vigra_array_piper):
     source_op.Output.meta.ome_zarr_meta = OMEZarrMultiscaleMeta.from_multiscale_spec(
         {
             "name": "wonderful_pyramid",
-            "axes": ["t", "z", "y", "x"],  # Input metadata tzyx, but e.g. Probabilities output would be tczyx
+            "axes": [
+                {"name": "t", "type": "time", "unit": "second"},
+                {"name": "z", "type": "space", "unit": "micrometer"},
+                {"name": "y", "type": "space", "unit": "micrometer"},
+                {"name": "x", "type": "space", "unit": "micrometer"},
+            ],  # Input metadata tzyx, but e.g. Probabilities output would be tczyx
             "coordinateTransformations": [{"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0]}],
             "datasets": [
                 {
@@ -324,6 +329,13 @@ def test_port_ome_zarr_metadata_from_input(tmp_path, tiny_5d_vigra_array_piper):
     assert "datasets" in m and "path" in m["datasets"][0]
     assert len(m["datasets"]) == 1
     assert m["name"] == "subdir"  # Input name should not be carried over - presumably it names the raw data
+    assert m["axes"] == [
+        {"name": "t", "type": "time", "unit": "second"},
+        {"name": "c", "type": "channel"},
+        {"name": "z", "type": "space", "unit": "micrometer"},
+        {"name": "y", "type": "space", "unit": "micrometer"},
+        {"name": "x", "type": "space", "unit": "micrometer"},
+    ]  # Axis units should be carried over
     assert m["coordinateTransformations"] == expected_multiscale_transform
     assert m["datasets"][0]["path"] == "subdir/matching_scale"
     assert m["datasets"][0]["coordinateTransformations"] == expected_matching_scale_transform

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -72,6 +72,7 @@ def test_metadata_integrity(tmp_path, graph, shape, axes):
         (1, 1, 4, 1008, 1010),  # Just under criterion to be scaled
         (1, 1, 1, 30, 30),  # Tiny
         (1, 1, 2, 1432, 1432),  # No reduction to singleton or anisotropic scaling
+        (3, 3, 67, 79, 97),  # Big enough to scale when taking c and t into account (which we shouldn't)
     ],
 )
 def test_writes_with_no_scaling(tmp_path, graph, data_shape):

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -1,3 +1,4 @@
+import math
 from unittest import mock
 
 import numpy
@@ -6,22 +7,33 @@ import vigra
 import zarr
 
 from lazyflow.operators import OpArrayPiper
+from lazyflow.utility import Timer
 from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
 
 
-@pytest.fixture(params=["ilastik default order", "2d", "3d", "2dc"])
+@pytest.fixture(params=["125MiB"])
 def data_array(request) -> vigra.VigraArray:
     shapes = {
-        "ilastik default order": (1, 128, 128, 10, 1),
-        "2d": (128, 128),
-        "3d": (10, 128, 128),
-        "2dc": (128, 128, 3),
+        "ilastik default order": (1, 128, 127, 10, 1),
+        "2d": (256, 255),
+        "3d": (10, 126, 125),
+        "2dc": (124, 123, 3),
+        "125MiB": (30, 1024, 1024),  # 4 bytes per pixel
+        "500MiB": (125, 1024, 1024),  # 4 bytes per pixel
+        "1GiB": (256, 1024, 1024),
+        "3GiB": (768, 1024, 1024),
+        "6GiB": (768, 2048, 1024),
     }
     axis_order = {
         "ilastik default order": "txyzc",
         "2d": "yx",
         "3d": "zyx",
         "2dc": "yxc",
+        "125MiB": "zyx",
+        "500MiB": "zyx",
+        "1GiB": "zyx",
+        "3GiB": "zyx",
+        "6GiB": "zyx",
     }
     shape = shapes[request.param]
     data = vigra.VigraArray(shape, axistags=vigra.defaultAxistags(axis_order[request.param]))
@@ -34,13 +46,34 @@ def test_write_new_ome_zarr_on_disc(tmp_path, graph, data_array):
     source_op = OpArrayPiper(graph=graph)
     source_op.Input.setValue(data_array)
     progress = mock.Mock()
-    write_ome_zarr(str(export_path), source_op.Output, progress)
+    with Timer() as timer:
+        write_ome_zarr(str(export_path), source_op.Output, progress)
+        duration = timer.seconds()
 
+    # Manual benchmarking
+    raw_size = math.prod(data_array.shape) * data_array.dtype.type().nbytes
+    print(";" f"{data_array.shape};" f"{data_array.dtype};" f"{raw_size};" f"{duration};" f"{duration / raw_size};")
+
+    expected_axiskeys = "tczyx"
     assert export_path.exists()
     store = zarr.open(str(export_path))
     assert "multiscales" in store.attrs
     m = store.attrs["multiscales"][0]
     assert all(key in m for key in ("datasets", "axes", "version"))
     assert m["version"] == "0.4"
-    assert [a["name"] for a in m["axes"]] == ["t", "c", "z", "y", "x"]
-    assert all(dataset["path"] in store for dataset in m["datasets"])
+    assert [a["name"] for a in m["axes"]] == list(expected_axiskeys)
+    tagged_shape = dict(zip(data_array.axistags.keys(), data_array.shape))
+    original_shape_reordered = [tagged_shape[a] if a in tagged_shape else 1 for a in expected_axiskeys]
+
+    discovered_keys = []
+    for i, dataset in enumerate(m["datasets"]):
+        assert dataset["path"] in store
+        discovered_keys.append(dataset["path"])
+        written_array = store[dataset["path"]]
+        assert "axistags" in written_array.attrs, f"no axistags for {dataset['path']}"
+        assert vigra.AxisTags.fromJSON(written_array.attrs["axistags"]) == vigra.defaultAxistags(expected_axiskeys)
+        reported_scaling = dataset["coordinateTransformations"][0]["scale"]
+        expected_shape = tuple(numpy.array(original_shape_reordered) / numpy.array(reported_scaling))
+        assert written_array.shape == expected_shape
+        assert numpy.count_nonzero(written_array) > numpy.prod(expected_shape) / 2, "did not write actual data"
+    assert all([key in discovered_keys for key in store.keys()]), "store contains undocumented subpaths"


### PR DESCRIPTION
Support exporting to OME-Zarr

This PR on its own only enables writing to OME-Zarr through headless, since the export GUI is in volumina (https://github.com/ilastik/volumina/pull/316)

* Local file system only, writing to web stores tbd
* Output image is single-scale. Scaling turns out to be quite complex to do properly and blockwise / RAM-friendly / web-friendly, so leaving it for another PR. Hopefully if someone wants to have their output scaled before I get it done, they can use other tools that are out there. Though I'm not sure how good the converters/scalers out there actually are at handling OME-Zarr as input. Once I do implement it, they will be able to load any single-scale exports from this version, and "convert" them to multiscale by exporting them in the to-be-added format option.
* If the input was already a multiscale dataset (Precomputed or OME-Zarr), the output will match the scale key to the input, and the output's scaling factor metadata will be recorded relative to the raw data size of the input
* If the input was OME-Zarr, the output will carry over scaling and translation metadata both for the entire pyramid and for the exported scale(s). In regards to scaling metadata of individual scales, this is specifically the "t" scaling factor, since the factors for xyz depend on the actual written scale (or scaling relative to raw data, see above), and metadata for "c" should not be carried over because export channels != input channels. Scaling metadata on the pyramid level is supposed to represent pixel resolutions relevant for all scales, so only "t" should ever be anything other than 1.0. But here we carry over all numbers to the output, because who knows what they might mean, and there are no meaningful numbers from ilastik's side to write there instead.
* Refuses to write to existing paths, enable appending and merging metadata tbd

## Checklist

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Update [user documentation](https://github.com/ilastik/ilastik.github.io). -- https://github.com/ilastik/ilastik.github.io/pull/281
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
