### PR TITLE
Filter out unsupported extensions

### DIFF
--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -76,7 +76,8 @@ class OpExportSlot(Operator):
     ExportPath = OutputSlot()
     FormatSelectionErrorMsg = OutputSlot()
 
-    _2d_exts = vigra.impex.listExtensions().split()
+    # Filter out formats that are not supported by vigra
+    _2d_exts = [ext for ext in vigra.impex.listExtensions().split() if ext not in {"xv", "exr"}]
 
     # List all supported formats
     # Only FormatInfo.name is used (to generate help text for a cmd parameter, DataExportApplet)

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -76,12 +76,8 @@ class OpExportSlot(Operator):
     ExportPath = OutputSlot()
     FormatSelectionErrorMsg = OutputSlot()
 
-    # Filter out formats that are not supported by vigra
-    unsupported_vigra_formats = {"xv", "exr"}
-    _2d_exts = []
-    for ext in vigra.impex.listExtensions().split():
-        if ext not in unsupported_vigra_formats:
-            _2d_exts.append(ext)
+    # Vigra supports some file formats that Ilastik doesn't handle, so we exclude "xv" and "exr" extensions.
+    _2d_exts = [ext for ext in vigra.impex.listExtensions().split() if ext not in {"xv", "exr"}]
 
     # List all supported formats
     # Only FormatInfo.name is used (to generate help text for a cmd parameter, DataExportApplet)

--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -77,7 +77,11 @@ class OpExportSlot(Operator):
     FormatSelectionErrorMsg = OutputSlot()
 
     # Filter out formats that are not supported by vigra
-    _2d_exts = [ext for ext in vigra.impex.listExtensions().split() if ext not in {"xv", "exr"}]
+    unsupported_vigra_formats = {"xv", "exr"}
+    _2d_exts = []
+    for ext in vigra.impex.listExtensions().split():
+        if ext not in unsupported_vigra_formats:
+            _2d_exts.append(ext)
 
     # List all supported formats
     # Only FormatInfo.name is used (to generate help text for a cmd parameter, DataExportApplet)


### PR DESCRIPTION
<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->
Fixes #2916

This PR filters out unsupported in by updating the list comprehension.
The change ensures that these formats are not included in the file format options, which should prevent them from appearing in the drop-down list in ilastik. (I verified it by running ilastik)

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->
- [x] Reference relevant issues and other pull requests.
