### PR TITLE
Add pixel size support

### DIFF
--- a/ilastik/workflows/counting/countingWorkflow.py
+++ b/ilastik/workflows/counting/countingWorkflow.py
@@ -35,6 +35,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+traceLogger = logging.getLogger("TRACE." + __name__)
+traceLogger.setLevel(logging.DEBUG)
+
 
 class CountingWorkflow(Workflow):
     workflowName = "Cell Density Counting"
@@ -141,6 +144,12 @@ class CountingWorkflow(Workflow):
         Overridden from Workflow base class.
         Called immediately after a new lane is added to the workflow and initialized.
         """
+        # Log pixel dimensions and units (if applicable)
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(0)
+        if opData.Image.meta.resolution and opData.Image.meta.units:
+            traceLogger.debug("Pixel Dimensions: " + (" ".join(map(str, opData.Image.meta.resolution))))
+            traceLogger.debug("Dimension Units: " + (" ".join(map(str, opData.Image.meta.units))))
+
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifier is not None:
             self.countingApplet.topLevelOperator.classifier_cache.forceValue(self.stored_classifier)

--- a/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
+++ b/ilastik/workflows/edgeTrainingWithMulticut/edgeTrainingWithMulticutWorkflow.py
@@ -40,6 +40,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+traceLogger = logging.getLogger("TRACE." + __name__)
+traceLogger.setLevel(logging.DEBUG)
+
 
 class EdgeTrainingWithMulticutWorkflow(Workflow):
     workflowName = "Edge Training With Multicut"
@@ -167,6 +170,12 @@ class EdgeTrainingWithMulticutWorkflow(Workflow):
         """
         opEdgeTrainingWithMulticut = self.edgeTrainingWithMulticutApplet.topLevelOperator
         opClassifierCache = opEdgeTrainingWithMulticut.opEdgeTraining.opClassifierCache
+
+        # Log pixel dimensions and units (if applicable)
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(0)
+        if opData.Image.meta.resolution and opData.Image.meta.units:
+            traceLogger.debug("Pixel Dimensions: " + (" ".join(map(str, opData.Image.meta.resolution))))
+            traceLogger.debug("Dimension Units: " + (" ".join(map(str, opData.Image.meta.units))))
 
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifier:

--- a/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
+++ b/ilastik/workflows/newAutocontext/newAutocontextWorkflow.py
@@ -31,6 +31,9 @@ from ilastik.applets.pixelClassification.opPixelClassification import OpPixelCla
 
 logger = logging.getLogger(__name__)
 
+traceLogger = logging.getLogger("TRACE." + __name__)
+traceLogger.setLevel(logging.DEBUG)
+
 import numpy as np
 
 from ilastik.config import cfg as ilastik_config
@@ -239,6 +242,12 @@ class NewAutocontextWorkflowBase(Workflow):
         Overridden from Workflow base class.
         Called immediately after a new lane is added to the workflow and initialized.
         """
+        # Log pixel dimensions and units (if applicable)
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(0)
+        if opData.Image.meta.resolution and opData.Image.meta.units:
+            traceLogger.debug("Pixel Dimensions: " + (" ".join(map(str, opData.Image.meta.resolution))))
+            traceLogger.debug("Dimension Units: " + (" ".join(map(str, opData.Image.meta.units))))
+
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifers:
             for pcApplet, classifier in zip(self.pcApplets, self.stored_classifers):

--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -42,6 +42,9 @@ from ilastik.utility import SlotNameEnum
 from lazyflow.graph import Graph
 from lazyflow.roi import TinyVector, fullSlicing
 
+traceLogger = logging.getLogger("TRACE." + __name__)
+traceLogger.setLevel(logging.DEBUG)
+
 
 class PixelClassificationWorkflow(Workflow):
     workflowName = "Pixel Classification"
@@ -233,6 +236,13 @@ class PixelClassificationWorkflow(Workflow):
         Overridden from Workflow base class.
         Called immediately after a new lane is added to the workflow and initialized.
         """
+
+        # Log pixel dimensions and units (if applicable)
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(0)
+        if opData.Image.meta.resolution and opData.Image.meta.units:
+            traceLogger.debug("Pixel Dimensions: " + (" ".join(map(str, opData.Image.meta.resolution))))
+            traceLogger.debug("Dimension Units: " + (" ".join(map(str, opData.Image.meta.units))))
+
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifier:
             self.pcApplet.topLevelOperator.classifier_cache.forceValue(self.stored_classifier)

--- a/ilastik/workflows/voxelSegmentation/voxelSegmentationWorkflow.py
+++ b/ilastik/workflows/voxelSegmentation/voxelSegmentationWorkflow.py
@@ -42,6 +42,9 @@ from .voxelSegmentationApplet import VoxelSegmentationApplet
 
 logger = logging.getLogger(__name__)
 
+traceLogger = logging.getLogger("TRACE." + __name__)
+traceLogger.setLevel(logging.DEBUG)
+
 
 class VoxelSegmentationWorkflow(Workflow):
     workflowName = "Voxel Segmentation Workflow"
@@ -232,6 +235,12 @@ class VoxelSegmentationWorkflow(Workflow):
         Overridden from Workflow base class.
         Called immediately after a new lane is added to the workflow and initialized.
         """
+        # Log pixel dimensions and units (if applicable)
+        opData = self.dataSelectionApplet.topLevelOperator.getLane(0)
+        if opData.Image.meta.resolution and opData.Image.meta.units:
+            traceLogger.debug("Pixel Dimensions: " + (" ".join(map(str, opData.Image.meta.resolution))))
+            traceLogger.debug("Dimension Units: " + (" ".join(map(str, opData.Image.meta.units))))
+
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifier:
             self.pcApplet.topLevelOperator.classifier_cache.forceValue(self.stored_classifier)


### PR DESCRIPTION
Proof of concept for importing pixel resolution metadata from TIFF files. Reads metadata where applicable and logs the values and units when the file is loaded.

## Checklist
- ✓ Format code and imports.
- ✓ Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Rebase commits into a logical sequence.
