### PR TITLE
Better recovery from batch processing failures

### DIFF
--- a/ilastik/applets/dataExport/dataExportApplet.py
+++ b/ilastik/applets/dataExport/dataExportApplet.py
@@ -23,6 +23,7 @@ import argparse
 # 		   http://ilastik.org/license.html
 ###############################################################################
 import os
+from typing import Union
 
 import numpy
 
@@ -100,19 +101,16 @@ class DataExportApplet(Applet):
     # The following functions act as hooks for subclasses to override or clients to
     # monkey-patch for custom behavior before/during/after an export is performed.
     # (The GUI and/or batch applet will call them at the appropriate time.)
-    def prepare_for_entire_export(self):
+    def prepare_for_entire_export(self) -> None:
         """Called before the entire export process starts"""
-        pass
 
-    def prepare_lane_for_export(self, lane_index):
+    def prepare_lane_for_export(self, lane_index: int) -> None:
         """Called before each lane is exported."""
-        pass
 
-    def post_process_lane_export(self, lane_index):
+    def post_process_lane_export(self, lane_index: int, checkOverwriteFiles: bool = False) -> Union[None, bool]:
         """Called immediately after each lane is exported."""
-        pass
 
-    def post_process_entire_export(self):
+    def post_process_entire_export(self) -> None:
         """Called after the entire export process finishes."""
 
     @classmethod

--- a/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingApplet.py
+++ b/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingApplet.py
@@ -1,0 +1,99 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2025, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from unittest.mock import Mock
+
+import pytest
+
+from ilastik.applets.batchProcessing.batchProcessingApplet import BatchProcessingApplet
+from ilastik.applets.dataSelection.opDataSelection import OpMultiLaneDataSelectionGroup
+
+
+@pytest.fixture
+def dataselectionApplet():
+    dsa = Mock()
+    dsa.num_lanes = 3  # required by BatchProcessingApplet.export_dataset
+    dsa.topLevelOperator = Mock(spec=OpMultiLaneDataSelectionGroup)
+    return dsa
+
+
+@pytest.fixture
+def batchProcessingApplet(dataselectionApplet):
+    bpa = BatchProcessingApplet(
+        workflow=Mock(), title="test", dataSelectionApplet=dataselectionApplet, dataExportApplet=Mock()
+    )
+    return bpa
+
+
+def test_BatchProcessingCallsCustomizationHooks(batchProcessingApplet):
+    """
+    Make sure the customizationhooks
+    * `prepare_for_entire_export`
+    * `prepare_lane_for_export`
+    * `post_process_lane_export`
+    * `post_process_entire_export`
+
+    see `ilastik.applets.dataExport.DataExportApplet.prepare_for_entire_export`
+    """
+    dataExportApplet = batchProcessingApplet.dataExportApplet
+
+    dataExportApplet.prepare_for_entire_export.x.blah2.assert_not_called()
+    dataExportApplet.post_process_entire_export.assert_not_called()
+    dataExportApplet.prepare_lane_for_export.assert_not_called()
+    dataExportApplet.post_process_lane_export.assert_not_called()
+
+    export_function = Mock()
+
+    lane_configs = list(range(42))
+
+    batchProcessingApplet.run_export(lane_configs=lane_configs, export_to_array=False, export_function=export_function)
+
+    dataExportApplet.prepare_for_entire_export.assert_called_once()
+    dataExportApplet.post_process_entire_export.assert_called_once()
+    assert dataExportApplet.prepare_lane_for_export.call_count == len(lane_configs)
+    assert dataExportApplet.post_process_lane_export.call_count == len(lane_configs)
+
+
+def test_BatchProcessingCallsPostProcessOnException(batchProcessingApplet):
+    """
+    Make sure the customizationhooks `post_process_entire_export` is called even
+    in case of errors.
+    """
+    dataExportApplet = batchProcessingApplet.dataExportApplet
+
+    dataExportApplet.prepare_for_entire_export.x.blah2.assert_not_called()
+    dataExportApplet.post_process_entire_export.assert_not_called()
+    dataExportApplet.prepare_lane_for_export.assert_not_called()
+    dataExportApplet.post_process_lane_export.assert_not_called()
+
+    export_function = Mock()
+    export_function.side_effect = Exception("Who knows")
+
+    lane_configs = [0]
+
+    with pytest.raises(Exception):
+        batchProcessingApplet.run_export(
+            lane_configs=lane_configs, export_to_array=False, export_function=export_function
+        )
+
+    dataExportApplet.prepare_for_entire_export.assert_called_once()
+    dataExportApplet.post_process_entire_export.assert_called_once()
+    dataExportApplet.prepare_lane_for_export.assert_called_once()
+    dataExportApplet.post_process_lane_export.assert_not_called()


### PR DESCRIPTION
This PR ensures pre- (`prepare_for_entire_export`) and post export (`post_process_entire_export`) hooks are called, even in failure cases (those are used e.g. to open/close files with summaries (in counting)).

Also fixed call order of `prepare_for_entire_export` which was called for every lane and resulted in tables in counting being overwritten for each file.

Also fixed a few type annotations.

Fixes #2159 (coincidence ;) didn't investigate this specifically)
