### PR TITLE
OC: Add undo/redo for object level annotations

### DIFF
--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -780,7 +780,7 @@ class ObjectClassificationGui(LabelingGui):
 
     def _updateObjLabel(self, imageIndex, pos5d, label):
         try:
-            new_labels, old_label, dirty_key = self.topLevelOperatorView.updateObjectLabel(imageIndex, pos5d)
+            new_labels, old_label, dirty_key = self.topLevelOperatorView.prepareObjectLabels(imageIndex, pos5d)
         except IndexError:
             return
 

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -25,6 +25,7 @@ from PyQt5.QtCore import pyqtSlot, Qt
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QFileDialog, QTableWidget, QTableWidgetItem, QGridLayout, QProgressBar
 
+from ilastik.applets.objectClassification.opObjectClassification import InvalidObjectIndex
 from ilastik.applets.objectExtraction.opObjectExtraction import default_features_key
 
 import os
@@ -781,7 +782,7 @@ class ObjectClassificationGui(LabelingGui):
     def _updateObjLabel(self, imageIndex, pos5d, label):
         try:
             new_labels, old_label, dirty_key = self.topLevelOperatorView.prepareObjectLabels(imageIndex, pos5d)
-        except IndexError:
+        except InvalidObjectIndex:
             return
 
         self._undoStack.push(

--- a/ilastik/applets/objectClassification/objectClassificationGui.py
+++ b/ilastik/applets/objectClassification/objectClassificationGui.py
@@ -32,6 +32,7 @@ import copy
 import vigra
 
 import numpy
+import numpy.typing as npt
 import weakref
 from functools import partial
 
@@ -43,6 +44,8 @@ from ilastik.plugins.manager import pluginManager
 from lazyflow.request import Request, RequestPool
 
 import logging
+
+from lazyflow.slot import InputSlot
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +83,47 @@ class FeatureSubSelectionDialog(FeatureSelectionDialog):
         self.ui.label.setVisible(False)
         self.ui.label_2.setVisible(False)
         self.ui.label_z.setVisible(False)
+
+
+class LabelObjectCommand(QUndoCommand):
+    """Redo/Undo for object labelings
+
+    Note: the undo is not 100% true: In object classification the labeling dictionary
+    is somewhat sparse - it will only contain entries up to the labeled object with
+    the highest object id. The undo here will not revert the potential increase
+    in dictionary size.
+    Clearing a label in object classification will also not touch the length of
+    this label array, so that's in a way consistent.
+    """
+
+    def __init__(
+        self,
+        parent=None,
+        *,
+        slot: InputSlot,
+        labelsdict: dict[int, npt.NDArray],
+        old_value: int,
+        new_value: int,
+        dirty_key,
+    ):
+        super().__init__(parent)
+        self.__labels = labelsdict
+        self.__old_value = old_value
+        self.__new_value = new_value
+        self.__dirty_key = dirty_key
+        self.__slot = slot
+
+    def _update_label(self, value):
+        time_index, object_index = self.__dirty_key
+        self.__labels[time_index][object_index] = value
+        self.__slot.setValue(self.__labels)
+        self.__slot.setDirty(self.__dirty_key)
+
+    def redo(self):
+        self._update_label(self.__new_value)
+
+    def undo(self):
+        self._update_label(self.__old_value)
 
 
 class ObjectClassificationGui(LabelingGui):
@@ -219,6 +263,10 @@ class ObjectClassificationGui(LabelingGui):
         self.checkEnableButtons()
 
         self._labelAssistDialog = None
+
+        self._undoStack = self.editor._undoStack
+        fn = self.op.BinaryImages.notifyDirty(lambda *_, **__: self._undoStack.clear())
+        self.__cleanup_fns.append(fn)
 
     def menus(self):
         m = QMenu("&Export", self.volumeEditorWidget)
@@ -730,6 +778,22 @@ class ObjectClassificationGui(LabelingGui):
         arr = slot[slicing].wait()
         return arr.flat[0]
 
+    def _updateObjLabel(self, imageIndex, pos5d, label):
+        try:
+            new_labels, old_label, dirty_key = self.topLevelOperatorView.updateObjectLabel(imageIndex, pos5d)
+        except IndexError:
+            return
+
+        self._undoStack.push(
+            LabelObjectCommand(
+                slot=self.topLevelOperatorView.LabelInputs,
+                labelsdict=new_labels,
+                old_value=old_label,
+                new_value=label,
+                dirty_key=dirty_key,
+            )
+        )
+
     def onClick(self, layer, pos5d, pos):
         """Extracts the object index that was clicked on and updates
         that object's label.
@@ -748,7 +812,7 @@ class ObjectClassificationGui(LabelingGui):
         ), "Need to update onClick() if the operator no longer expects volumina axis order.  Operator wants: {}".format(
             operatorAxisOrder
         )
-        self.topLevelOperatorView.assignObjectLabel(imageIndex, pos5d, label)
+        self._updateObjLabel(imageIndex, pos5d, label)
 
     def handleEditorRightClick(self, position5d, globalWindowCoordinate):
         layer = self.getLayer("Labels")
@@ -831,7 +895,7 @@ class ObjectClassificationGui(LabelingGui):
         elif action.text() == clearlabel:
             topLevelOp = self.topLevelOperatorView.viewed_operator()
             imageIndex = topLevelOp.LabelInputs.index(self.topLevelOperatorView.LabelInputs)
-            self.topLevelOperatorView.assignObjectLabel(imageIndex, position5d, 0)
+            self._updateObjLabel(imageIndex, position5d, 0)
 
         # todo: remove old
         elif self.applet.connected_to_knime:
@@ -852,7 +916,7 @@ class ObjectClassificationGui(LabelingGui):
                 return
             topLevelOp = self.topLevelOperatorView.viewed_operator()
             imageIndex = topLevelOp.LabelInputs.index(self.topLevelOperatorView.LabelInputs)
-            self.topLevelOperatorView.assignObjectLabel(imageIndex, position5d, label + 1)
+            self._updateObjLabel(imageIndex, position5d, label + 1)
 
     def setVisible(self, visible):
         super(ObjectClassificationGui, self).setVisible(visible)

--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -51,6 +51,10 @@ logger = logging.getLogger(__name__)
 MISSING_VALUE = 0
 
 
+class InvalidObjectIndex(BaseException):
+    pass
+
+
 class TableExporter(ExportingOperator):
     def __init__(self, op):
         self._op = op
@@ -575,7 +579,7 @@ class OpObjectClassification(Operator, MultiLaneOperatorABC):
 
         objIndex = arr.flat[0]
         if objIndex == 0:  # background; FIXME: do not hardcode
-            raise IndexError("Background label selected")
+            raise InvalidObjectIndex("Background label selected")
         timeCoord = coordinate[0]
         labelslot = self.LabelInputs[imageIndex]
         labelsdict = labelslot.value

--- a/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
+++ b/tests/test_ilastik/test_applets/blockwiseObjectClassification/testOpBlockwiseObjectClassification.py
@@ -186,6 +186,12 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
 
         opObjectClassification = OpObjectClassification(graph=self.graph)
 
+        def assign_object_label(img_index, coord5d, label):
+            new_labels, _old_label, dirty_key = opObjectClassification.prepareObjectLabels(img_index, coord5d)
+            time_index, object_index = dirty_key
+            new_labels[time_index][object_index] = label
+            opObjectClassification.commitObjectLabel(img_index, new_labels, dirty_key)
+
         # STEP 1: connect the operator
 
         # raw image data, i.e. cubes with intensity 1 or 1/2
@@ -228,7 +234,7 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
             assert raw_5d[coord] == 255, "Input data error: expected this pixel to be white, but it was {}".format(
                 raw_5d[coord]
             )
-            opObjectClassification.assignObjectLabel(0, coord, 1)
+            assign_object_label(0, coord, 1)
 
         # small & gray: label 1
         small_gray_coords = [(0, 10, 10, 10, 0), (0, 10, 30, 10, 0), (0, 10, 10, 30, 0)]
@@ -236,7 +242,7 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
             assert raw_5d[coord] == 255 // 2, "Input data error: expected this pixel to be gray, but it was {}".format(
                 raw_5d[coord]
             )
-            opObjectClassification.assignObjectLabel(0, coord, 1)
+            assign_object_label(0, coord, 1)
 
         # small & white: label 2
         small_white_coords = [(0, 70, 10, 10, 0), (0, 70, 30, 10, 0), (0, 70, 10, 30, 0)]
@@ -244,7 +250,7 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
             assert raw_5d[coord] == 255, "Input data error: expected this pixel to be white, but it was {}".format(
                 raw_5d[coord]
             )
-            opObjectClassification.assignObjectLabel(0, coord, 2)
+            assign_object_label(0, coord, 2)
 
         # big & gray: label 2
         big_gray_coords = [(0, 0, 0, 0, 0), (0, 0, 20, 0, 0), (0, 0, 0, 20, 0)]
@@ -252,7 +258,7 @@ class TestOpBlockwiseObjectClassification(unittest.TestCase):
             assert raw_5d[coord] == 255 // 2, "Input data error: expected this pixel to be gray, but it was {}".format(
                 raw_5d[coord]
             )
-            opObjectClassification.assignObjectLabel(0, coord, 2)
+            assign_object_label(0, coord, 2)
 
         assert opObjectClassification.SegmentationImages[0].ready()
         assert opObjectClassification.NumLabels.value == 2, "Wrong number of labels: {}".format(


### PR DESCRIPTION
Hook into the editors undo/redo stack to support undo/redo in Object Classification and Tracking flavors. When the input image changes, the undostack is cleared.


## Checklist

- [x] Add tests.
- [x] Refactor blockwise oc tests to get rid of `OpObjectClassification.assignObjectLabel`
- [x] Custom exception for clicks on background (`IndexError` can have other causes)