### PR TITLE
Add `DatasetOut` slot to OpDataSelection, Fix segfaults

### DIFF
--- a/ilastik/applets/dataSelection/dataLaneSummaryTableModel.py
+++ b/ilastik/applets/dataSelection/dataLaneSummaryTableModel.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2024, the ilastik developers
+#       Copyright (C) 2011-2025, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -88,7 +88,7 @@ class DataLaneSummaryTableModel(QAbstractItemModel):
         self._op = topLevelOperator
 
         def handleNewLane(multislot, laneIndex):
-            assert multislot is self._op.DatasetGroup
+            assert multislot is self._op.DatasetGroupOut
             self.beginInsertRows(QModelIndex(), laneIndex, laneIndex)
             self.endInsertRows()
 
@@ -105,23 +105,23 @@ class DataLaneSummaryTableModel(QAbstractItemModel):
             def handleNewDatasetInserted(mslot, index):
                 mslot[index].notifyDirty(bind(handleDatasetInfoChanged))
 
-            for laneIndex, datasetMultiSlot in enumerate(self._op.DatasetGroup):
+            for laneIndex, datasetMultiSlot in enumerate(self._op.DatasetGroupOut):
                 datasetMultiSlot.notifyInserted(bind(handleNewDatasetInserted))
                 for roleIndex, datasetSlot in enumerate(datasetMultiSlot):
                     handleNewDatasetInserted(datasetMultiSlot, roleIndex)
 
-        self._op.DatasetGroup.notifyInserted(bind(handleNewLane))
+        self._op.DatasetGroupOut.notifyInserted(bind(handleNewLane))
 
         def handleLaneRemoved(multislot, laneIndex):
-            assert multislot is self._op.DatasetGroup
+            assert multislot is self._op.DatasetGroupOut
             self.beginRemoveRows(QModelIndex(), laneIndex, laneIndex)
             self.endRemoveRows()
 
-        self._op.DatasetGroup.notifyRemoved(bind(handleLaneRemoved))
+        self._op.DatasetGroupOut.notifyRemoved(bind(handleLaneRemoved))
 
         # Any lanes that already exist must be added now.
-        for laneIndex, slot in enumerate(self._op.DatasetGroup):
-            handleNewLane(self._op.DatasetGroup, laneIndex)
+        for laneIndex, slot in enumerate(self._op.DatasetGroupOut):
+            handleNewLane(self._op.DatasetGroupOut, laneIndex)
 
     def columnCount(self, parent=QModelIndex()):
         if not self._op.DatasetRoles.ready():
@@ -162,15 +162,15 @@ class DataLaneSummaryTableModel(QAbstractItemModel):
         roleIndex = (index.column() - LaneColumn.NumColumns) // DatasetInfoColumn.NumColumns
         datasetInfoIndex = (index.column() - LaneColumn.NumColumns) % DatasetInfoColumn.NumColumns
 
-        datasetSlot = self._op.DatasetGroup[laneIndex][roleIndex]
+        datasetSlot = self._op.DatasetGroupOut[laneIndex][roleIndex]
         if not datasetSlot.ready():
             return ""
 
         UninitializedDisplayData = {DatasetInfoColumn.Name: "<please select>"}
 
-        datasetSlot = self._op.DatasetGroup[laneIndex][roleIndex]
+        datasetSlot = self._op.DatasetGroupOut[laneIndex][roleIndex]
         if datasetSlot.ready():
-            datasetInfo = self._op.DatasetGroup[laneIndex][roleIndex].value
+            datasetInfo = self._op.DatasetGroupOut[laneIndex][roleIndex].value
         else:
             return UninitializedDisplayData[datasetInfoIndex]
 

--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2024, the ilastik developers
+#       Copyright (C) 2011-2025, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -31,7 +31,7 @@ import h5py
 from PyQt5 import uic
 from PyQt5.QtWidgets import QDialog, QMessageBox, QStackedWidget, QWidget
 from vigra import AxisTags
