### PR TITLE
Added drag-n-drop support for projects to startup page

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -415,11 +415,32 @@ class StartupContainer(QWidget):
         if mimedata is None:
             return
         urls = mimedata.urls()
-        assert len(urls) == 1, f"Drag and drop should only ever get a single path, got {len(urls)}"
+
+        if len(urls) > 1:
+            QMessageBox.information(
+                self,
+                "Cannot open more than one 'ilp' file",
+                (
+                    "You were trying to open an ilastik project file via drag and drop. "
+                    "However, you gave more than a single file.\n\n"
+                    "Please try again using only a single file with the '.ilp' file extension."
+                ),
+            )
+            return
+
         url = urls[0].toLocalFile()
-        assert url.endswith(
-            ".ilp"
-        ), f"Drag and drop should should only ever receive files that end in '.ilp', got {url}"
+        if not url.endswith(".ilp"):
+            QMessageBox.information(
+                self,
+                f"Cannot open {url}",
+                (
+                    "You were trying to open an ilastik project file via drag and drop. "
+                    "However, you gave a single file that seems not to be an ilastik project file. "
+                    f"Got {url}.\n\n"
+                    "Please try again using only a single file with the '.ilp' file extension instead."
+                ),
+            )
+            return
         self.ilpDropped.emit(url)
 
     def dragEnterEvent(self, a0):
@@ -433,11 +454,7 @@ class StartupContainer(QWidget):
             return
         urls = mimedata.urls()
 
-        if len(urls) != 1:
-            return
-
-        url = urls[0]
-        if url.isLocalFile() and url.fileName().endswith(".ilp"):
+        if all(url.isLocalFile() for url in urls):
             a0.acceptProposedAction()
 
 

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -449,7 +449,7 @@ class StartupContainer(QWidget):
         mimedata = a0.mimeData()
         if mimedata is None:
             return
-        # Only accept drag-and-drop events that consist of urls to local .ilp files.
+        # Only accept drag-and-drop events that consist of urls to local files.
         if not mimedata.hasUrls():
             return
         urls = mimedata.urls()

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -215,9 +215,9 @@
                 </spacer>
                </item>
                <item>
-                <widget class="QLabel" name="twitterLinkLabel">
+                <widget class="QLabel" name="bskyLinkLabel">
                  <property name="text">
-                  <string notr="true">&lt;a href=&quot;https://twitter.com/ilastik_team&quot;&gt;@ilastik_team&lt;/a&gt;</string>
+                  <string notr="true">&lt;a href=&quot;https://bsky.app/profile/ilastik-team.bsky.social&quot;&gt;@ilastik-team&lt;/a&gt;</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignCenter</set>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -32,7 +32,7 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="startupPage">
+      <widget class="StartupContainer" name="startupPage">
        <layout class="QVBoxLayout" name="verticalLayout_5">
         <item>
          <layout class="QVBoxLayout" name="verticallayout">
@@ -649,6 +649,11 @@
    <extends>QToolBox</extends>
    <header>ilastik.widgets.appletDrawerToolBox</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>StartupContainer</class>
+   <extends>QWidget</extends>
+   <header>ilastik.shell.gui.ilastikShell</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/tests/test_ilastik/test_shell/test_startup_dnd.py
+++ b/tests/test_ilastik/test_shell/test_startup_dnd.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from PyQt5.QtCore import QUrl
+from PyQt5.QtWidgets import QMessageBox
+
+from ilastik.shell.gui.ilastikShell import StartupContainer
+
+
+@pytest.fixture
+def startup_container(qtbot):
+    container = StartupContainer()
+    qtbot.addWidget(container)
+    return container
+
+
+@pytest.fixture
+def intercept_info_popup(monkeypatch):
+    info_mock = Mock()
+    monkeypatch.setattr(QMessageBox, "information", lambda *args: info_mock(*args))
+    return info_mock
+
+
+def drag_n_drop_event(filenames):
+    dndevent = Mock()
+    urls = [QUrl.fromLocalFile(x) for x in filenames]
+    dndevent.mimeData.return_value.has_urls.return_value = True
+    dndevent.mimeData.return_value.urls.return_value = urls
+    return dndevent
+
+
+def test_single_ilp_file_drop(qtbot, startup_container):
+    event = drag_n_drop_event(["/path/to/project.ilp"])
+
+    with qtbot.waitSignal(startup_container.ilpDropped, timeout=100) as sig_receiver:
+        startup_container.dropEvent(event)
+
+    assert sig_receiver.args == ["/path/to/project.ilp"]
+
+
+def test_multiple_files_drop(intercept_info_popup, startup_container):
+    event = drag_n_drop_event(["/path/to/project1.ilp", "/path/to/project2.ilp"])
+
+    startup_container.dropEvent(event)
+
+    intercept_info_popup.assert_called_once_with(
+        startup_container,
+        "Cannot open more than one 'ilp' file",
+        (
+            "You were trying to open an ilastik project file via drag and drop. "
+            "However, you gave more than a single file.\n\n"
+            "Please try again using only a single file with the '.ilp' file extension."
+        ),
+    )
+
+
+def test_non_ilp_file_drop(intercept_info_popup, startup_container):
+    event = drag_n_drop_event(["/path/to/project.txt"])
+
+    startup_container.dropEvent(event)
+
+    intercept_info_popup.assert_called_once_with(
+        startup_container,
+        "Cannot open /path/to/project.txt",
+        (
+            "You were trying to open an ilastik project file via drag and drop. "
+            "However, you gave a single file that seems not to be an ilastik project file. "
+            "Got /path/to/project.txt.\n\n"
+            "Please try again using only a single file with the '.ilp' file extension instead."
+        ),
+    )
+
+
+def test_drag_enter_event_local_file_accepted(startup_container):
+    event = drag_n_drop_event(["/path/to/project.txt"])
+    startup_container.dragEnterEvent(event)
+    event.acceptProposedAction.assert_called_once_with()
+
+
+def test_drag_enter_event_no_urls_returns(startup_container):
+    event = Mock()
+    event.mimeData.return_value.hasUrls.return_value = False
+    startup_container.dragEnterEvent(event)
+    event.acceptProposedAction.assert_not_called()


### PR DESCRIPTION
Going via the "open file" dialog always is a pain.

Also since I'm already touching files here: replaced twitter link with link to bluesky ❤️ 

Todos:

- [x] Add tests
