### PR TITLE
Tests: disable automatic cache cleanup for lazyflow tests.

### DIFF
--- a/tests/test_lazyflow/conftest.py
+++ b/tests/test_lazyflow/conftest.py
@@ -1,10 +1,29 @@
-import os
-
 import pytest
 import pathlib
 
+import lazyflow
 from lazyflow.operator import format_operator_stack
 from lazyflow.graph import Graph
+
+
+@pytest.fixture(scope="module")
+def disabled_cache_manager():
+    """
+    Some tests rely on cache being persistent. On smaller machines it can
+    happen that cache is cleaned up during a test. By disabling the automatic
+    cleanup we ensure reproducible cache hits.
+    """
+    cache_manager = lazyflow.operators.cacheMemoryManager._cache_memory_manager
+    cache_manager.disable()
+    yield cache_manager
+    cache_manager.enable()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def ensure_clean_cache(disabled_cache_manager):
+    """Clean cache before after test"""
+    yield
+    disabled_cache_manager._cleanup()
 
 
 @pytest.hookimpl()


### PR DESCRIPTION
On CI caches could be cleaned in certain situations during tests that would require reproducible cache behavior.
With these two fixtures, all tests in lazyflow will get a fresh cache that is cleaned only after every test.

fixes https://github.com/ilastik/ilastik/issues/2540

other examples:

* `test_lazyflow.test_operators.testOpBlockedArrayCache.TestOpBlockedArrayCache_masked.testFixAtCurrent`
<details><summary>tb</summary>

