### PR TITLE
Fix pytorch fbgemm.dll dependency issue

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -116,7 +116,7 @@ outputs:
       run:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
-        - pytorch >=1.6,!=2.4.1
+        - pytorch >=1.6,<2.4.1
         - tiktorch
         - torchvision
         - volumina
@@ -168,7 +168,7 @@ outputs:
       run:
         - python 3.9.*
         - ilastik-core {{ setup_py_data.version }}
-        - pytorch >=1.6,!=2.4.1
+        - pytorch >=1.6,<2.4.1
         - tiktorch
         - torchvision
         - pytorch-cuda

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -49,26 +49,22 @@ dependencies:
   - aiohttp
   - fsspec
 
-  # Neural Network Workflow dependencies
+  # Deep learning dependencies (neural net workflow, trainable domain adaptation)
   # can be changed to request gpu versions
-  # pytorch 2.4.* will work for all platforms except osx-64, where currently the
-  # latest version is 2.2.2
-  - pytorch 2.4.*,!=2.4.1
+  - pytorch <2.4.1  # >=2.4 can clash with pyshtools on win; 2.2.2 newest available on osx
   - cpuonly  # comment out for pytorch with cuda
+  # - pytorch-cuda=11.3  # uncomment for pytorch with cuda, specify cuda version
+  - tiktorch 24.9.0*
   # mamba does not "respect" track_features, which is the idea behind cpuonly,
   # with ilastik-pytorch-version-helper-cpu we help mamba on linux and windows
   # to install a cpu-build
   - ilastik-pytorch-version-helper-cpu  # comment out for pytorch with cuda
-  # - pytorch-cuda=11.3  # uncomment for pytorch with cuda, specify cuda version
-
-  - tiktorch 24.9.0*
 
 
   # Third-party object feature plugins
   - sphericaltexture_plugin
   - sphericaltexture >=0.0.4
-  # pyshtools 4.10 conflicts with pytorch (via openmp) on windows
-  - pyshtools >=4.12
+  - pyshtools >=4.12  # If >=4.13 becomes available for win, might be able to unpin pytorch
 
   # dev-only dependencies
   - conda-build


### PR DESCRIPTION
Issue we first saw in https://github.com/ilastik/ilastik/pull/2904 with pytorch 2.4.1

E.g. https://github.com/ilastik/ilastik/actions/runs/11721367647/job/32654563102

```
Traceback (most recent call last):
  File "C:\Users\runneradmin\miniconda3\conda-bld\ilastik-gpu_1730976400239\test_tmp\run_test.py", line 23, in <module>
    import torch
  File "C:\Users\runneradmin\miniconda3\conda-bld\ilastik-gpu_1730976400239\_test_env\lib\site-packages\torch\__init__.py", line 262, in <module>
    _load_dll_libraries()
  File "C:\Users\runneradmin\miniconda3\conda-bld\ilastik-gpu_1730976400239\_test_env\lib\site-packages\torch\__init__.py", line 245, in _load_dll_libraries
    raise err
OSError: [WinError 182] The operating system cannot run %1. Error loading "C:\Users\runneradmin\miniconda3\conda-bld\ilastik-gpu_1730976400239\_test_env\lib\site-packages\torch\lib\fbgemm.dll" or one of its dependencies.
```

Conclusion:

I've put the `pytorch <2.4.1` constraint in meta.yaml, and also environment-dev.yml, so we should effectively be on 2.4.0 now.

The error we see on Windows CI with 2.4.1 and up may look identical to an error widely described for pytorch 2.4.0 (https://github.com/pytorch/pytorch/issues/131662), but I think they are separate issues. The error looks identical because in both cases, a dll related to openmp is missing/broken.

Evidently, unlike a huge number of people as documented by the pytorch issue, ilastik seems to be fine with pytorch 2.4.0. I suspect everyone else was having openmp ruined by `torchaudio`, which we don't pull.

In #2904, @k-dominik describes a clash between pytorch 2.4.1 and `pyshtools` due to its dependency `gmt` overwriting openmp. An attempted workaround with a modified pyshtools package, uploaded to the conda channel `ilastik-forge/label/patched`, may have slimmed the dependencies but didn't solve the problem.

In my attempts here, `pyshtools` was also the source of the problem; but instead of `gmt`, it looks like openmp was being overwritten by `libflang`. Specifically, it was pulling openmp and libflang both at versions 5, which are rather old. I tried if pytorch 2.5.1 was able to coexist with other openmp versions in an env, and looks like `openmp=8.0.1` would have been fine. `libflang=11.*` pulled `llvm-openmp` instead of `openmp`, with the overwriting issue persisting, but `libflang=17.*` no longer pulled any openmp and was fine as well.