### PR TITLE
Update forum counter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,7 @@
 
 > The interactive learning and segmentation toolkit
 
+[![Conda Badge][conda-img]][conda-url]
 [![CircleCI][circleci-img]][circleci-url]
 [![AppVeyor][appveyor-img]][appveyor-url]
 [![Codecov][codecov-img]][codecov-url]
@@ -16,7 +17,7 @@ Most operations are interactive, even on large datasets: you just draw the label
 
 ![Screenshot][screenshot]
 
-See [ilastik.org](https://ilastik.org) for more info.
+See [ilastik.org](https://ilastik.org) for more info and [downloads][download-page].
 
 ---
 
@@ -49,6 +50,7 @@ ilastik
 
 #### Python compatibility notes
 
+The current version of ilastik (up to the stable release `1.4.1`) is developed for Python `3.9`.
 Versions of ilastik until `1.4.1b2` are based on, and only compatible with Python `3.7`
 Starting from ilastik `1.4.1b3` ilastik environments can be created with Python versions `3.7` to `3.9`.
 Limitations when going with Python `3.7`: please use a version of tifffile `>2020.9.22,<=2021.11.2` (see also note in [environment-dev.yml](dev/environment-dev.yml)).
@@ -83,7 +85,9 @@ For more complex changes, see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 [appveyor-url]: https://ci.appveyor.com/project/ilastik/ilastik/branch/main
 [codecov-img]: https://img.shields.io/codecov/c/github/ilastik/ilastik/main
 [codecov-url]: https://codecov.io/gh/ilastik/ilastik/branch/main
-[imagesc-img]: https://img.shields.io/badge/dynamic/json?color=informational&label=forum.image.sc&query=%24.topic_list.tags%5B0%5D.id&suffix=%20topics&url=https%3A%2F%2Fforum.image.sc%2Ftag%2Filastik.json
+[conda-img]: https://anaconda.org/ilastik-forge/ilastik/badges/version.svg
+[conda-url]: https://anaconda.org/ilastik-forge/ilastik
+[imagesc-img]: https://img.shields.io/badge/dynamic/json.svg?label=forum&amp;url=https%3A%2F%2Fforum.image.sc%2Ftags%2Filastik.json&amp;query=%24.topic_list.tags.0.topic_count&amp;colorB=brightgreen&amp;&amp;suffix=%20topics&amp;logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABPklEQVR42m3SyyqFURTA8Y2BER0TDyExZ+aSPIKUlPIITFzKeQWXwhBlQrmFgUzMMFLKZeguBu5y+//17dP3nc5vuPdee6299gohUYYaDGOyyACq4JmQVoFujOMR77hNfOAGM+hBOQqB9TjHD36xhAa04RCuuXeKOvwHVWIKL9jCK2bRiV284QgL8MwEjAneeo9VNOEaBhzALGtoRy02cIcWhE34jj5YxgW+E5Z4iTPkMYpPLCNY3hdOYEfNbKYdmNngZ1jyEzw7h7AIb3fRTQ95OAZ6yQpGYHMMtOTgouktYwxuXsHgWLLl+4x++Kx1FJrjLTagA77bTPvYgw1rRqY56e+w7GNYsqX6JfPwi7aR+Y5SA+BXtKIRfkfJAYgj14tpOF6+I46c4/cAM3UhM3JxyKsxiOIhH0IO6SH/A1Kb1WBeUjbkAAAAAElFTkSuQmCC
 [imagesc-url]: https://forum.image.sc/tags/ilastik
 [black-img]: https://img.shields.io/badge/code%20style-black-black
 [black-url]: https://github.com/psf/black


### PR DESCRIPTION
Noticed our forum counter showed an unreasonably low number, so I search for a url that would be more accurate.

<img width="298" alt="image" src="https://github.com/user-attachments/assets/7321d753-d6d0-4185-aad8-b0b251494585" />

left old, right new 🤷 