### PR TITLE
Migrate to modern testing interface

### DIFF
--- a/tests/test_ilastik/test_applets/objectClassification/testOperators.py
+++ b/tests/test_ilastik/test_applets/objectClassification/testOperators.py
@@ -388,7 +388,7 @@ class TestOpBadObjectsToWarningMessage(unittest.TestCase):
 
         # valid format, bad features existent
         self.op.BadObjects.setValue({"objects": {1: {0: [1, 2]}}, "feats": set()})
-        self.assertNotEquals(self.op.WarningMessage.value, {})
+        self.assertNotEqual(self.op.WarningMessage.value, {})
         notimemsg = self.op.WarningMessage.value
 
         # valid format, bad features existent


### PR DESCRIPTION
## PR Summary
This small PR migrates from `unittest.assertNotEquals` to `unittest.assertNotEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertNotEqual instead.
```
See [CI logs](https://github.com/ilastik/ilastik/actions/runs/15352247032) for more infromation.

## Checklist

- [x] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
