### PR TITLE
Add logging widget to status bar

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -195,6 +195,7 @@ class NotificationsBar(QLabel):
         self.notifications_widget: Union[NotificationsWindow, None] = None
         self.setToolTip("Double click for history.")
         self._setup_logging()
+        self.setContentsMargins(10, 0, 10, 0)
 
     def _setup_logging(self):
         s = logging.StreamHandler(stream=self)
@@ -222,9 +223,13 @@ class NotificationsBar(QLabel):
 
     def cleanUp(self):
         self._history = []
-        self.setText("")
+        self.clear()
         if self.notifications_widget is not None:
             self.notifications_widget.clear()
+
+    def clear(self):
+        """Clear displayed text"""
+        self.setText("")
 
     def write(self, text):
         text = text.rstrip("\n")
@@ -1281,6 +1286,9 @@ class IlastikShell(QMainWindow):
             self.showViewerControlWidget(applet_index)
             self.showMenus(applet_index)
             self.refreshAppletDrawer(applet_index)
+
+            # clear NotificatioinsBar
+            self.progressDisplayManager.logBar.clear()
 
             self._refreshDrawerRecursionGuard = False
 

--- a/lazyflow/__init__.py
+++ b/lazyflow/__init__.py
@@ -23,6 +23,11 @@ import z5py
 import json
 import numpy as np
 
+# This level can be used to issue user-facing log messages
+# log messages at this level get special treatment in ilastik:
+# those are shown in the status bar
+USER_LOGLEVEL = 23
+
 from . import utility
 from . import request
 from . import classifiers

--- a/lazyflow/__init__.py
+++ b/lazyflow/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   lazyflow: data flow based lazy parallel computation framework
 #

--- a/lazyflow/classifiers/lazyflowClassifier.py
+++ b/lazyflow/classifiers/lazyflowClassifier.py
@@ -1,3 +1,23 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 import abc
 
 from typing import Type, TypeVar

--- a/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   lazyflow: data flow based lazy parallel computation framework
 #
-#       Copyright (C) 2011-2016, the ilastik developers
+#       Copyright (C) 2011-2024, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -19,20 +19,6 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
-from builtins import map
-from builtins import zip
-from builtins import range
-
-import sys
-
-if sys.version_info.major >= 3:
-    unicode = str
-
 import os
 import tempfile
 from functools import partial
@@ -448,7 +434,7 @@ class ParallelVigraRfLazyflowClassifier(LazyflowVectorwiseClassifierABC):
 
         try:
             feature_names = list(h5py_group["feature_names"][:])
-            feature_names = list(map(unicode, feature_names))
+            feature_names = list(map(str, feature_names))
         except KeyError:
             # Older projects don't store feature names.
             feature_names = None

--- a/lazyflow/classifiers/sklearnLazyflowClassifier.py
+++ b/lazyflow/classifiers/sklearnLazyflowClassifier.py
@@ -1,7 +1,23 @@
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 import pickle as pickle
 import numpy
 import vigra

--- a/lazyflow/classifiers/vigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/vigraRfLazyflowClassifier.py
@@ -1,10 +1,23 @@
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
-from builtins import map
-from builtins import zip
-from builtins import range
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 import os
 import tempfile
 import pickle as pickle

--- a/lazyflow/classifiers/vigraRfPixelwiseClassifier.py
+++ b/lazyflow/classifiers/vigraRfPixelwiseClassifier.py
@@ -1,9 +1,23 @@
-from __future__ import absolute_import
-from future import standard_library
-
-standard_library.install_aliases()
-from builtins import zip
-from builtins import range
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2024, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
 import os
 import tempfile
 import pickle as pickle

--- a/tests/test_ilastik/test_shell/test_status_log.py
+++ b/tests/test_ilastik/test_shell/test_status_log.py
@@ -1,0 +1,93 @@
+import logging
+
+import pytest
+from PyQt5.QtCore import Qt
+
+from ilastik.shell.gui.ilastikShell import LogBar, LogWindow
+from lazyflow import USER_LOGLEVEL
+
+logger = logging.getLogger("root")
+
+
+@pytest.fixture
+def log_bar(qtbot):
+    log_bar = LogBar()
+    qtbot.addWidget(log_bar)
+    with qtbot.waitExposed(log_bar):
+        log_bar.show()
+    return log_bar
+
+
+@pytest.fixture
+def enable_log(caplog):
+    # necessary to override otherwise log message would not be handled
+    caplog.set_level(logging.INFO, logger="root")
+    return caplog
+
+
+def test_log_window_scroll_to_last(qtbot):
+    log_win = LogWindow(data=[f"some_text {i}" for i in range(100)])
+    qtbot.addWidget(log_win)
+    with qtbot.waitExposed(log_win):
+        log_win.show()
+
+    log_scroll_max_tmp = log_win.verticalScrollBar().maximum()
+
+    assert log_win.verticalScrollBar().value() == log_scroll_max_tmp
+
+    log_win.appendMessage("another one")
+
+    assert log_win.verticalScrollBar().maximum() > log_scroll_max_tmp
+    assert log_win.verticalScrollBar().value() == log_win.verticalScrollBar().maximum()
+
+
+def test_print_message(log_bar: LogBar, enable_log):
+    assert log_bar.text() == ""
+
+    some_text = "ilastik logbar"
+    logger.log(USER_LOGLEVEL, some_text)
+    assert log_bar.text() == some_text
+
+
+def test_double_click_opens_window(log_bar: LogBar, qtbot):
+    qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
+
+    with qtbot.waitExposed(log_bar.log_widget):
+        pass
+
+    assert isinstance(log_bar.log_widget, LogWindow)
+
+
+def test_reopen_shows_same_window(log_bar: LogBar, qtbot):
+    qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
+    with qtbot.waitExposed(log_bar.log_widget):
+        pass
+    assert isinstance(log_bar.log_widget, LogWindow)
+
+    original_id = id(log_bar.log_widget)
+
+    qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
+    with qtbot.waitExposed(log_bar.log_widget):
+        pass
+    assert id(log_bar.log_widget) == original_id
+
+
+def test_clear(log_bar: LogBar, qtbot, enable_log):
+    assert log_bar.text() == ""
+
+    for i in range(42):
+        logger.log(USER_LOGLEVEL, f"msg {i}")
+
+    assert log_bar.text() == "msg 41"
+
+    qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
+    with qtbot.waitExposed(log_bar.log_widget):
+        pass
+
+    log_history = log_bar.log_widget.toPlainText()
+    assert len(log_history.split("\n")) == 42
+
+    log_bar.cleanUp()
+
+    assert log_bar.text() == ""
+    assert log_bar.log_widget.toPlainText() == ""

