### PR TITLE
Fix crash in Suggest Features when no labels are present

### DIFF
--- a/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
+++ b/ilastik/applets/pixelClassification/suggestFeaturesDialog.py
@@ -844,9 +844,15 @@ class SuggestFeaturesDialog(QtWidgets.QDialog):
             cannot be modified from within this dialog)
             """
             if not self._initialized_feature_matrix:
-                self.featureLabelMatrix_all_features = (
-                    self.opFeatureMatrixCaches.LabelAndFeatureMatrix.value
-                )  # FIXME: why is this initialized?
+                self.featureLabelMatrix_all_features = self.opFeatureMatrixCaches.LabelAndFeatureMatrix.value
+                if self.featureLabelMatrix_all_features is None or self.featureLabelMatrix_all_features.size == 0:
+                    QMessageBox.warning(
+                        self,
+                        "No Labeled Data Found",
+                        "Feature selection cannot proceed because no labeled data is available.\n\n"
+                        "Please add annotations before running 'Suggest Features'.",
+                    )
+                    return
                 self.opFilterFeatureSelection.FeatureLabelMatrix.setValue(self.featureLabelMatrix_all_features)
                 self.opFilterFeatureSelection.FeatureLabelMatrix.resize(1)
                 self.opFilterFeatureSelection.setupOutputs()


### PR DESCRIPTION
This PR fixes issue #2683, where running "Suggest Features" without adding annotations caused an exception.
So added a tooltip instructing users to add annotations before running the feature selection.
Please let me know if I can make the message more clear.

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->
![image](https://github.com/user-attachments/assets/f0ccbf18-f33f-4bf8-a1b3-abf3465e6a36)


- [x] Format code and imports.
- [x] Reference relevant issues and other pull requests.
@k-dominik, please review when available!
