### PR TITLE
Fix relative logfile path handling

### DIFF
--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -212,8 +212,9 @@ def init(format_prefix="", output_mode=OutputMode.LOGFILE_WITH_CONSOLE_ERRORS, l
         output_mode = OutputMode.CONSOLE
 
     if output_mode != OutputMode.CONSOLE:
-        os.makedirs(os.path.dirname(logfile_path), exist_ok=True)
-        _delete_old_session_logs(log_dir=Path(logfile_path).parent)
+        log_dir = Path(logfile_path).parent
+        log_dir.mkdir(parents=True, exist_ok=True)
+        _delete_old_session_logs(log_dir=log_dir)
 
     # Preserve pre-existing handlers
     original_root_handlers = list(logging.getLogger().handlers)


### PR DESCRIPTION
If logfile path is relative (e.g. from `--logfile my-log.txt`), then `os.path.dirname(logfile_path)` returned an empty string, which broke on `os.makedirs`.

Now, logdir is wrapped in `Path` that correctly handles relative dirs.