### PR TITLE
Error on missing plugin

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationSerializer.py
+++ b/ilastik/applets/objectClassification/objectClassificationSerializer.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2025, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -18,8 +18,6 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-import warnings
-
 from ilastik.applets.base.appletSerializer import (
     AppletSerializer,
     SerialSlot,
@@ -28,20 +26,6 @@ from ilastik.applets.base.appletSerializer import (
     SerialListSlot,
     SerialPickleableSlot,
 )
-
-
-class SerialDictSlotWithoutDeserialization(SerialDictSlot):
-    def __init__(self, slot, mainOperator, **kwargs):
-        super(SerialDictSlotWithoutDeserialization, self).__init__(slot, **kwargs)
-        self.mainOperator = mainOperator
-
-    def serialize(self, group):
-        # if self.slot.ready() and self.mainOperator._predict_enabled:
-        return SerialDictSlot.serialize(self, group)
-
-    def deserialize(self, group):
-        # Do not deserialize this slot
-        pass
 
 
 class ObjectClassificationSerializer(AppletSerializer):

--- a/ilastik/applets/objectExtraction/objectExtractionSerializer.py
+++ b/ilastik/applets/objectExtraction/objectExtractionSerializer.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2025, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -19,6 +19,7 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 import logging
+from typing import Optional
 
 import numpy
 
@@ -33,6 +34,7 @@ from ilastik.applets.base.appletSerializer import (
 )
 from ilastik.plugins.manager import pluginManager
 from ilastik.utility.commandLineProcessing import convertStringToList
+from lazyflow.slot import InputSlot, OutputSlot
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +45,17 @@ class UnsatisfyableObjectFeaturesError(BaseException):
 
 
 class SerialObjectFeaturesSlot(SerialSlot):
-    def __init__(self, slot, inslot, blockslot, name=None, subname=None, default=None, depends=None, selfdepends=True):
+    def __init__(
+        self,
+        slot: OutputSlot,
+        inslot: InputSlot,
+        blockslot: OutputSlot,
+        name: Optional[str] = None,
+        subname=None,
+        default=None,
+        depends=None,
+        selfdepends=True,
+    ):
         super(SerialObjectFeaturesSlot, self).__init__(slot, inslot, name, subname, default, depends, selfdepends)
 
         self.blockslot = blockslot

--- a/ilastik/applets/objectExtraction/opObjectExtraction.py
+++ b/ilastik/applets/objectExtraction/opObjectExtraction.py
@@ -661,6 +661,7 @@ class OpRegionFeatures(Operator):
 
         def compute_for_one_plugin(plugin_name, feature_dict):
             plugin_inner = pluginManager.getPluginByName(plugin_name, "ObjectFeatures")
+            assert plugin_inner, f"object features plugin {plugin_name} missing!"
             global_features[plugin_name] = plugin_inner.plugin_object.compute_global(image, labels, feature_dict, axes)
 
         for plugin_name, feature_dict in feature_names.items():

--- a/ilastik/excepthooks.py
+++ b/ilastik/excepthooks.py
@@ -77,7 +77,9 @@ def init_user_mode_excepthook():
 
             root_exc = root_cause(exc_value)
 
-            msg = f"{exc_value!r}\n\nwith root cause:\n\n{root_exc!r}\n\n"
+            msg = f"{exc_value!r}\n\n"
+            if root_exc != exc_value:
+                msg += f"with root cause:\n\n{root_exc!r}\n\n"
 
             logfile_path = get_logfile_path()
             if logfile_path:

--- a/tests/test_ilastik/test_applets/objectExtraction/testObjectExtractionSerializer.py
+++ b/tests/test_ilastik/test_applets/objectExtraction/testObjectExtractionSerializer.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+import numpy
+import pytest
+
+from ilastik.applets.objectExtraction.objectExtractionSerializer import (
+    ObjectExtractionSerializer,
+    UnsatisfyableObjectFeaturesError,
+)
+from lazyflow.utility.testing import SlotDesc, build_multi_output_mock_op
+
+
+@pytest.fixture
+def mock_op(graph):
+    slot_data = {
+        "LabelImage": SlotDesc(typ_="output", level=1, dtype=numpy.uint32, shape=(5, 6, 1), axistags="yxc"),
+        "LabelImageCacheInput": SlotDesc(typ_="input", level=1, dtype=numpy.uint32, shape=(5, 6, 1), axistags="yxc"),
+        "CleanLabelBlocks": SlotDesc(typ_="output", level=1, dtype=object, shape=(1,)),
+        "Features": SlotDesc(typ_="input", level=0, dtype=object, shape=(1,)),
+        "BlockwiseRegionFeatures": SlotDesc(typ_="output", level=1),
+        "RegionFeaturesCacheInput": SlotDesc(typ_="input", level=1),
+        "RegionFeaturesCleanBlocks": SlotDesc(typ_="output", level=1),
+    }
+    return build_multi_output_mock_op(slot_data, graph, n_lanes=2)
+
+
+@pytest.fixture
+def project_group_name():
+    return "ObjectExtraction"
+
+
+@pytest.fixture
+def serializer(mock_op, project_group_name):
+    serializer = ObjectExtractionSerializer(mock_op, project_group_name)
+    return serializer
+
+
+@patch("ilastik.plugins.manager.pluginManager.getPluginByName")
+def test_deserializeFromHdf5_missing_feature_plugin(
+    mocked_plugin_fct, serializer, project_group_name, empty_in_memory_project_file
+):
+    mocked_plugin_fct.return_value = False
+
+    empty_in_memory_project_file.create_dataset(f"/{project_group_name}/StorageVersion", data=b"1.0")
+    empty_in_memory_project_file.create_dataset(
+        f"/{project_group_name}/Features/SomeNoneExistingPlugin/SomeNoneExistingFeature", data=numpy.void(b"test")
+    )
+    with pytest.raises(UnsatisfyableObjectFeaturesError):
+        serializer.deserializeFromHdf5(empty_in_memory_project_file, empty_in_memory_project_file.name)
+
+
+@patch("ilastik.plugins.manager.pluginManager.getPluginByName")
+def test_deserializeFromHdf5_no_missing_feature_plugin(
+    mocked_plugin_fct, mock_op, serializer, project_group_name, empty_in_memory_project_file
+):
+    mocked_plugin_fct.return_value = True
+
+    empty_in_memory_project_file.create_dataset(f"/{project_group_name}/StorageVersion", data=b"1.0")
+    empty_in_memory_project_file.create_dataset(
+        f"/{project_group_name}/Features/SomeExistingPlugin/SomeExistingFeature", data=b"test"
+    )
+
+    serializer.deserializeFromHdf5(empty_in_memory_project_file, empty_in_memory_project_file.name)
+
+    assert mock_op.Features[()].wait() == [{"SomeExistingPlugin": {"SomeExistingFeature": "test"}}]


### PR DESCRIPTION
This PR adds a check to the deserialization logic of `ObjectExtractionApplet` that checks that all plugins for feature computation are available when deserializing to avoid loading projects where some features can not be computed.

fixes https://github.com/ilastik/ilastik/issues/2942