```pytb

AssertionError: 33 <= 2
assert 33 <= 2
 +  where 33 = <lazyflow.utility.testing.OpArrayPiperWithAccessCount object at 0x719548650850>.accessCount
self = <tests.test_lazyflow.test_operators.testOpSlicedBlockedArrayCache.TestOpSlicedBlockedArrayCache object at 0x719578db8610>

    def testFixAtCurrent(self):
        opCache = self.opCache
        opProvider = self.opProvider
    
        # Track dirty notifications
        gotDirtyKeys = []
    
        def handleDirty(slot, roi):
            gotDirtyKeys.append(list(roiToSlice(roi.start, roi.stop)))
    
        opCache.Output.notifyDirty(handleDirty)
    
        opCache.fixAtCurrent.setValue(True)
    
        oldAccessCount = 0
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
    
        # Request (no access to provider because fixAtCurrent)
        slicing = make_key[:, 0:50, 15:45, 0:1, :]
        data = opCache.Output(slicing).wait()
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
    
        # We haven't accessed this data yet,
        #  but fixAtCurrent is True so the cache gives us zeros
        assert (data == 0).all()
    
        opCache.fixAtCurrent.setValue(False)
    
        # Request again.  Data should match this time.
        oldAccessCount = opProvider.accessCount
        data = opCache.Output(slicing).wait()
        data = data.view(vigra.VigraArray)
        data.axistags = opCache.Output.meta.axistags
        assert (data == self.data[slicing]).all()
    
        # Our slice intersects 3*3=9 outerBlocks, and a total of 20 innerBlocks
        # Inner caches are allowed to split up the accesses, so there could be as many as 20
        minAccess = oldAccessCount + 9
        maxAccess = oldAccessCount + 20
        assert opProvider.accessCount >= minAccess
        assert opProvider.accessCount <= maxAccess
        oldAccessCount = opProvider.accessCount
    
        # Request again.  Data should match WITHOUT requesting from the source.
        data = opCache.Output(slicing).wait()
        data = data.view(vigra.VigraArray)
        data.axistags = opCache.Output.meta.axistags
        assert (data == self.data[slicing]).all()
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
    
        # Freeze it again
        opCache.fixAtCurrent.setValue(True)
    
        # Clear previous
        gotDirtyKeys = []
    
        # Change some of the input data that ISN'T cached yet and mark it dirty
        dirtykey = make_key[0:1, 90:100, 90:100, 0:1, 0:1]
        self.data[dirtykey] = 0.12345
        opProvider.Input.setDirty(dirtykey)
    
        # Dirtiness not propagated due to fixAtCurrent
        assert len(gotDirtyKeys) == 0
    
        # Same request.  Data should still match the previous data (not yet refreshed)
        data2 = opCache.Output(slicing).wait()
        data2 = data2.view(vigra.VigraArray)
        data2.axistags = opCache.Output.meta.axistags
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
        assert (data2 == data).all()
    
        # Unfreeze.
        opCache.fixAtCurrent.setValue(False)
    
        # Dirty blocks are propagated after the cache is unfixed.
        assert len(gotDirtyKeys) > 0
    
        # Same request.  Data should be updated now that we're unfrozen.
        data = opCache.Output(slicing).wait()
        data = data.view(vigra.VigraArray)
        data.axistags = opCache.Output.meta.axistags
        assert (data == self.data[slicing]).all()
    
        # Dirty data did not intersect with this request.
        # Data should still be cached (no extra accesses)
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
    
        ###########################3
        # Freeze it again
        opCache.fixAtCurrent.setValue(True)
    
        # Clear previous
        gotDirtyKeys = []
    
        # Change some of the input data that IS cached and mark it dirty
        dirtykey = make_key[:, 0:25, 20:40, 0:1, :]
        self.data[dirtykey] = 0.54321
        opProvider.Input.setDirty(dirtykey)
    
        # Dirtiness not propagated due to fixAtCurrent
        assert len(gotDirtyKeys) == 0
    
        # Same request.  Data should still match the previous data (not yet refreshed)
        data2 = opCache.Output(slicing).wait()
        data2 = data2.view(vigra.VigraArray)
        data2.axistags = opCache.Output.meta.axistags
        assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(
            opProvider.accessCount, oldAccessCount
        )
        assert (data2 == data).all()
    
        # Unfreeze. Previous dirty notifications should now be seen.
        opCache.fixAtCurrent.setValue(False)
        assert len(gotDirtyKeys) > 0
    
        # Same request.  Data should be updated now that we're unfrozen.
        data = opCache.Output(slicing).wait()
        data = data.view(vigra.VigraArray)
        data.axistags = opCache.Output.meta.axistags
        assert (data == self.data[slicing]).all()
    
        # The dirty data intersected 2 outerBlocks, and a total of 6 innerblocks
        # Inner caches are allowed to split up the accesses, so there could be as many as 6
        minAccess = oldAccessCount + 2
        maxAccess = oldAccessCount + 6
        assert opProvider.accessCount >= minAccess
        assert opProvider.accessCount <= maxAccess
        oldAccessCount = opProvider.accessCount
    
        #####################
    
        #### Repeat plain dirty test to ensure fixAtCurrent didn't mess up the block states.
    
        gotDirtyKeys = []
        slicing = make_key[:, 0:50, 15:45, 0:10, :]
        data = opCache.Output(slicing).wait()
    
        # Change some of the input data and mark it dirty
        dirtykey = make_key[0:1, 10:11, 20:21, 0:3, 0:1]
        self.data[dirtykey] = 0.54321
        opProvider.Input.setDirty(dirtykey)
    
        assert len(gotDirtyKeys) > 0
    
        # Should need access again.
        opProvider.clear()
        data = opCache.Output(slicing).wait()
        data = data.view(vigra.VigraArray)
        data.axistags = opCache.Output.meta.axistags
        assert (data == self.data[slicing]).all()
    
        # The dirty data intersected 1*1*2 outerBlocks
        minAccess = 2
        maxAccess = 2
        assert opProvider.accessCount >= minAccess, "{} <= {}".format(opProvider.accessCount, minAccess)
>       assert opProvider.accessCount <= maxAccess, "{} <= {}".format(opProvider.accessCount, maxAccess)
E       AssertionError: 33 <= 2
E       assert 33 <= 2
E        +  where 33 = <lazyflow.utility.testing.OpArrayPiperWithAccessCount object at 0x719548650850>.accessCount

tests/test_lazyflow/test_operators/testOpSlicedBlockedArrayCache.py:334: AssertionError
```

</details>