### PR TITLE
Unpin grpcio, devenv uses 1.49 already

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -38,7 +38,7 @@ outputs:
         - fsspec
         - future
         - greenlet
-        - grpcio <1.42
+        - grpcio !=1.42.*
         - h5py
         - hytra >=1.1.5
         - ilastik-feature-selection


### PR DESCRIPTION
keep avoiding 1.42 as it resulted in segfaults

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
