### PR TITLE
Update environment for next development cycle

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -119,14 +119,14 @@ jobs:
         shell: bash -l {0}
         run: |
           xvfb-run --server-args="-screen 0 1024x768x24" conda-build --test --override-channels \
-            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge -c conda-forge \
+            -c ./pkgs -c ilastik-forge -c conda-forge \
             ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
       - name: osx test
         if: matrix.os == 'macos-latest'
         shell: bash -l {0}
         run: |
           VOLUMINA_SHOW_3D_WIDGET=0 conda-build --test --override-channels \
-            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge -c conda-forge \
+            -c ./pkgs -c ilastik-forge -c conda-forge \
             ./pkgs/noarch/${ILASTIK_PACKAGE_NAME}
       - name: windows test
         if: matrix.os == 'windows-latest'
@@ -134,7 +134,7 @@ jobs:
         run: |
           set VOLUMINA_SHOW_3D_WIDGET=0
           conda build --test --override-channels ^
-            -c ./pkgs -c pytorch -c nvidia -c ilastik-forge/label/patched -c ilastik-forge -c conda-forge ^
+            -c ./pkgs -c ilastik-forge/label/patched -c ilastik-forge -c conda-forge ^
             ./pkgs/noarch/%ILASTIK_PACKAGE_NAME%
         # HACK: due to a bug in conda-build need to point to
         # libarchive explicitly.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
     conda install --name %ENV_NAME% --freeze-installed -c ilastik-forge -c conda-forge volumina
     conda run -n %ENV_NAME% pip install -e .
   - conda clean -p
+  - conda list -n %ENV_NAME%
 
 build: off
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,12 +20,12 @@ outputs:
         - python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
     requirements:
       host:
-        - python >=3.7
+        - python >=3.9
         - pip
         - setuptools >=40.0
         - setuptools_scm
       run:
-        - python >=3.7
+        - python >=3.9
         - numpy >1.12,<1.23
         # aiohttp to enable zarr.storage.FSStore
         - aiohttp
@@ -118,7 +118,7 @@ outputs:
       run:
         - python 3.9.*
         - {{ pin_subpackage("ilastik-core", exact=True) }}
-        - pytorch >=1.6,<2.4.1
+        - pytorch >=1.6
         - tiktorch
         - torchvision
         - volumina
@@ -135,8 +135,6 @@ outputs:
       requires:
         - pytest >4
         - pytest-qt
-        # need to help mamba here a bit
-        - ilastik-pytorch-version-helper-cpu
         - pytorch 2.*
 
       imports:
@@ -170,7 +168,7 @@ outputs:
       run:
         - python 3.9.*
         - {{ pin_subpackage("ilastik-core", exact=True) }}
-        - pytorch >=1.6,<2.4.1
+        - pytorch >=1.6
         - tiktorch
         - torchvision
         - pytorch-cuda

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -68,7 +68,6 @@ outputs:
         - z5py
         - zarr 2.*
       run_constrained:
-        - mkl <2024.1.0
         - tiktorch 25.4.0
         - volumina >=1.3.10
         # TODO: sphericaltexture 0.1.1 currently times out in the tests

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -63,7 +63,7 @@ outputs:
         - tifffile >=2022
         # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
         # need to bump this manually until there is a true version bump in vigra
-        - vigra 1.11.1=*_1038
+        - vigra 1.12.1
         - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
         - z5py
         - zarr 2.*
@@ -170,7 +170,7 @@ outputs:
         - pytorch >=1.6
         - tiktorch
         - torchvision
-        - pytorch-cuda
+        - pytorch *cuda*
         - volumina
         # Third-party object feature plugins
         - sphericaltexture_plugin
@@ -186,7 +186,6 @@ outputs:
         - pytest >4
         - pytest-qt
         - pytorch 2.*
-        - pytorch-cuda 11.*
 
       imports:
         - ilastik

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -1,7 +1,7 @@
 channels:
   - ilastik-forge/label/patched
-  - ilastik-forge
   - conda-forge
+  - ilastik-forge
 dependencies:
   - python 3.11.*
   - numpy 1.*

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -1,23 +1,17 @@
 channels:
-  - pytorch
-#  - nvidia  # uncomment for pytorch with cuda
-  # ilastik-forge/label/patched contains patched versions of pyshtools
-  # with certain dependencies removed that made solving the ilastik
-  # environment impossible / extremely inflexible
   - ilastik-forge/label/patched
   - ilastik-forge
   - conda-forge
-  - nodefaults
 dependencies:
