### PR TITLE
Data Export: Round when normalizing float to int

### DIFF
--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpFormattedDataExport.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpFormattedDataExport.py
@@ -21,14 +21,15 @@ from builtins import object
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-import os
 import tempfile
 import shutil
 
 import numpy
+import pytest
 import vigra
 
 from lazyflow.graph import Graph
+from lazyflow.operators.ioOperators.opFormattedDataExport import normalize
 from lazyflow.roi import roiToSlice
 from lazyflow.operators.ioOperators import OpInputDataReader, OpFormattedDataExport
 
@@ -42,7 +43,50 @@ class TestOpFormattedDataExport(object):
     def teardown_class(cls):
         shutil.rmtree(cls._tmpdir)
 
-    def testBasic(self):
+    def testConvertOnly(self):
+        """
+        Choosing only conversion, not normalization, bypasses the `normalize` function.
+        In this case we expect a simple dtype casting - without rounding values.
+        """
+        graph = Graph()
+        opExport = OpFormattedDataExport(graph=graph)
+
+        data = numpy.random.random((100, 100)).astype(numpy.float32) * 100
+        data = vigra.taggedView(data, vigra.defaultAxistags("xy"))
+        data[0, 0] = numpy.float32(0.5)  # make sure there are some edge cases
+        data[0, 1] = numpy.float32(0.0000000001)
+        data[0, 2] = numpy.float32(0.9999999999)
+        opExport.Input.setValue(data)
+        opExport.ExportDtype.setValue(numpy.uint8)
+
+        opExport.OutputFormat.setValue("hdf5")
+        opExport.OutputFilenameFormat.setValue(self._tmpdir + "/export")
+        opExport.OutputInternalPath.setValue("volume/data")
+
+        opExport.TransactionSlot.setValue(True)
+
+        assert opExport.ImageToExport.ready()
+        assert opExport.ExportPath.ready()
+        assert opExport.ImageToExport.meta.dtype == numpy.uint8
+
+        assert opExport.ExportPath.value == self._tmpdir + "/" + "export.h5/volume/data"
+        opExport.run_export()
+
+        opRead = OpInputDataReader(graph=graph)
+        try:
+            opRead.FilePath.setValue(opExport.ExportPath.value)
+
+            expected_data = data.view(numpy.ndarray)[:].astype(numpy.uint8)
+
+            assert opRead.Output.meta.shape == expected_data.shape
+            assert opRead.Output.meta.dtype == expected_data.dtype
+            read_data = opRead.Output[:].wait()
+
+            numpy.testing.assert_array_equal(read_data, expected_data)
+        finally:
+            opRead.cleanUp()
+
+    def testNormalize(self):
         graph = Graph()
         opExport = OpFormattedDataExport(graph=graph)
 
@@ -94,8 +138,29 @@ class TestOpFormattedDataExport(object):
             # Also, must promote to signed values to avoid unsigned rollover
             # See issue ( https://github.com/ilastik/lazyflow/issues/165 ).
             expected_data_signed = expected_data.astype(numpy.int16)
-            read_data_signed = expected_data.astype(numpy.int16)
+            read_data_signed = read_data.astype(numpy.int16)
             difference_from_expected = expected_data_signed - read_data_signed
             assert (numpy.abs(difference_from_expected) <= 1).all(), "Read data didn't match exported data!"
         finally:
             opRead.cleanUp()
+
+    @pytest.mark.parametrize(
+        "target_dtype", [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64, numpy.float32, numpy.float64]
+    )
+    def testNormalizeRoundsFloatImprecision(self, target_dtype):
+        """
+        Special case when normalizing float probabilities from 0.0 ... 1.0 to int range 0 ... 100
+        Probabilities are integer percentages (0.00, 0.01, 0.02 etc.), so there are 101 unique values
+        from 0.0 to 1.0. They should map to 101 unique values from 0 to 100 regardless of output dtype.
+
+        Doing maths may introduce float imprecision:
+        list((np.arange(0, 101, dtype=np.float64) / 100 * 100.0)[[29, 57, 58]])
+        [28.999999999999996, 56.99999999999999, 57.99999999999999]
+        Simply casting to integer dtypes converts these to 28, 56 and 57 respectively, instead of 29, 57 and 58.
+        """
+        probabilities = numpy.arange(0, 101, dtype=numpy.float64) / 100
+        normalized = normalize(0.0, 1.0, 0, 100, target_dtype, probabilities)
+        assert len(numpy.unique(probabilities)) == len(
+            numpy.unique(normalized)
+        ), "Expected 101 values before and after normalization"
+        numpy.testing.assert_array_equal(numpy.round(probabilities * 100), numpy.round(normalized))


### PR DESCRIPTION
We recommend our users convert Probabilities to `uint8` and normalize `0.0 ... 1.0` to `0 ... 255`.

It looks like some people would like to [normalize to `0 ... 100`](https://forum.image.sc/t/export-probabilities-as-8-bit-images/114083) so that pixels contain integer percentage probabilities. This is currently not possible - float imprecision isn't rounded but truncated during dtype conversion and as a consequence, some probability values like `14.99998` get mismapped to `14` instead of `15`.

I went with `numpy.round(a, 5)` to maintain existing behaviour as much as possible while fixing the specific issue for Probabilities, but I am wondering whether `numpy.round(a)` (without restricting to lower decimals) wouldn't actually be the correct thing to do here.

Fixes https://github.com/ilastik/ilastik/issues/3038

(Also a minor typo fix in the other test in the file which probably made the test not actually test anything)