### PR TITLE
OME-Zarr: Support reading from URIs with s3: scheme

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         # previous versions would set thread limits globally with side effects
         - python-elf >=0.4.8
         # s3fs allows zarr.storage.FSStore to read s3:// URIs
-        - s3fs
+        - s3fs >=2022.8.2
         - scikit-image
         - scikit-learn
         - tifffile >=2022

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -56,6 +56,8 @@ outputs:
         - pyqt 5.15.*
         # previous versions would set thread limits globally with side effects
         - python-elf >=0.4.8
+        # s3fs allows zarr.storage.FSStore to read s3:// URIs
+        - s3fs
         - scikit-image
         - scikit-learn
         - tifffile >=2022

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -52,6 +52,7 @@ dependencies:
   - zarr 2.*
   - aiohttp
   - fsspec
+  - s3fs
 
   # Deep learning dependencies (neural net workflow, trainable domain adaptation)
   # can be changed to request gpu versions

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -52,7 +52,7 @@ dependencies:
   - zarr 2.*
   - aiohttp
   - fsspec
-  - s3fs
+  - s3fs >=2022.8.2
 
   # Deep learning dependencies (neural net workflow, trainable domain adaptation)
   # can be changed to request gpu versions

--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -188,6 +188,7 @@ def get_default_config(
             "py.warnings": {"level": "WARN", "handlers": warnings_module_handlers, "propagate": False},
             "PyQt5": {"level": "INFO"},
             "requests": {"level": "WARN"},  # Lots of messages at INFO
+            "botocore.httpchecksum": {"level": "WARN"},
             "wsdt": {"level": "INFO"},
             "OpenGL": {"level": "INFO"},
             "yapsy": {"level": "INFO"},

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -100,6 +100,9 @@ class OpInputDataReader(Operator):
         h5_n5_Exts + n5Selection + npyExts + npzExts + rawExts + vigraImpexExts + blockwiseExts + videoExts + klbExts
     )
 
+    supported_ome_zarr_schemes = ["http:", "https:", "file:", "s3:"]
+    precomputed_protocol = "precomputed://"
+
     if _supports_dvid:
         dvidExts = ["dvidvol"]
         SupportedExtensions += dvidExts
@@ -301,7 +304,7 @@ class OpInputDataReader(Operator):
             return ([], None)
         if not isUrl(filePath):
             filePath = Path(filePath).as_uri()
-        if not any(filePath.startswith(scheme) for scheme in ["http", "file", "s3"]):
+        if not any(filePath.startswith(scheme) for scheme in self.supported_ome_zarr_schemes):
             return ([], None)
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.
         # We pass this down to the loader so that it can avoid loading scale metadata unnecessarily.
@@ -311,7 +314,7 @@ class OpInputDataReader(Operator):
         return [reader], reader.Output
 
     def _attemptOpenAsRESTfulPrecomputedChunkedVolume(self, filePath):
-        if not filePath.lower().startswith("precomputed://"):
+        if not filePath.lower().startswith(self.precomputed_protocol):
             return ([], None)
         reader = OpRESTfulPrecomputedChunkedVolumeReader(parent=self)
         reader.Scale.connect(self.ActiveScale)

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -301,7 +301,7 @@ class OpInputDataReader(Operator):
             return ([], None)
         if not isUrl(filePath):
             filePath = Path(filePath).as_uri()
-        if not (filePath.startswith("http") or filePath.startswith("file")):
+        if not any(filePath.startswith(scheme) for scheme in ["http", "file", "s3"]):
             return ([], None)
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.
         # We pass this down to the loader so that it can avoid loading scale metadata unnecessarily.

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -31,6 +31,7 @@ import jsonschema
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
+from botocore.exceptions import NoCredentialsError
 from zarr.core import Array as ZarrArray
 from zarr.errors import ArrayNotFoundError
 from zarr.storage import FSStore, LRUStoreCache
@@ -257,41 +258,82 @@ def _get_zarr_cache_max_size() -> int:
     return math.floor(caches_max * permissible_fraction_max)
 
 
