### PR TITLE
Fix typo in carve/preprocessing

### DIFF
--- a/ilastik/workflows/carving/preprocessingDrawer.ui
+++ b/ilastik/workflows/carving/preprocessingDrawer.ui
@@ -193,7 +193,7 @@
        <item row="2" column="0">
         <widget class="QLabel" name="label_3">
          <property name="toolTip">
-          <string>Reduce the number of superpixels to this parameter * original number. By defalut, reduce to 20% of the original superpixel number.</string>
+          <string>Reduce the number of superpixels to this parameter * original number. By default, reduce to 20% of the original superpixel number.</string>
          </property>
          <property name="text">
           <string>reduce to </string>


### PR DESCRIPTION
Super tiny typo fix in carve/preprocessing reduce-to tooltip

## Checklist

n/a :) 

<!-- 
- [] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
-->
