### PR TITLE
Add cpu fallback for tiktorch server on macos silicon

### DIFF
--- a/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
+++ b/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
@@ -1,6 +1,8 @@
 import grpc
+import os
 import platform
 import pytest
+from unittest import mock
 
 from ilastik.workflows.neuralNetwork._localLauncher import LocalServerLauncher
 
@@ -8,8 +10,18 @@ from tiktorch.proto.inference_pb2 import Empty
 from tiktorch.proto.inference_pb2_grpc import FlightControlStub
 
 
-def test_local_launcher(tiktorch_executable_path):
-    launcher = LocalServerLauncher(tiktorch_executable_path)
+@pytest.fixture
+def macos_arm64_mock():
+    with mock.patch("platform.system", new=lambda: "darwin"), mock.patch("platform.machine", new=lambda: "arm64"):
+        yield
+
+
+@pytest.fixture
+def launcher(tiktorch_executable_path):
+    return LocalServerLauncher(tiktorch_executable_path)
+
+
+def test_local_launcher(launcher):
     conn_str = launcher.start()
 
     chan = grpc.insecure_channel(conn_str)
@@ -28,3 +40,31 @@ def test_local_launcher(tiktorch_executable_path):
         assert error.value.code() in [grpc.StatusCode.UNKNOWN, grpc.StatusCode.UNAVAILABLE]
     else:
         assert error.value.code() is grpc.StatusCode.UNAVAILABLE
+
+
+def test_local_launcher_macos_silicon_env_override(macos_arm64_mock, launcher):
+    with mock.patch("os.environ", new={}):
+        assert launcher._proc_env.get("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
+
+
+def test_local_launcher_macos_silicon_no_env_override_if_default(macos_arm64_mock, launcher):
+    """should not modify env on silicon mac variable if set by user"""
+    with mock.patch("os.environ", new={"PYTORCH_ENABLE_MPS_FALLBACK": "some_test_value"}):
+        assert launcher._proc_env.get("PYTORCH_ENABLE_MPS_FALLBACK") == "some_test_value"
+
+
+def test_local_launcher_macos_silicon_no_env_override_if_not_arm(launcher):
+    """should not modify env variable if on mac intel machines"""
+    with (
+        mock.patch("platform.system", new=lambda: "darwin"),
+        mock.patch("platform.machine", new=lambda: "x86_64"),
+        mock.patch("os.environ", new={}),
+    ):
+        assert "PYTORCH_ENABLE_MPS_FALLBACK" not in launcher._proc_env
+
+
+@pytest.mark.parametrize("system", ["Linux", "Windows"])
+def test_local_launcher_passthrough_env(system, launcher):
+    current_env = os.environ.copy()
+    with mock.patch("platform.system", new=lambda: system):
+        assert launcher._proc_env == current_env


### PR DESCRIPTION
currently, pytorch does not support all operators, especially in 3D on apple silicon (mps) devices. Setting the env variable "PYTORCH_ENABLE_MPS_FALLBACK". for the tiktorch server process allows running these networks on CPU instead of failing.

Looks like this will still be an issue for a while. With this env variable set, pytorch will decide to fall back to CPU if the network cannot be run on MPS devices.