+def _try_authenticated_aws_s3(uri, kwargs, mode, test_path) -> Optional[FSStore]:
+    authenticated_store = FSStore(uri, mode=mode, anon=False, **kwargs)
+    try:
+        authenticated_store[test_path]
+    except NoCredentialsError:
+        logger.warning(
+            "AWS S3 credentials are not set up. Will continue without authentication and assume "
+            "the bucket is public.\n"
+            "If this bucket may be private, please check your credentials are set up for S3FS."
+        )
+    except KeyError as ke:
+        if isinstance(ke.__context__.__context__, FileNotFoundError):
+            # Even if .zattrs isn't here, we still managed to access the bucket
+            logger.warning(
+                "S3 credentials found, continuing with authentication. "
+                "This may prevent access if the dataset is actually public."
+            )
+            return authenticated_store
+    else:
+        return authenticated_store
+    return None
+
+
+def _try_authenticated_s3_compatible(uri, kwargs, e, test_path) -> FSStore:
+    split_bucket = uri.split("/", 4)
+    if len(split_bucket) < 5:  # Does not follow S3 pattern (https://s3.server.org/bucket/file)
+        raise ConnectionError(
+            f"Server refused permission to read {uri}.\n"
+            "It seems authentication is required, but ilastik does not support this kind of server yet."
+        ) from e
+    base_uri_inc_bucket = "/".join(split_bucket[:4])
+    sub_uri = split_bucket[4]
+    fs = s3fs.S3FileSystem(anon=False, endpoint_url=base_uri_inc_bucket)
+    store = FSStore(sub_uri, fs=fs, **kwargs)
+    try:
+        store[test_path]
+    except (KeyError, NoCredentialsError) as ee:
+        if isinstance(ee.__context__, PermissionError) or isinstance(ee, NoCredentialsError):
+            # This probably is an S3-compatible store, but auth rejected/not found.
+            raise ConnectionError(
+                f"Server refused permission to read {uri}.\n"
+                f"Please ensure you have access to this bucket and your credentials are set up for S3FS."
+            ) from ee
+    return store
+
+
 def _ensure_connection_and_get_store(uri: str, mode="r", **kwargs) -> FSStore:
+    test_path = ".zattrs"
     if uri.startswith("file:"):
         # Zarr's FSStore implementation doesn't unescape file URLs before piping them to
         # the file system. We do it here the same way as in pathHelpers.uri_to_Path.
         # Primarily this is to deal with spaces in Windows paths (encoded as %20).
         uri = os.fsdecode(unquote_to_bytes(uri))
-    store = FSStore(uri, mode=mode, **kwargs)
+    if uri.startswith("s3:"):
+        # s3fs.S3FileSystem defaults to anon=False, but we want to try anon=True first
+        store = FSStore(uri, anon=True, mode=mode, **kwargs)
+    else:
+        # Non-S3 don't like to be called with anon keyword
+        store = FSStore(uri, mode=mode, **kwargs)
     try:
-        store["test"]
-        # Any error not handled here is either a successful connection (404 for "test"), or an unknown problem
-    except KeyError as e:
+        store[test_path]
+        # Any error not handled here is either a successful connection (even 404), or an unknown problem
+    except (KeyError, ClientResponseError) as e:
         # FSStore wraps some errors in KeyError (FileNotFoundError even double-wrapped)
         if isinstance(e.__context__, ClientConnectorError):
             raise ConnectionError(f"Could not connect to {e.__context__.host}:{e.__context__.port}.") from e
-    except ClientResponseError as e:
-        if not (e.status == 403 and uri.startswith("https://")):
-            raise
-        # 403 indicates we need authentication; FSStore maps https: to HTTPFileSystem, which cannot authenticate
-        split_bucket = uri.split("/", 4)
-        if len(split_bucket) < 5:  # Does not follow S3 pattern (https://s3.server.org/bucket/file)
-            raise ConnectionError(
-                f"Server refused permission to read {uri}.\nIt seems authentication is required, but ilastik does not support this kind of server yet."
-            ) from e
-        base_uri_inc_bucket = "/".join(split_bucket[:4])
-        sub_uri = split_bucket[4]
-        fs = s3fs.S3FileSystem(anon=False, endpoint_url=base_uri_inc_bucket)
-        store = FSStore(sub_uri, fs=fs, **kwargs)
-        try:
-            store["test"]
-        except KeyError as ke:
-            if isinstance(ke.__context__, PermissionError):
-                # This probably is an S3-compatible store, but auth rejected/not found.
-                raise ConnectionError(
-                    f"Server refused permission to read {uri}.\nCheck your S3 credentials setup."
-                ) from ke
+        if isinstance(e.__context__, PermissionError) and uri.startswith("s3:"):
+            # Depending on bucket setup, AWS S3 may respond with "PermissionError: Access Denied"
+            # even if the bucket is public (but the .zattrs file is not at this URI).
+            # So test if authentication is set up, but continue with the unauthenticated store if not.
+            authenticated_store = _try_authenticated_aws_s3(uri, kwargs, mode, test_path)
+            if authenticated_store is not None:
+                store = authenticated_store
+        if isinstance(e, ClientResponseError) and e.status == 403:
+            # Server requires authentication. Try if it's an S3-compatible store.
+            store = _try_authenticated_s3_compatible(uri, kwargs, e, test_path)
     return store
 
 

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -903,7 +903,6 @@ class TestOpDataSelection_OMEZarr:
     CHUNK_SIZE_ZYX = (1, 16, 16)
     IMAGE_SCALED = numpy.random.randint(0, 256, SHAPE_SCALED_ZYX, dtype=numpy.uint16)
     IMAGE_ORIGINAL = numpy.random.randint(0, 256, SHAPE_ORIGINAL_ZYX, dtype=numpy.uint16)