-from volumina.utility import preferences, ShortcutManager
+from volumina.utility import preferences
 
 from ilastik.applets.base.applet import DatasetConstraintError
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
@@ -131,7 +131,7 @@ class DataSelectionGui(QWidget):
     ###########################################
     ###########################################
 
-    class UserCancelledError(Exception):
+    class UserCancelledError(BaseException):
         # This exception type is raised when the user cancels the
         #  addition of dataset files in the middle of the process somewhere.
         # It isn't an error -- it's used for control flow.
@@ -438,7 +438,7 @@ class DataSelectionGui(QWidget):
         return firstNewLane
 
     def getNumLanes(self) -> int:
-        return len(self.topLevelOperator.DatasetGroup)
+        return len(self.topLevelOperator.DatasetGroupOut)
 
     def getInfoSlots(self, roleIndex: int):
         return [self.topLevelOperator.DatasetGroup[laneIndex][roleIndex] for laneIndex in range(self.getNumLanes())]
@@ -482,6 +482,8 @@ class DataSelectionGui(QWidget):
             for slot, original_info in zip(info_slots, original_infos):
                 if original_info is not None:
                     slot.setValue(original_info)
+                else:
+                    slot.disconnect()
 
         try:
             for new_info, info_slot in zip(new_infos, info_slots):

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2024, the ilastik developers
+#       Copyright (C) 2011-2025, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -65,43 +65,43 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         self._currently_inserting = False
         self._currently_removing = False
 
-        self._op.DatasetGroup.notifyInsert(self.prepareForNewLane)  # pre
-        self._op.DatasetGroup.notifyInserted(self.handleNewLane)  # post
+        self._op.DatasetGroupOut.notifyInsert(self.prepareForNewLane)  # pre
+        self._op.DatasetGroupOut.notifyInserted(self.handleNewLane)  # post
 
-        self._op.DatasetGroup.notifyRemove(self.handleLaneRemove)  # pre
-        self._op.DatasetGroup.notifyRemoved(self.handleLaneRemoved)  # post
+        self._op.DatasetGroupOut.notifyRemove(self.handleLaneRemove)  # pre
+        self._op.DatasetGroupOut.notifyRemoved(self.handleLaneRemoved)  # post
 
         # Any lanes that already exist must be added now.
-        for laneIndex, slot in enumerate(self._op.DatasetGroup):
-            self.prepareForNewLane(self._op.DatasetGroup, laneIndex)
-            self.handleNewLane(self._op.DatasetGroup, laneIndex)
+        for laneIndex, slot in enumerate(self._op.DatasetGroupOut):
+            self.prepareForNewLane(self._op.DatasetGroupOut, laneIndex)
+            self.handleNewLane(self._op.DatasetGroupOut, laneIndex)
 
     @threadRouted
     def prepareForNewLane(self, multislot, laneIndex, *args):
-        assert multislot is self._op.DatasetGroup
+        assert multislot is self._op.DatasetGroupOut
         self.beginInsertRows(QModelIndex(), laneIndex, laneIndex)
         self._currently_inserting = True
 
     @threadRouted
     def handleNewLane(self, multislot, laneIndex, *args):
-        assert multislot is self._op.DatasetGroup
+        assert multislot is self._op.DatasetGroupOut
         self.endInsertRows()
         self._currently_inserting = False
 
-        for laneIndex, datasetMultiSlot in enumerate(self._op.DatasetGroup):
+        for laneIndex, datasetMultiSlot in enumerate(self._op.DatasetGroupOut):
             datasetMultiSlot.notifyInserted(bind(self.handleNewDatasetInserted))
             if self._roleIndex < len(datasetMultiSlot):
                 self.handleNewDatasetInserted(datasetMultiSlot, self._roleIndex)
 
     @threadRouted
     def handleLaneRemove(self, multislot, laneIndex, *args):
