### PR TITLE
remove faulthandler activation on lazyflow import

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -120,6 +120,10 @@ jobs:
         run: |
           set VOLUMINA_SHOW_3D_WIDGET=0
           conda mambabuild --test --override-channels ^
-            -c .\pkgs -c pytorch -c nvidia -c ilastik-forge -c conda-forge ^
-            .\pkgs\noarch\%ILASTIK_PACKAGE_NAME%
-
+            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge -c conda-forge ^
+            ./pkgs/noarch/%ILASTIK_PACKAGE_NAME%
+        # HACK: due to a bug in conda-build need to point to
+        # libarchive explicitly.
+        # https://github.com/conda/conda/issues/12563#issuecomment-1494264704
+        env:
+          LIBARCHIVE: C:\Miniconda\Library\bin\archive.dll

--- a/lazyflow/__init__.py
+++ b/lazyflow/__init__.py
@@ -21,9 +21,6 @@ from __future__ import absolute_import
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-import faulthandler
-
-faulthandler.enable()  # noqa
 import z5py
 import json
 import numpy as np


### PR DESCRIPTION
this causes problems for consumers of the API, see #2913. Note, the ilastik application installs the faulthandler anyways, so for ilastik there is no change in behavior.

fixes #2913 
