### PR TITLE
Fix: include Qt.PartiallyChecked in feature selection check logic

### DIFF
--- a/ilastik/applets/objectExtraction/objectExtractionGui.py
+++ b/ilastik/applets/objectExtraction/objectExtractionGui.py
@@ -366,7 +366,7 @@ class FeatureSelectionDialog(QDialog):
                         if feature_item.checkState(0) == Qt.Checked:
                             featnames.append(feature_item.feature_id)
                 else:
-                    if child.checkState(0) == Qt.Checked:
+                    if child.checkState(0) in (Qt.Checked, Qt.PartiallyChecked):
                         featnames.append(child.feature_id)
 
             if len(featnames) > 0:

--- a/tests/test_ilastik/test_applets/objectExtraction/test_objectExtractionGui.py
+++ b/tests/test_ilastik/test_applets/objectExtraction/test_objectExtractionGui.py
@@ -1,0 +1,13 @@
+from PyQt5.QtWidgets import QTreeWidgetItem
+from PyQt5.QtCore import Qt
+
+def test_partially_checked_state_is_included():
+    parent = QTreeWidgetItem()
+    child = QTreeWidgetItem(parent)
+
+    # Simulate PartiallyChecked checkbox state
+    child.setCheckState(0, Qt.PartiallyChecked)
+
+    # This should match the logic you updated
+    assert child.checkState(0) in (Qt.Checked, Qt.PartiallyChecked)
+


### PR DESCRIPTION
Fixes #2894

<!-- Thank you very much for opening a PR!

     Please summarize your pull request in 1-2 sentences. -->

This pull request updates the feature selection logic to include `Qt.PartiallyChecked` items in addition to `Qt.Checked`. Previously, partially-checked items were ignored, which caused issues in the UI when using preset buttons like "All But Location".

This fix ensures the correct features are selected even when some sub-items are not fully checked, improving usability and consistency.

### Changes

- Updated condition from:
  ```python
  if child.checkState(0) == Qt.Checked:

to:

if child.checkState(0) in (Qt.Checked, Qt.PartiallyChecked):


## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
