### PR TITLE
Log data selection errors

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionGui.py
+++ b/ilastik/applets/dataSelection/dataSelectionGui.py
@@ -474,6 +474,7 @@ class DataSelectionGui(QWidget):
         except Exception as e:
             self.topLevelOperator.DatasetGroup.resize(originalNumLanes)
             QMessageBox.critical(self, "File selection error", str(e))
+            logger.error(e, exc_info=True)
 
     def applyDatasetInfos(self, new_infos: List[DatasetInfo], info_slots: List[Slot]):
         original_infos = []

--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -22,7 +22,7 @@ import logging
 import pathlib
 from functools import partial
 from time import perf_counter
-from typing import Callable
+from typing import Type
 
 from PyQt5.QtCore import pyqtSignal, QThread
 from PyQt5.QtWidgets import (
@@ -73,7 +73,7 @@ class CheckRemoteStoreWorker(QThread):
     success = pyqtSignal(object)  # returns MultiscaleStore
     error = pyqtSignal(str)  # returns error message
 
-    def __init__(self, parent, store_init: Callable):
+    def __init__(self, parent, store_init: Type[MultiscaleStore.__init__]):
         super().__init__(parent)
         self.store_init = store_init
 


### PR DESCRIPTION
Tiny change for better debuggability. Noticed this because it made errors while working with multiscale datasets across roles hard to debug, but it's independent of that feature/fix.