### PR TITLE
OME-Zarr export: Fix corner cases when matching input scales

### DIFF
--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -86,7 +86,11 @@ def _match_target_scales_to_input(export_shape: TaggedShape, input_scales: Multi
         input_scalings = _multiscales_to_scalings(input_scales, source_scale_shape, export_shape.keys())
         target_shapes = []
         for scale_key, scale_factors in input_scalings.items():
-            target_shapes.append(ODict([(a, int(size / scale_factors[a])) for a, size in export_shape.items()]))
+            scaled_shape = ODict([(a, int(size / scale_factors[a])) for a, size in export_shape.items()])
+            spatials = [a for a in SPATIAL_AXES if a in scaled_shape]
+            if all(scaled_shape[a] <= 1 for a in spatials):
+                break
+            target_shapes.append(scaled_shape)
         target_scales = ODict(zip(input_scales.keys(), target_shapes))
 
     scales_items = []

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -83,7 +83,7 @@ def _match_target_scales_to_input(export_shape: TaggedShape, input_scales: Multi
         # Export shape is modified (cropped).
         # Get source multiscale's scaling factors relative to the (uncropped) input shape and compute cropped scale
         # shapes from that.
-        input_scalings = _multiscales_to_scalings(input_scales, source_scale_shape, source_scale_shape.keys())
+        input_scalings = _multiscales_to_scalings(input_scales, source_scale_shape, export_shape.keys())
         target_shapes = []
         for scale_key, scale_factors in input_scalings.items():
             target_shapes.append(ODict([(a, int(size / scale_factors[a])) for a, size in export_shape.items()]))

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -656,6 +656,24 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
                 ]
             ),
         ),
+        (  # Export is cropped so tiny that matching downscales would be degenerate
+            tagged_shape("zyxc", (10, 7, 5, 3)),
+            OrderedDict(
+                [
+                    ("0", tagged_shape("czyx", (2, 225, 225, 225))),
+                    ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
+                    ("2", tagged_shape("czyx", (2, 25, 25, 25))),
+                    ("3", tagged_shape("czyx", (2, 8, 8, 8))),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("source_scale", tagged_shape("tczyx", (1, 3, 10, 7, 5))),
+                    ("2", tagged_shape("tczyx", (1, 3, 3, 2, 1))),  # Include even if one axis is singleton
+                    # "3" excluded because all axes become singleton (or 0 in case of x)
+                ]
+            ),
+        ),
     ],
 )
 def test_match_target_scales_to_input_excluding_upscales(shape, input_scales, expected_shapes):

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -641,6 +641,21 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
                 ]
             ),
         ),
+        (  # Export is cropped + input has no channels
+            tagged_shape("zyxc", (16, 16, 16, 3)),
+            OrderedDict(
+                [
+                    ("source_scale", tagged_shape("zyx", (25, 25, 25))),
+                    ("4", tagged_shape("zyx", (8, 8, 8))),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("source_scale", tagged_shape("tczyx", (1, 3, 16, 16, 16))),
+                    ("4", tagged_shape("tczyx", (1, 3, 5, 5, 5))),
+                ]
+            ),
+        ),
     ],
 )
 def test_match_target_scales_to_input_excluding_upscales(shape, input_scales, expected_shapes):


### PR DESCRIPTION
😭 

* input has no channels -> KeyError "c"
* input has a bunch of downscales smaller than the working scale, but export gets cropped tiny -> matched downscale shapes can have 1 and 0 along xyz