### PR TITLE
Add deprecation notice for PC+OC workflow

### DIFF
--- a/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
+++ b/ilastik/workflows/objectClassification/objectClassificationWorkflow.py
@@ -601,7 +601,7 @@ class ObjectClassificationWorkflow(Workflow):
 
 class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
     workflowName = "Object Classification (from pixel classification)"
-    workflowDisplayName = "Pixel Classification + Object Classification"
+    workflowDisplayName = "Pixel Classification + Object Classification (deprecated)"
 
     @property
     def ExportNames(self):
@@ -614,6 +614,17 @@ class ObjectClassificationWorkflowPixel(ObjectClassificationWorkflow):
     def __init__(self, *args, **kwargs):
         self.stored_pixel_classifier = None
         super().__init__(*args, **kwargs)
+        warnings.warn(
+            "The Pixel Classification + Object Classification workflow is deprecated and will be removed. Please use Pixel Classification and Object Classification as separate workflows.",
+            UserWarning,
+        )
+
+    @property
+    def data_instructions(self):
+        return (
+            super().data_instructions
+            + "This workflow is no longer maintained and will be removed in ilastik 1.5.0. We recommend using Pixel Classification and Object classification as separate workflows."
+        )
 
     @property
     def exportsArgParser(self):

--- a/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
+++ b/ilastik/workflows/trainableDomainAdaptation/_localTrainableDomainAdaptationWorkflow.py
@@ -47,7 +47,7 @@ class LocalTrainableDomainAdaptationWorkflow(_NNWorkflowBase):
     """
 
     auto_register = True
-    workflowName = "Trainable Domain Adaptation (Local) (beta)"
+    workflowName = "Trainable Domain Adaptation (Local)"
     workflowDescription = "Allows to apply bioimage.io shallow2deep models on your data using bundled tiktorch"
 
     @enum.unique


### PR DESCRIPTION
In https://github.com/ilastik/ilastik/issues/2621 we agreed to deprecate and ultimately remove this workflow due to the many issues it introduces (huge memory consumption, unreliability...).

I added "deprecated" to the workflow name, and also added a note on the data selection applet, as well as a logger warning to inform headless users, too.

I added a "welcome message" option some time in the past, but it was slashed ;) https://github.com/ilastik/ilastik/pull/2333. Could be revived for more aggressive deprecation...

Edit: somewhere the console/log warning is filtered out 🙄 