-    MOCK_DATASET_URL = "https://localhost:8000/dataset.zarr"
     S1ZARRAY = {
         "zarr_format": 2,
         "shape": list(SHAPE_SCALED_ZYX),
@@ -970,9 +969,9 @@ class TestOpDataSelection_OMEZarr:
         images = {"s0": self.IMAGE_ORIGINAL, "s1": self.IMAGE_SCALED}
         monkeypatch.setattr(zarr.Array, "__getitem__", lambda _self, slicing: images[_self.path][slicing])
 
-    @pytest.fixture
-    def datasetInfo(self, monkeypatch, mock_ome_zarr_metadata):
-        return MultiscaleUrlDatasetInfo(url=self.MOCK_DATASET_URL)
+    @pytest.fixture(params=["https://localhost:8000/dataset.zarr", "s3://some-bucket/dataset.zarr"])
+    def datasetInfo(self, request, monkeypatch, mock_ome_zarr_metadata):
+        return MultiscaleUrlDatasetInfo(url=request.param)
 
     @pytest.fixture
     def op(self, graph, monkeypatch, datasetInfo):
@@ -1024,7 +1023,7 @@ class TestOpDataSelection_OMEZarr:
         monkeypatch.setattr(zarr.Array, "__init__", track_instances)
 
         # Make sure that instantiating a DatasetInfo does not load more than one scale into a zarr.Array
-        _ = MultiscaleUrlDatasetInfo(url=self.MOCK_DATASET_URL)
+        _ = MultiscaleUrlDatasetInfo(url="https://some.url.com/dataset.zarr")
         assert zarr.Array.instance_counter == 1
 
 

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -969,7 +969,13 @@ class TestOpDataSelection_OMEZarr:
         images = {"s0": self.IMAGE_ORIGINAL, "s1": self.IMAGE_SCALED}
         monkeypatch.setattr(zarr.Array, "__getitem__", lambda _self, slicing: images[_self.path][slicing])
 
-    @pytest.fixture(params=["https://localhost:8000/dataset.zarr", "s3://some-bucket/dataset.zarr"])
+    @pytest.fixture(
+        params=[
+            "https://localhost:8000/dataset.zarr",
+            "s3://some-bucket/dataset.zarr",
+            "https://s3.selfhoster.com/bucket/dataset.zarr",
+        ]
+    )
     def datasetInfo(self, request, monkeypatch, mock_ome_zarr_metadata):
         return MultiscaleUrlDatasetInfo(url=request.param)
 

--- a/tests/test_ilastik/test_applets/thresholdTwoLevels/testOpGraphcutSegment.py
+++ b/tests/test_ilastik/test_applets/thresholdTwoLevels/testOpGraphcutSegment.py
@@ -25,7 +25,7 @@ import numpy as np
 import vigra
 import pytest
 
-from numpy.testing.utils import assert_array_equal, assert_array_almost_equal, assert_array_less
+from numpy.testing import assert_array_equal
 
 from lazyflow.graph import Graph
 from lazyflow.operators.opArrayPiper import OpArrayPiper

--- a/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
@@ -60,12 +60,6 @@ def count_s3fs_instances(monkeypatch):
     return track_instances
 
 
-def test_maps_s3_scheme_to_s3fs(count_s3fs_instances):
-    with pytest.raises(NoOMEZarrMetaFound):
-        OMEZarrStore("s3://some-nonexistent-bucket-foobar123/some.zarr")
-    assert s3fs.core.S3FileSystem.instance_counter == 1
-
-
 @pytest.fixture
 def mock_httpfs_403(monkeypatch):
     # Mimics what happens when an S3-compatible store is accessed with a default fsspec HTTPFileSystem

--- a/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_OMEZarrStore.py
@@ -19,15 +19,64 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
+import asyncio
+from unittest import mock
+
+import fsspec.implementations.http
 import pytest
+import s3fs
+from aiohttp import ClientResponseError
 
-from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore
+from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore, NoOMEZarrMetaFound
 
 
-def test_OMEZarrStore_handles_wrapped_connection_error():
+def test_handles_wrapped_connection_error(monkeypatch):
     # zarr.storage.FSStore raises a ClientConnectorError wrapped in a KeyError
     # when the web connection fails. We handle this by re-raising as ConnectionError.
     # Check that it hasn't changed in the zarr library.
-    nonsense_host = "nonexistent-address.zarr.foobar123"
-    with pytest.raises(ConnectionError, match=nonsense_host):
-        OMEZarrStore(f"https://{nonsense_host}")
+    f = asyncio.Future()
+    f.set_result("{}")
+    monkeypatch.setattr(fsspec.implementations.http.HTTPFileSystem, "_cat_file", lambda _, __: f)
+    with pytest.raises(NoOMEZarrMetaFound):
+        OMEZarrStore(f"https://nonexistent-address.zarr.foobar123")
+
+
+@pytest.fixture
+def count_s3fs_instances(monkeypatch):
+    # Simply patching __init__ with a mock is iffy because fsspec does custom imports
+    s3fs.core.S3FileSystem.instance_counter = 0
+    s3fs_init = s3fs.core.S3FileSystem.__init__
+
+    def track_instances(*args, **kwargs):
+        s3fs.core.S3FileSystem.instance_counter += 1
+        return s3fs_init(*args, **kwargs)
+
+    monkeypatch.setattr(s3fs.core.S3FileSystem, "__init__", track_instances)
+    # Prevent actually sending web requests
+    f = asyncio.Future()
+    f.set_result("{}")
+    monkeypatch.setattr(s3fs.core.S3FileSystem, "_cat_file", lambda _, __: f)
+
+    return track_instances
+
+
+def test_maps_s3_scheme_to_s3fs(count_s3fs_instances):
+    with pytest.raises(NoOMEZarrMetaFound):
+        OMEZarrStore("s3://some-nonexistent-bucket-foobar123/some.zarr")
+    assert s3fs.core.S3FileSystem.instance_counter == 1
+
+
+@pytest.fixture
+def mock_httpfs_403(monkeypatch):
+    # Mimics what happens when an S3-compatible store is accessed with a default fsspec HTTPFileSystem
+    # E.g. when passing "https://s3.embl.de/bucket/file" to zarr.storage.FSStore
+    def raise_403(_, __):
+        raise ClientResponseError(status=403, request_info=mock.Mock(), history=mock.Mock())
+
+    monkeypatch.setattr(fsspec.implementations.http.HTTPFileSystem, "_cat_file", raise_403)
+
+
+def test_maps_https_scheme_to_s3fs_on_403(count_s3fs_instances, mock_httpfs_403):
+    with pytest.raises(NoOMEZarrMetaFound):
+        OMEZarrStore(f"https://localhost/bucket/some.zarr")
+    assert s3fs.core.S3FileSystem.instance_counter == 1


### PR DESCRIPTION
This enables reading OME-Zarr from URIs pointing to AWS S3 and S3-compatible objects.

## AWS S3

You can try it live with a public bucket I set up for testing: `s3://btbest-public/img.zarr/`

While it's not super user friendly, this also at least enables users to access S3 buckets that require authentication _at all_, by setting up a credentials file in the default location (`~/.aws/credentials`). Alternatively, one can invoke ilastik with the credentials as env variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).

You cannot try it with the private bucket that I also set up to try the authenticated access :) (at least not without some private communication)

Setting up your own private bucket for testing is quite a bit of work. You have to:

1. Create an AWS account (which requires payment information)
2. Set up billing rules to make sure you get at least an alert if something shady happens and you incur charges
3. Create a private S3 bucket
4. Upload some OME-Zarr folder to it
5. Create a new user in your IAM, and a new user group to assign it into, and an access policy for the group that gives readonly for S3
6. Create an access key for the user
7. Store the [access key and secret in a file](https://github.com/aws/aws-cli/?tab=readme-ov-file#configuration) called `~/.aws/credentials`

This file has to be present _before_ you run ilastik, botocore seems to only pick it up on first load/import.

Considering all the work involved in just setting this up, maybe we don't even need to make authentication more convenient than that. People who want to use S3 might already be accustomed to authenticating this way and it will "just work" for them.

## S3-compatible

All of the public OME-Zarr datasets on IDR are actually hosted on S3-compatible storage, so the publicly accessible ones have been supported since day 1 (e.g. https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr)

Access requiring authentication apparently works according to email with collaborators. I admittedly haven't tried it with s3.embl.de.