-  - python 3.9.*
-  - numpy 1.22.*
+  - python 3.11.*
+  - numpy 1.*
   - appdirs
   - cachetools
   - dpct
   - fastfilters
   - future
   - greenlet
-  - grpcio 1.49.1
+  - grpcio >=1.49.1
   - h5py
   - hytra
   - ilastik-feature-selection
@@ -44,7 +38,7 @@ dependencies:
   - tifffile >=2022
   # build 1.11.1=*_1028 on cf is the first to be compatible with numpy>1.19
   # need to bump this manually until there is a true version bump in vigra
-  - vigra 1.11.1=*_1038
+  - vigra 1.12.1
   # xarray versions not compatible with numpy 1.21, 2023.08.0 might be, but lost trust
   # 2023.10.1 correctly pins numpy to 1.22 and up
   - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
@@ -56,14 +50,14 @@ dependencies:
 
   # Deep learning dependencies (neural net workflow, trainable domain adaptation)
   # can be changed to request gpu versions
-  - pytorch <2.4.1  # >=2.4 can clash with pyshtools on win; 2.2.2 newest available on osx
-  - cpuonly  # comment out for pytorch with cuda
+  - pytorch 2.6.*  # >=2.4 can clash with pyshtools on win; 2.2.2 newest available on osx
+  # - cpuonly  # comment out for pytorch with cuda
   # - pytorch-cuda=11.3  # uncomment for pytorch with cuda, specify cuda version
   - tiktorch 25.4.0
   # mamba does not "respect" track_features, which is the idea behind cpuonly,
   # with ilastik-pytorch-version-helper-cpu we help mamba on linux and windows
   # to install a cpu-build
-  - ilastik-pytorch-version-helper-cpu  # comment out for pytorch with cuda
+  # - ilastik-pytorch-version-helper-cpu  # comment out for pytorch with cuda
 
 
   # Third-party object feature plugins
@@ -84,4 +78,4 @@ dependencies:
   # - mkl 2021.*  # [osx]
 
   # must be commented out on arm-64 native (no mkl!)
-  - mkl <2024.1.0  # [linux] until pytorch is compatible with the current version
+  # - mkl <2024.1.0  # [linux] until pytorch is compatible with the current version

--- a/lazyflow/operators/opLazyConnectedComponents.py
+++ b/lazyflow/operators/opLazyConnectedComponents.py
@@ -380,11 +380,11 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
                 extendingLabels = np.array([b for a, b in zip(myLabels, otherLabels) if a in actualLabels]).astype(
                     myLabels.dtype
                 )
-                extendingLabels = np.sort(vigra.analysis.unique(extendingLabels)).astype(_LABEL_TYPE)
 
                 # add the neighbour to our processing queue only if it actually
                 # shares objects
                 if extendingLabels.size > 0:
+                    extendingLabels = np.sort(vigra.analysis.unique(extendingLabels)).astype(_LABEL_TYPE)
                     # check if already in queue
                     found = False
                     for i in range(len(chunksToProcess)):
@@ -740,7 +740,7 @@ class OpLazyConnectedComponents(Operator, ObservableCache):
         m = {np.uint8: 1, np.uint16: 2, np.uint32: 4, np.uint64: 8}
         nStoredChunks = self._isFinal.sum()
         nChunks = self._isFinal.size
-        cachedMB = self._cache.data_bytes / 1024.0 ** 2
+        cachedMB = self._cache.data_bytes / 1024.0**2
         rawMB = self._cache.size * m[_LABEL_TYPE]
         logger.debug("Currently stored chunks: {}/{} ({:.1f} MB)".format(nStoredChunks, nChunks, cachedMB))
 

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -124,7 +124,7 @@ class ArrayLike(SlotType):
         if self.slot.meta.has_mask:
             storage_mask = numpy.zeros(storage.shape, dtype=bool)
             storage_fill_value = None
-            if issubclass(storage.dtype.type, (numpy.bool8, numpy.integer)):
+            if issubclass(storage.dtype.type, (numpy.bool_, numpy.integer)):
                 storage_fill_value = storage.dtype.type(0)
             elif issubclass(storage.dtype.type, numpy.floating):
                 storage_fill_value = storage.dtype.type(numpy.nan)


### PR DESCRIPTION
In progress...

* Removed deprecated `pytorch` and `nvidia` channels in favor of `conda-forge`

Major dependency updates:

* `python`: `3.9` -> `3.11`
* `vigra`: `1.11.1` (with annoying build pinning) -> `1.12.1`
* `pytorch`: `2.4` (from _pytorch_ channel) -> `2.6` (from _conda-forge_ channel)