### PR TITLE
OME-Zarr: Sync front- and backend check for compatibility

### DIFF
--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -41,6 +41,7 @@ from lazyflow.operators.ioOperators import (
 )
 from lazyflow.utility.jsonConfig import JsonConfigParser
 from lazyflow.utility.pathHelpers import lsH5N5, isRelative, splitPath, PathComponents, isUrl
+from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore
 from .opOMEZarrMultiscaleReader import OpOMEZarrMultiscaleReader
 
 from .opStreamingUfmfReader import OpStreamingUfmfReader
@@ -100,7 +101,6 @@ class OpInputDataReader(Operator):
         h5_n5_Exts + n5Selection + npyExts + npzExts + rawExts + vigraImpexExts + blockwiseExts + videoExts + klbExts
     )
 
-    supported_ome_zarr_schemes = ["http:", "https:", "file:", "s3:"]
     precomputed_protocol = "precomputed://"
 
     if _supports_dvid:
@@ -300,11 +300,9 @@ class OpInputDataReader(Operator):
             return ([], None)
 
     def _attemptOpenAsOmeZarrUri(self, filePath):
-        if PathComponents(filePath).extension != ".zarr":
-            return ([], None)
         if not isUrl(filePath):
             filePath = Path(filePath).as_uri()
-        if not any(filePath.startswith(scheme) for scheme in self.supported_ome_zarr_schemes):
+        if not OMEZarrStore.is_uri_compatible(filePath):
             return ([], None)
         # DatasetInfo instantiates a standalone OpInputDataReader to obtain laneShape and dtype.
         # We pass this down to the loader so that it can avoid loading scale metadata unnecessarily.

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -582,7 +582,8 @@ class OMEZarrStore(MultiscaleStore):
 
     @staticmethod
     def is_uri_compatible(uri: str) -> bool:
-        return ZARR_EXT in uri
+        supported_ome_zarr_schemes = ["http:", "https:", "file:", "s3:"]
+        return ZARR_EXT in uri and any(uri.startswith(scheme) for scheme in supported_ome_zarr_schemes)
 
     def get_chunk_size(self, scale_key=DEFAULT_SCALE_KEY):
         scale_key = scale_key if scale_key != DEFAULT_SCALE_KEY else self.lowest_resolution_key


### PR DESCRIPTION
Tiny change that should have 0 functional impact.

This is to ensure that we don't get in a situation like https://github.com/ilastik/ilastik/issues/2925 again, where the multiscale URI selector dialog checks and confirms compatibility for a dataset, and then once the user clicks "Add to project", they get an error because the backend checks the compatibility differently.

By using the same function to check compatibility (`OMEZarrStore.is_uri_compatible`), whatever passes the dialog should also pass the backend.