### PR TITLE
bump vigra to 1.11.1 build 1038

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           set VOLUMINA_SHOW_3D_WIDGET=0
           conda build --test --override-channels ^
-            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge -c conda-forge ^
+            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge/label/patched -c ilastik-forge -c conda-forge ^
             ./pkgs/noarch/%ILASTIK_PACKAGE_NAME%
         # HACK: due to a bug in conda-build need to point to
         # libarchive explicitly.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
         - setuptools_scm
       run:
         - python >=3.7
-        - numpy >1.12
+        - numpy >1.12,<1.23
         # aiohttp to enable zarr.storage.FSStore
         - aiohttp
         - appdirs

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -61,7 +61,7 @@ outputs:
         - tifffile >=2022
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
-        - vigra
+        - vigra 1.11.1=*_1038
         - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
         - z5py
         - zarr 2.*

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -1,6 +1,10 @@
 channels:
   - pytorch
 #  - nvidia  # uncomment for pytorch with cuda
+  # ilastik-forge/label/patched contains patched versions of pyshtools
+  # with certain dependencies removed that made solving the ilastik
+  # environment impossible / extremely inflexible
+  - ilastik-forge/label/patched
   - ilastik-forge
   - conda-forge
   - nodefaults

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -40,7 +40,7 @@ dependencies:
   - tifffile >=2022
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
-  - vigra 1.11.1=*_1033
+  - vigra 1.11.1=*_1038
   # xarray versions not compatible with numpy 1.21, 2023.08.0 might be, but lost trust
   # 2023.10.1 correctly pins numpy to 1.22 and up
   - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0


### PR DESCRIPTION
build 1038 is the latest version of vigra built against boost 1.78.0 (which is the latest boost version we have builds of our packages for, that depend on it).

Note for windows devs (@btbest): It's now necessary to include `ilastik-forge/label/patched` if you want to create a development env close to the release env (where the patched pyshtools is already used).
