### PR TITLE
Try orb-based codecov upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  codecov: codecov/codecov@5.4.3
+
 jobs:
   checkout_ilastik:
     resource_class: medium
@@ -91,12 +95,10 @@ jobs:
             DISPLAY: :42
         command: >
             cd ${ILASTIK_ROOT}/ilastik-meta/ilastik &&
-            conda run --live-stream -n ${TEST_ENV_NAME} pytest -v -s --run-legacy-gui --cov-report=xml --cov=lazyflow --cov=ilastik --junitxml=test-results/junit.xml
-    - run:
-        name: upload codecov results
-        command: cd ${ILASTIK_ROOT}/ilastik-meta/ilastik && bash <(curl -s https://codecov.io/bash)
-    - store_test_results:
-        path: test-results
+            conda run --live-stream -n ${TEST_ENV_NAME} pytest -v -s --run-legacy-gui --cov-report=json:cov.json --cov=lazyflow --cov=ilastik
+    - codecov/upload:
+        files: cov.json
+
     - save_cache:
         name: store dependency cache
         key: v1.4.15-dep-{{ .Branch }}-{{ epoch }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -59,7 +59,8 @@ outputs:
         # s3fs allows zarr.storage.FSStore to read s3:// URIs
         - s3fs >=2022.8.2
         - scikit-image
-        - scikit-learn
+        # There seems to be a problem with scikit-learn 1.7.0, test testContourMWTExport breaks
+        - scikit-learn <=1.6.1
         - tifffile >=2022
         - vigra 1.12.1
         - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -33,7 +33,8 @@ dependencies:
   - python-elf >= 0.4.8
   - qimage2ndarray
   - scikit-image
-  - scikit-learn
+  # There seems to be a problem with scikit-learn 1.7.0, test testContourMWTExport breaks
+  - scikit-learn <=1.6.1
   # for python 3.7 compatible environment use
   # tiffile >2020.9.22,<=2021.11.2
   - tifffile >=2022


### PR DESCRIPTION
Switched to "orb"-based upload on circleCI. Trickiest part was setting the token in the right place and configuring circleci properly. Works now.

Edit: in the end the reason why codecov stopped working was that they now require token usage on protected branches. Technically this is solved by setting the token properly. However, they deprecated their bash script for upload (that was used before in our CI) and using the orb is the way.