### PR TITLE
Switch to .conda package format (with latest conda build)

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -61,7 +61,7 @@ jobs:
             build_prefix: "py_"
     runs-on: ${{ matrix.os }}
     env:
-      ILASTIK_PACKAGE_NAME: ${{ matrix.ilastik_variant }}-${{ needs.conda-noarch-build.outputs.version }}-${{ matrix.build_prefix }}0.tar.bz2
+      ILASTIK_PACKAGE_NAME: ${{ matrix.ilastik_variant }}-${{ needs.conda-noarch-build.outputs.version }}-${{ matrix.build_prefix }}0.conda
     steps:
       # necessary on windows: https://github.com/actions/cache/issues/591#issuecomment-845132253
       - name: "Use GNU tar instead BSD tar"


### PR DESCRIPTION
`.conda` is the default package format since conda build `25.1.0`