-        assert multislot is self._op.DatasetGroup
+        assert multislot is self._op.DatasetGroupOut
         self.beginRemoveRows(QModelIndex(), laneIndex, laneIndex)
         self._currently_removing = True
 
     @threadRouted
     def handleLaneRemoved(self, multislot, laneIndex, *args):
-        assert multislot is self._op.DatasetGroup
+        assert multislot is self._op.DatasetGroupOut
         self.endRemoveRows()
         self._currently_removing = False
 
@@ -121,7 +121,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
             slot[self._roleIndex].notifyDisconnect(bind(self.handleDatasetInfoChanged))
 
     def isEditable(self, row):
-        return self._op.DatasetGroup[row][self._roleIndex].ready()
+        return self._op.DatasetGroupOut[row][self._roleIndex].ready()
 
     def getNumRoles(self):
         # Return the number of possible roles in the workflow
@@ -133,7 +133,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         return DatasetColumn.NumColumns
 
     def rowCount(self, parent=QModelIndex()):
-        return len(self._op.DatasetGroup)
+        return len(self._op.DatasetGroupOut)
 
     def data(self, index, role=Qt.DisplayRole):
         if role == Qt.DisplayRole or role == Qt.ToolTipRole:
@@ -168,7 +168,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
             return section + 1
 
     def isEmptyRow(self, index):
-        return not self._op.DatasetGroup[index][self._roleIndex].ready()
+        return not self._op.DatasetGroupOut[index][self._roleIndex].ready()
 
     def _getDisplayRoleData(self, index):
         laneIndex = index.row()
@@ -182,10 +182,10 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
             DatasetColumn.Scale: "",
         }
 
-        if len(self._op.DatasetGroup) <= laneIndex or len(self._op.DatasetGroup[laneIndex]) <= self._roleIndex:
+        if len(self._op.DatasetGroupOut) <= laneIndex or len(self._op.DatasetGroupOut[laneIndex]) <= self._roleIndex:
             return UninitializedDisplayData[index.column()]
 
-        datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]
+        datasetSlot = self._op.DatasetGroupOut[laneIndex][self._roleIndex]
 
         # Default
         if not datasetSlot.ready():
@@ -223,7 +223,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
 
     def get_scale_options(self, laneIndex) -> Dict[str, str]:
         try:
-            datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]
+            datasetSlot = self._op.DatasetGroupOut[laneIndex][self._roleIndex]
         except IndexError:  # This can happen during "Save Project As"
             return {}
         if not datasetSlot.ready():
@@ -240,7 +240,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         }
 
     def is_scale_locked(self, laneIndex) -> bool:
-        datasetSlot = self._op.DatasetGroup[laneIndex][self._roleIndex]
+        datasetSlot = self._op.DatasetGroupOut[laneIndex][self._roleIndex]
         if not datasetSlot.ready():
             return False
         datasetInfo = datasetSlot.value


### PR DESCRIPTION
This slot exposed the same information as the input `OpDataSelection.Dataset`, but it is only connected if there are no data constraints violated. The slot is intended to be connected to UI elements of the data selection table. Ui then can rely on this data being valid when connected.

`DatasetDetailedInfoTable` now listens to this slots, instead of `Dataset` so no update gets triggered if data is not valid. Before, invalid states could be already added to the table and had to be rectified which I think could lead to objects being destroyed prematurely. Now the "correct axistags" loop runs before any data is added to the table.

Not sure if I want to merge this before 1.4.1. On the one hand -> segfaults that we know of are avoided, on the other hand, I would test drive this setup for a few weeks in case there are corner UI cases that I haven't reached yet.

In any case this should stay a single commit for easy revertability.

Before we were experiencing segfaults that were hard to debug. So the issue of segfaults is likely related to the item delegates for datasets.

Fixes #2967
Fixes #992
Fixes https://github.com/ilastik/ilastik/issues/1956

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
