### PR TITLE
Lazyflow.Slot: Fix multi-inputs not signalling unreadiness

### DIFF
--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -629,6 +629,8 @@ class Slot(object):
                 self.upstream_slot.disconnect()
             return
 
+        oldReady = self.ready()
+
         for slot in self._subSlots:
             slot.disconnect()
 
@@ -646,7 +648,6 @@ class Slot(object):
         self.upstream_slot = None
         had_value = self._value is not None
         self._value = None
-        oldReady = self.meta._ready
         self.meta = MetaDict()
 
         if len(self._subSlots) > 0 and self.operator and not self.operator._cleaningUp:

--- a/tests/test_lazyflow/test_operator.py
+++ b/tests/test_lazyflow/test_operator.py
@@ -1,0 +1,61 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2025, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+# 		   http://ilastik.org/license/
+###############################################################################
+from lazyflow.operator import Operator, InputSlot, OutputSlot
+
+
+class OpSimpleInput(Operator):
+    Input = InputSlot()
+    Output = OutputSlot()
+
+    def setupOutputs(self):
+        pass
+
+    def propagateDirty(self, slot, subindex, roi):
+        pass
+
+
+class OpMultiInput(Operator):
+    MultiInput = InputSlot(level=1)
+    Output = OutputSlot()
+
+    def setupOutputs(self):
+        pass
+
+    def propagateDirty(self, slot, subindex, roi):
+        pass
+
+
+def test_simple_input_sets_output_ready_and_unready(graph):
+    op = OpSimpleInput(graph=graph)
+    op.Input.setValue(True)
+    assert op.Output.ready()
+    op.Input.disconnect()
+    assert not op.Output.ready()
+
+
+def test_multi_input_sets_output_ready_and_unready(graph):
+    op = OpMultiInput(graph=graph)
+    op.MultiInput.resize(1)
+    op.MultiInput[0].setValue(True)
+    assert op.Output.ready()
+    op.MultiInput.disconnect()
+    assert not op.Output.ready()


### PR DESCRIPTION
This sneaky bug is one of the reasons some ilastik workflows can't deal with input datasets changing shape: InputSlots with levels > 0 don't correctly trigger their unready signal. As a consequence, ops that have InputSlots with e.g. level=1 end up with their outputs still ready even if their inputs are unready. Example (note input on the left is red but output is white):

<img width="761" height="148" alt="image" src="https://github.com/user-attachments/assets/42b747c1-9e50-45aa-87cc-79fa17841aea" />

This is an `OpMultiArrayMerger` in object classification. I found this bug while trying to get multiple multiscales in different roles to work properly; it's a bit hard to reproduce through the gui.

I've added a couple of very simple tests to illustrate and reproduce the problem (is lazyflow core functionality really basically untested..?). The root cause of the issue is that when disconnecting, multi-inputs check their previous ready-state the wrong way, and too late. *The wrong way*: `oldReady` is taken from `self.meta._ready`. For multi-slots, `self.meta._ready` is never `True`. Multi-slots determine whether they are `ready()` by checking `len(self._subSlots) > 0 and all(_subSlots.ready())`. *Too late*: By the time `disconnect` collects `oldReady`, multi-slots have already `disconnect`ed all their `_subSlots`, making `oldReady` always False for multi-slots.

The alternative fix would be to attach the operator's `handleInputBecameUnready` listener (the one responsible for setting the op's outputs unready) to every `_subSlot` for multi-inputs. The approach I've chosen is probably the better one, because the current behaviour seems plain wrong, as illustrated by the tests.

Note: The op shown here is also the culprit behind #3053, and this PR is part of fixing that, but the problem with the shape metadata described in that issue is not fixed by this. You can add asserts on `meta.shape` to the tests in this PR and see that neither the simple input nor the multi-input erase shape meta when becoming unready due to an input disconnecting. I also consider this wrong, but we can discuss whether the change to `Operator.handleInputBecameUnready` should go in this PR or a separate one (I've kept it separate so that this PR can be strictly the bug fix, while that would basically be a new feature).