### PR TITLE
Logging: Ignore failed session log deletions

### DIFF
--- a/ilastik/ilastik_logging/default_config.py
+++ b/ilastik/ilastik_logging/default_config.py
@@ -76,7 +76,14 @@ def _delete_old_session_logs(*, log_dir: Path):
         [child for child in log_dir.iterdir() if re.match(SESSION_LOGFILE_NAME_PATTERN, child.name)], reverse=True
     )
     for log_file in log_files[KEEP_SESSION_LOGS:]:
-        log_file.unlink()
+        try:
+            log_file.unlink()
+        except OSError as e:
+            print(
+                f"(Warning) There was an error while trying to delete an old log file. "
+                f"Please consider checking what's up with the file if this keeps happening. "
+                f"Problematic file: {log_file} Error: {e}"
+            )
 
 
 def get_default_config(


### PR DESCRIPTION
micro-PR - We don't want ilastik to crash during startup just because a log file is locked.

Unlikely to actually happen to a user in any case, but I somehow managed to lock a log file during debugging and now ilastik can't start 🙃 