### PR TITLE
changes in (dataExport): ensure table updates to show correct file extension

### DIFF
--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -150,6 +150,10 @@ class DataExportGui(QWidget):
             if subslot.ready():
                 self.updateTableForSlot(subslot)
 
+        self.topLevelOperator.OutputFormat.notifyDirty(
+            lambda *args: [self.updateTableForSlot(slot) for slot in self.topLevelOperator.ExportPath]
+        )
+
         @threadRoutedWithRouter(self.threadRouter)
         def handleLaneRemoved(multislot, index, finalLength):
             if self.batchOutputTableWidget.rowCount() <= finalLength:


### PR DESCRIPTION
##  Bug Fix for Export with notifyDirty on All Slots
Fixes #2906

This PR fixes bug for export by applying `notify dirty` on slots to `ExportPath` So UI updates correctly when output changes.

However, updating all slots this way might cause performance issues, though I haven't observed any yet, expressed my concern and solution in [this comment](https://github.com/ilastik/ilastik/issues/2906#issuecomment-2737637673)

I used a lambda function here because defining a separate function for this small task didn't seem necessary
However, if using a lambda doesn't look good, we can change it into a separate function, to improve readability or I can also add a comment explaining the approach

What this PR ensures is by using `notifydirty` through all slots bug is fixed (which is the simplest solution i can think of, if this is not the ideal solution then please ignore this PR)

Output on updating it shows updated extension(eg. tiff here) instead of .h5


![Screenshot from 2025-03-20 19-30-20](https://github.com/user-attachments/assets/0c1cf70f-46cd-4a8f-82ae-e6f9aa2a0132)

## Checklist

- [x] Reference relevant issues and other pull requests.