### PR TITLE
Fix flaky ObjectClassificationGui test

### DIFF
--- a/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
+++ b/tests/test_ilastik/test_workflows/testObjectClassificationGui.py
@@ -31,6 +31,7 @@ from PyQt5.QtWidgets import QApplication
 
 import h5py
 import numpy
+import pytest
 
 from ilastik.workflows import ObjectClassificationWorkflowPrediction
 from ilastik.applets.dataSelection.opDataSelection import FilesystemDatasetInfo
@@ -364,6 +365,7 @@ class TestObjectClassificationGui(ShellGuiTestCaseBase):
         # Run this test from within the shell event loop
         self.exec_in_shell(impl)
 
+    @pytest.mark.usefixtures("reliable_vigra_train_rf_seed")
     def test_05_live_update_mode(self):
         def impl():
             shell = self.shell


### PR DESCRIPTION
this test was flaky due to so many features in training - fixing the seed should fix this.

Edit: triggered the test runs 3 times and _that particular_ test didn't fail.

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
