### PR TITLE
Quickfix: Same object size limits in tracking and oc

### DIFF
--- a/ilastik/applets/thresholdTwoLevels/drawer.ui
+++ b/ilastik/applets/thresholdTwoLevels/drawer.ui
@@ -393,7 +393,7 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Min object area in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
+            <string>Min object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
            </property>
            <property name="maximum">
             <number>2147483647</number>
@@ -423,7 +423,7 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Max object area in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
+            <string>Max object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
            </property>
            <property name="maximum">
             <number>2147483647</number>

--- a/ilastik/applets/tracking/conservation/drawer.ui
+++ b/ilastik/applets/tracking/conservation/drawer.ui
@@ -765,10 +765,13 @@
        <item row="5" column="1" colspan="2">
         <widget class="QSpinBox" name="from_size">
          <property name="maximum">
-          <number>100000</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
           <number>3</number>
+         </property>
+         <property name="toolTip">
+          <string>Min object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
          </property>
         </widget>
        </item>
@@ -778,10 +781,13 @@
        <item row="5" column="3">
         <widget class="QSpinBox" name="to_size">
          <property name="maximum">
-          <number>100000000</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
-          <number>100000</number>
+          <number>1000000</number>
+         </property>
+         <property name="toolTip">
+          <string>Max object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
          </property>
         </widget>
        </item>

--- a/ilastik/applets/tracking/structured/drawer.ui
+++ b/ilastik/applets/tracking/structured/drawer.ui
@@ -740,20 +740,26 @@
        <item row="5" column="1">
         <widget class="QSpinBox" name="from_size">
          <property name="maximum">
-          <number>100000</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
           <number>3</number>
+         </property>
+         <property name="toolTip">
+          <string>Min object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
          </property>
         </widget>
        </item>
        <item row="5" column="2" colspan="2">
         <widget class="QSpinBox" name="to_size">
          <property name="maximum">
-          <number>1000000</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
           <number>1000000</number>
+         </property>
+         <property name="toolTip">
+          <string>Max object area/volume in pixels. Cannot be higher than the max value of a 32-bit integer (2147483647).</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This commit sets the size filter initial values to the same ones than as in thresholding. Also same initial value in all tracking flavors.

Tracking reuses some elements from Object Classification. E.g. the thresholding applet. For the actual tracking there is another size-filter step, as there is one in thresholding, too. These don't necessarily need to be in sync, but it's better to start off that way.

fixes #2810

Ideally these values would come from a unique source to keep them in sync also in the future, but every time I look at tracking I think it's either complete rewrite or minimal fix...

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->
