### PR TITLE
Fix parent checkbox state updates in feature selection dialog

### DIFF
--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -231,7 +231,7 @@ class FeatureSelectionDialog(QDialog):
                             child.setCheckState(0, val)
                 
     @staticmethod 
-    def updateParentState(item):
+    def updateParentCheckState(item):
         """Update parent checkbox state based on children's states"""
         if item.parent() is None:
             return

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -229,6 +229,25 @@ class FeatureSelectionDialog(QDialog):
                     if getattr(child, "group_name", ""):
                         if child.group_name != "Location":
                             child.setCheckState(0, val)
+                
+    @staticmethod 
+    def updateParentState(item):
+        """Update parent checkbox state based on children's states"""
+        if item.parent() is None:
+            return
+            
+        parent = item.parent()
+        child_states = [parent.child(i).checkState(0) for i in range(parent.childCount())]
+        
+        if all(state == Qt.Checked for state in child_states):
+            parent.setCheckState(0, Qt.Checked)
+        elif all(state == Qt.Unchecked for state in child_states):
+            parent.setCheckState(0, Qt.Unchecked)
+        else:
+            parent.setCheckState(0, Qt.PartiallyChecked)
+        
+        # Recursively update parents up the tree
+        FeatureSelectionDialog.updateParentState(parent)
 
     def updateTree(self, item, col):
         # Clicking on the CheckBox OR Text of a QTreeWidgetItem should change the check.
@@ -406,6 +425,17 @@ class FeatureSelectionDialog(QDialog):
 
             plugin.setCheckState(0, Qt.Checked)
             FeatureSelectionDialog.recursiveCheckChildren(plugin, Qt.Checked, exclude_location=True)
+
+            # Update parent states after modifying children
+            self.updateParentState(plugin)
+
+            # Update counter and tooltip
+            checked_count = 0
+            for child_id in range(plugin.childCount()):
+                child = plugin.child(child_id)
+                if child.checkState(0) == Qt.Checked:
+                    checked_count += 1
+
 
             self.countChecked[pluginName] = self.countAll[pluginName]
             self.updateToolTip(plugin)

--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -247,7 +247,7 @@ class FeatureSelectionDialog(QDialog):
             parent.setCheckState(0, Qt.PartiallyChecked)
         
         # Recursively update parents up the tree
-        FeatureSelectionDialog.updateParentState(parent)
+        FeatureSelectionDialog.updateParentCheckState(parent)
 
     def updateTree(self, item, col):
         # Clicking on the CheckBox OR Text of a QTreeWidgetItem should change the check.
@@ -426,8 +426,7 @@ class FeatureSelectionDialog(QDialog):
             plugin.setCheckState(0, Qt.Checked)
             FeatureSelectionDialog.recursiveCheckChildren(plugin, Qt.Checked, exclude_location=True)
 
-            # Update parent states after modifying children
-            self.updateParentState(plugin)
+            self.updateParentCheckState(plugin)
 
             # Update counter and tooltip
             checked_count = 0
@@ -437,7 +436,7 @@ class FeatureSelectionDialog(QDialog):
                     checked_count += 1
 
 
-            self.countChecked[pluginName] = self.countAll[pluginName]
+            self.countChecked[pluginName] = checked_count
             self.updateToolTip(plugin)
 
     def _setAll(self, val: Qt.CheckState):


### PR DESCRIPTION
# Fix parent checkbox state updates in feature selection dialog

Updates the parent checkbox states to properly reflect partial selections when using preset buttons like "All But Location". Previously the parent states weren't being updated correctly after modifying child checkboxes.

## Changes
- Added `updateParentState()` helper method to recursively update parent checkbox states
- Modified `_setDefaults()` to properly update parent states after changing child selections
- Fixed checked count tracking for accurate tooltips
- Closes #2894

## Checklist

- [x] Format code and imports
- [x] Add docstrings and comments
- [ ] Add tests
- [ ] Update user documentation
- [x] Reference relevant issues and other pull requests
- [x] Rebase commits into a logical sequence

Fixes inconsistent parent checkbox states when using preset selection buttons.
<img width="178" alt="image" src="https://github.com/user-attachments/assets/6c791968-cfeb-4f12-8553-2182f2ea0c32" />