--- a/tests/test_ilastik/test_shell/test_status_log.py
+++ b/tests/test_ilastik/test_shell/test_status_log.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from PyQt5.QtCore import Qt
 
-from ilastik.shell.gui.ilastikShell import LogBar, LogWindow
+from ilastik.shell.gui.ilastikShell import NotificationsBar, NotificationsWindow
 from lazyflow import USER_LOGLEVEL
 
 logger = logging.getLogger("root")
@@ -11,7 +11,7 @@ logger = logging.getLogger("root")
 
 @pytest.fixture
 def log_bar(qtbot):
-    log_bar = LogBar()
+    log_bar = NotificationsBar()
     qtbot.addWidget(log_bar)
     with qtbot.waitExposed(log_bar):
         log_bar.show()
@@ -26,7 +26,7 @@ def enable_log(caplog):
 
 
 def test_log_window_scroll_to_last(qtbot):
-    log_win = LogWindow(data=[f"some_text {i}" for i in range(100)])
+    log_win = NotificationsWindow(data=[f"some_text {i}" for i in range(100)])
     qtbot.addWidget(log_win)
     with qtbot.waitExposed(log_win):
         log_win.show()
@@ -41,7 +41,7 @@ def test_log_window_scroll_to_last(qtbot):
     assert log_win.verticalScrollBar().value() == log_win.verticalScrollBar().maximum()
 
 
-def test_print_message(log_bar: LogBar, enable_log):
+def test_print_message(log_bar: NotificationsBar, enable_log):
     assert log_bar.text() == ""
 
     some_text = "ilastik logbar"
@@ -49,30 +49,26 @@ def test_print_message(log_bar: LogBar, enable_log):
     assert log_bar.text() == some_text
 
 
-def test_double_click_opens_window(log_bar: LogBar, qtbot):
+def test_double_click_opens_window(log_bar: NotificationsBar, qtbot):
     qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
 
-    with qtbot.waitExposed(log_bar.log_widget):
-        pass
-
-    assert isinstance(log_bar.log_widget, LogWindow)
+    assert isinstance(log_bar.notifications_widget, NotificationsWindow)
 
 
-def test_reopen_shows_same_window(log_bar: LogBar, qtbot):
+def test_reopen_shows_same_window(log_bar: NotificationsBar, qtbot):
     qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
-    with qtbot.waitExposed(log_bar.log_widget):
-        pass
-    assert isinstance(log_bar.log_widget, LogWindow)
 
-    original_id = id(log_bar.log_widget)
+    assert isinstance(log_bar.notifications_widget, NotificationsWindow)
+
+    original_id = id(log_bar.notifications_widget)
 
     qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
-    with qtbot.waitExposed(log_bar.log_widget):
+    with qtbot.waitExposed(log_bar.notifications_widget):
         pass
-    assert id(log_bar.log_widget) == original_id
+    assert id(log_bar.notifications_widget) == original_id
 
 
-def test_clear(log_bar: LogBar, qtbot, enable_log):
+def test_clear(log_bar: NotificationsBar, qtbot, enable_log):
     assert log_bar.text() == ""
 
     for i in range(42):
@@ -81,13 +77,11 @@ def test_clear(log_bar: LogBar, qtbot, enable_log):
     assert log_bar.text() == "msg 41"
 
     qtbot.mouseDClick(log_bar, Qt.MouseButton.LeftButton)
-    with qtbot.waitExposed(log_bar.log_widget):
-        pass
 
-    log_history = log_bar.log_widget.toPlainText()
+    log_history = log_bar.notifications_widget.toPlainText()
     assert len(log_history.split("\n")) == 42
 
     log_bar.cleanUp()
 
     assert log_bar.text() == ""
-    assert log_bar.log_widget.toPlainText() == ""
+    assert log_bar.notifications_widget.toPlainText() == ""


### PR DESCRIPTION
Log messages that are emitted using the log level 23 (or `lazyflow.USER_LOGLEVEL`) will show up in the status bar. Double clicking that area will open the log history.

<img width="926" alt="image" src="https://github.com/user-attachments/assets/e93df8df-ea1a-4a66-b297-ade1fb027bb2">


Currently this will show the number of labels and oob in pixel classification, object classification (and related workflows - tracking...) as well as multicut.

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [couldn't find one] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
