### PR TITLE
OME-Zarr: Remove kwargs when reading

### DIFF
--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -39,7 +39,6 @@ from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.OMEZarrStore import (
-    OME_ZARR_V_0_4_KWARGS,
     OMEZarrMultiscaleMeta,
     InvalidTransformationError,
 )
@@ -53,6 +52,7 @@ TaggedShape = OrderedDict[Axiskey, int]  # { axis: size }
 OrderedScaling = OrderedTranslation = OrderedDict[Axiskey, float]  # { axis: scaling }
 ScalingsByScaleKey = OrderedDict[str, OrderedScaling]  # { scale_key: { axis: scaling } }
 
+OME_ZARR_V_0_4_KWARGS = dict(dimension_separator="/")
 OME_ZARR_AXES: List[Axiskey] = ["t", "c", "z", "y", "x"]
 SPATIAL_AXES: List[Axiskey] = ["z", "y", "x"]
 SINGE_SCALE_DEFAULT_KEY = "s0"

--- a/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
+++ b/tests/test_ilastik/test_workflows/test_HeadlessPixelClassificationWorkflow.py
@@ -20,7 +20,7 @@ import z5py
 import zarr
 
 from ilastik.applets.featureSelection import FeatureSelectionConstraintError
-from lazyflow.utility.io_util.OMEZarrStore import OME_ZARR_V_0_4_KWARGS
+from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -37,12 +37,12 @@ from typing import Tuple, List
 from PIL import Image
 
 from lazyflow.utility.io_util.OMEZarrStore import (
-    OME_ZARR_V_0_4_KWARGS,
     OMEZarrMultiscaleMeta,
     InvalidTransformationError,
     NotAnOMEZarrMultiscale,
 )
 from lazyflow.utility.io_util.multiscaleStore import Multiscales
+from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 
 
 class TestOpInputDataReader(object):


### PR DESCRIPTION
I had included these kwargs going by the example of ome-zarr-py ([kwargs for v0.1](https://github.com/ome/ome-zarr-py/blob/ba98c05959283e3084eb30d6e5f1289e2fb2abff/ome_zarr/format.py#L138) and [for v0.4](https://github.com/ome/ome-zarr-py/blob/ba98c05959283e3084eb30d6e5f1289e2fb2abff/ome_zarr/format.py#L190)).

On the reading side, it's not necessary to specify these kwargs. `"."` is the default dimension separator up to and including module version `zarr=2.*`. When it is overriden by the writer to `dimension_separator="/"` (as one should for OME-Zarr since v0.2), zarr writes this into the `.zarray` file along with the other array metadata like shape, dtype and chunk shape. From there, zarr will find it when re-reading the same data.

On the writing side, we write OME-Zarr v0.4, which should use `dimension_separator="/"` to stick with the community standard, and therefore has to override the default `"."`. But `normalize_keys=False` is not necessary as `False` is the default value anyway.

They recently caused an issue where an OME-Zarr v0.4 dataset that was written with `dimension_separator="."` appeared to be empty to the reader, since paths like `0/0/0/0` were indeed empty, and hence loaded only zeros (the `fill_value`). The [spec for v0.4](https://ngff.openmicroscopy.org/0.4/index.html#image-layout) gives an example that shows the slash-separation, but the phrasing doesn't actually use spec vocabulary ("MUST"/"SHOULD") to make it clear whether this is required or just recommended. In any case, it's clear there is at least one OME-Zarr writer tool out there that exposes this option to its users and doesn't enforce that the usage comply with the "common" or "recommended" on-disk layout from the spec.