### PR TITLE
Optimize bioimage model downloads, update tiktoch/bioimageio

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -69,7 +69,7 @@ outputs:
         - zarr 2.*
       run_constrained:
         - mkl <2024.1.0
-        - tiktorch 24.12.0
+        - tiktorch 25.4.0
         - volumina >=1.3.10
         # TODO: sphericaltexture 0.1.1 currently times out in the tests
         - sphericaltexture 0.0.4

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -59,7 +59,7 @@ dependencies:
   - pytorch <2.4.1  # >=2.4 can clash with pyshtools on win; 2.2.2 newest available on osx
   - cpuonly  # comment out for pytorch with cuda
   # - pytorch-cuda=11.3  # uncomment for pytorch with cuda, specify cuda version
-  - tiktorch 24.12.0
+  - tiktorch 25.4.0
   # mamba does not "respect" track_features, which is the idea behind cpuonly,
   # with ilastik-pytorch-version-helper-cpu we help mamba on linux and windows
   # to install a cpu-build

--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -336,7 +336,7 @@ class ModelStateControl(QWidget):
                 QMessageBox.information(
                     self,
                     "Model incompatible",
-                    f"Model incompatible, reasons :\n\n{reasons}.\nPlease select a different model.",
+                    f"Model incompatible, reasons:\n\n{reasons}.\nPlease select a different model.",
                 )
                 reasons_log = " - ".join(r["reason"] for r in compatibility_checks if r)
                 logger.debug(f"Incompatible model from {model_uri}. Reasons: {reasons_log}")

--- a/ilastik/utility/bioimageio_utils.py
+++ b/ilastik/utility/bioimageio_utils.py
@@ -343,5 +343,11 @@ class InputValidator:
             ), f"Axis {axis_id} not an expected bioimage io axis string {SPEC_TO_VIGRA.keys()}."
 
             target_axis_size = spec_shape[axis_id]
-            if target_axis_size < min_size:
-                raise ValueError(f"Incompatible axis {axis}: {target_axis_size} < {min_size}")
+            if isinstance(axis, ChannelAxis):
+                if target_axis_size != min_size:
+                    raise ValueError(
+                        f"Incompatible axis {axis}: Number of channels in data: {target_axis_size} != Number of channels expected by model: {min_size}"
+                    )
+            else:
+                if target_axis_size < min_size:
+                    raise ValueError(f"Incompatible axis {axis}: {target_axis_size} < {min_size}")

--- a/ilastik/workflows/neuralNetwork/_localLauncher.py
+++ b/ilastik/workflows/neuralNetwork/_localLauncher.py
@@ -30,7 +30,7 @@ from typing import List, Optional
 
 import grpc
 import psutil
-from tiktorch.proto.inference_pb2 import Empty
+from tiktorch.proto.utils_pb2 import Empty
 from tiktorch.proto.inference_pb2_grpc import FlightControlStub
 
 logger = logging.getLogger(__name__)

--- a/lazyflow/operators/tiktorch/classifier.py
+++ b/lazyflow/operators/tiktorch/classifier.py
@@ -35,7 +35,7 @@ from lazyflow.roi import roiToSlice
 from lazyflow.futures_utils import MappableFuture, map_future
 
 from tiktorch import converters
-from tiktorch.proto import data_store_pb2, data_store_pb2_grpc, inference_pb2, inference_pb2_grpc
+from tiktorch.proto import data_store_pb2, data_store_pb2_grpc, inference_pb2, inference_pb2_grpc, utils_pb2
 
 from vigra import AxisTags
 
@@ -253,9 +253,9 @@ class ModelSession:
                 for t in reordered_tensors
             ]
             resp = self.tiktorchClient.Predict.future(
-                inference_pb2.PredictRequest(
+                utils_pb2.PredictRequest(
+                    modelSessionId=utils_pb2.ModelSession(id=self.__session.id),
                     tensors=pb_tensors,
-                    modelSessionId=self.__session.id,
                 )
             )
             resp.add_done_callback(lambda o: current_rq._wake_up())
@@ -334,7 +334,7 @@ class Connection(_base.IConnection):
         self._upload_client = upload_client
 
     def get_devices(self):
-        resp = self._client.ListDevices(inference_pb2.Empty())
+        resp = self._client.ListDevices(utils_pb2.Empty())
         return [(d.id, d.id) for d in resp.devices]
 
     def upload(self, content: bytes, *, progress_cb: Callable[[int], None], cancel_token=None) -> MappableFuture[str]:

--- a/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
+++ b/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from ilastik.workflows.neuralNetwork._localLauncher import LocalServerLauncher
 
-from tiktorch.proto.inference_pb2 import Empty
+from tiktorch.proto.utils_pb2 import Empty
 from tiktorch.proto.inference_pb2_grpc import FlightControlStub
 
 

--- a/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
+++ b/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
@@ -22,12 +22,12 @@ from bioimageio.spec.model.v0_5 import (
 from lazyflow.operators.tiktorch.classifier import ModelSession
 
 import pytest
-from tiktorch.proto import inference_pb2
+from tiktorch.proto import utils_pb2
 
 
 @pytest.fixture
 def pb_session():
-    return inference_pb2.ModelSession(id="1")
+    return utils_pb2.ModelSession(id="1")
 
 
 @pytest.fixture


### PR DESCRIPTION
Updated tiktorch to `25.4.0` which depends on the current bioimageio versions for spec (`0.5.4.1`) and core (`0.8.0`)

Also:
* only get one set of weights.
* removed tensorflow from supported models, since it is currently not supported on our side
* Don't add model if data channels don't match model channels (#2678)

Fixes #2678

