### PR TITLE
Multicut: Fix deprecated append on pd.DataFrame

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,8 +49,7 @@ outputs:
         - marching_cubes
         - ndstructs
         - nifty
-        # need to update our packages to be compatible with pandas 2 API
-        - pandas
+        - pandas 2.*
         - psutil
         - pydantic 2.*
         - pyopengl

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -24,7 +24,7 @@ dependencies:
   - marching_cubes
   - ndstructs
   - nifty
-  - pandas
+  - pandas 2.*
   - psutil
   - pydantic 2.*
   - pyopengl

--- a/ilastik/applets/edgeTraining/opEdgeTraining.py
+++ b/ilastik/applets/edgeTraining/opEdgeTraining.py
@@ -367,7 +367,7 @@ class OpTrainEdgeClassifier(Operator):
             # Merge in features
             features_and_labels_df = pd.merge(edge_features_df, labels_df, how="right", on=["sp1", "sp2"])
             if all_features_and_labels_df is not None:
-                all_features_and_labels_df = all_features_and_labels_df.append(features_and_labels_df)
+                all_features_and_labels_df = pd.concat([all_features_and_labels_df, features_and_labels_df])
             else:
                 all_features_and_labels_df = features_and_labels_df
 


### PR DESCRIPTION
Fixes training for multiple images in multicut. `pandas` deprecated `DataFrame.append` as of 1.4.0, and removed it in `pandas` 2. Also added an explicit version 2 pin for pandas for dev envs and conda recipes.

fixes #2933