### PR TITLE
Fix show model name for models from ilp

### DIFF
--- a/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
+++ b/ilastik/applets/trainableDomainAdaptation/modelStateControl.py
@@ -83,8 +83,9 @@ class BioImageModelCombo(QComboBox):
             # from file
             with silent_qobject(self) as silent_self:
                 silent_self.insertItem(1, model_info.name, model_info)
-        else:
-            self.setCurrentText(self.itemText(idx))
+            idx = 1
+
+        self.setCurrentText(self.itemText(idx))
 
         model = self.model()
         assert model


### PR DESCRIPTION
Tiny fix for a problem that I found just now when poking the workflow a bit more...

Previously, if a model loaded from ilp was not in the list of models from the zoo, the field would say "remove model". This commit fixes it by always setting the current text.

