### PR TITLE
Fix depl

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -117,7 +117,7 @@ outputs:
     requirements:
       run:
         - python 3.9.*
-        - ilastik-core {{ setup_py_data.version }}
+        - {{ pin_subpackage("ilastik-core", exact=True) }}
         - pytorch >=1.6,<2.4.1
         - tiktorch
         - torchvision
@@ -169,7 +169,7 @@ outputs:
     requirements:
       run:
         - python 3.9.*
-        - ilastik-core {{ setup_py_data.version }}
+        - {{ pin_subpackage("ilastik-core", exact=True) }}
         - pytorch >=1.6,<2.4.1
         - tiktorch
         - torchvision


### PR DESCRIPTION
boa and conda-build seem to have slightly different behavior wrt to pins.

Our subpackage pin in the form of

```yaml
  - ilastik {{ version }}
```

would work correctly with boa, but conda-build seems to add a `.*` to that requirement, which will pull in all kinds of other versions.

The proper way to pin subpackage is using `{{ pin_subpackage("ilastik-core", exact=True) }}` ...