### PR TITLE
Enforce encoding when reading license file

### DIFF
--- a/ilastik/shell/gui/licenseDialog.py
+++ b/ilastik/shell/gui/licenseDialog.py
@@ -129,7 +129,9 @@ class LicenseDialog(QDialog):
 
         def show_license(license_path: Path, error_message: str, title: str):
             if license_path.is_file():
-                LongLicenseDialog.show_license(license_text=license_path.read_text(), title=title, parent=self)
+                LongLicenseDialog.show_license(
+                    license_text=license_path.read_text(encoding="utf-8"), title=title, parent=self
+                )
             else:
                 # parent, title, text
                 QMessageBox.warning(self, "License file not found!", error_message)


### PR DESCRIPTION
On mac, apps use ascii as default encoding (.app). The file 3rd party license file contains non-ascii characters -> encoding needs to be set.

<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
