### PR TITLE
Refactor Main splitter from .ui definition to Python

### DIFF
--- a/ilastik/applets/dataSelection/dataSelection.ui
+++ b/ilastik/applets/dataSelection/dataSelection.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QSplitter" name="splitter">
      <property name="orientation">

--- a/ilastik/applets/featureSelection/viewerControls.ui
+++ b/ilastik/applets/featureSelection/viewerControls.ui
@@ -20,6 +20,18 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>15</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QWidget" name="viewerControls" native="true">
      <property name="sizePolicy">
@@ -29,6 +41,9 @@
       </sizepolicy>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="margin">
+    <number>0</number>
+   </property>
       <item>
        <widget class="QLabel" name="label_2">
         <property name="sizePolicy">

--- a/ilastik/applets/neuralNetwork/viewerControls.ui
+++ b/ilastik/applets/neuralNetwork/viewerControls.ui
@@ -14,6 +14,9 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">

--- a/ilastik/applets/pixelClassification/viewerControls.ui
+++ b/ilastik/applets/pixelClassification/viewerControls.ui
@@ -14,6 +14,18 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>15</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -60,6 +60,7 @@ from PyQt5.QtWidgets import (
 )
 
 # lazyflow
+from ilastik.shell.gui.shellWidgets import HorizontalMainSplitter, MainControls
 from ilastik.widgets.collapsibleWidget import CollapsibleWidget
 from lazyflow.roi import TinyVector
 from lazyflow.graph import Operator
@@ -746,6 +747,16 @@ class IlastikShell(QMainWindow):
 
         self.startscreen.CreateList.setWidget(self.startscreen.VL1.widget())
         self.startscreen.CreateList.setWidgetResizable(True)
+
+        # Expose some attributes of custom widgets on class level
+        self.sideSplitter: HorizontalMainSplitter = self.startscreen.sideSplitter
+        mainControls: MainControls = self.sideSplitter.mainSplitter
+        self.imageSelectionCombo = mainControls.imageSelectionCombo
+        self.appletBar = mainControls.appletBar
+        self.viewerControlStack = mainControls.viewerControlStack
+        self.imageSelectionGroup = mainControls.imageSelectionGroup
+        self.mainSplitter = mainControls
+        self.appletStack = self.sideSplitter.appletStack
 
         self._replaceLogo(localDir)
 

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -125,8 +125,13 @@ class HorizontalMainSplitter(QSplitter):
             parent=parent,
         )
         self.setChildrenCollapsible(False)
-        self.mainSplitter = MainControls()
-        self.appletStack = CentralWidgetStack()
+        self.mainControls = MainControls()
+        self.viewerControlStack = self.mainControls.viewerControlStack
+        self.appletBar = self.mainControls.appletBar
+        self.imageSelectionGroup = self.mainControls.imageSelectionGroup
+        self.imageSelectionCombo = self.mainControls.imageSelectionCombo
 
-        self.insertWidget(0, self.mainSplitter)
-        self.insertWidget(1, self.appletStack)
+        self.centralStack = CentralWidgetStack()
+
+        self.insertWidget(0, self.mainControls)
+        self.insertWidget(1, self.centralStack)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -67,7 +67,7 @@ class MainControls(QSplitter):
         self.appletBar = AppletDrawerToolBox()
         appletbar_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
         appletbar_policy.setHorizontalStretch(0)
-        appletbar_policy.setVerticalStretch(0)
+        appletbar_policy.setVerticalStretch(6)
         self.appletBar.setSizePolicy(appletbar_policy)
 
         appletBar_pallette = QPalette()
@@ -102,10 +102,15 @@ class MainControls(QSplitter):
 
         verticalLayout = QVBoxLayout()
         verticalLayout.setSpacing(0)
+        verticalLayout.setContentsMargins(0, 0, 0, 0)
         verticalLayout.addWidget(self.imageSelectionGroup)
         verticalLayout.addWidget(self.viewerControlStack)
         layoutWidget = QWidget()
         layoutWidget.setLayout(verticalLayout)
+        layout_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout_policy.setHorizontalStretch(2)
+        layout_policy.setVerticalStretch(5)
+        layoutWidget.setSizePolicy(layout_policy)
 
         self.addWidget(self.appletBar)
         self.addWidget(layoutWidget)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -1,0 +1,132 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2025, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from typing import Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSizePolicy,
+    QSplitter,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ilastik.widgets.appletDrawerToolBox import AppletDrawerToolBox
+
+
+class CentralWidgetStack(QStackedWidget):
+    """Stacked widget that will contain/show the various central widgets
+
+    usually volumina, sometimes also additional elements, e.g. in DataSelection
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        policy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        policy.setHorizontalStretch(2)
+        policy.setVerticalStretch(2)
+        self.setSizePolicy(policy)
+
+        self.setMinimumSize(500, 100)
+        self.setBaseSize(500, 100)
+
+        self.setFrameShape(QFrame.NoFrame)
+        self.setFrameShadow(QFrame.Plain)
+        self.setLineWidth(0)
+
+
+class MainControls(QSplitter):
+    """The widget home to the applet drawer and viewer control stack"""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(Qt.Vertical, parent)
+        self.appletBar = AppletDrawerToolBox()
+        appletbar_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+        appletbar_policy.setHorizontalStretch(0)
+        appletbar_policy.setVerticalStretch(0)
+        self.appletBar.setSizePolicy(appletbar_policy)
+
+        appletBar_pallette = QPalette()
+        appletBar_pallette.setColor(QPalette.Active, QPalette.Highlight, QColor(62, 62, 62, 255))
+        appletBar_pallette.setColor(QPalette.Inactive, QPalette.Highlight, QColor(62, 62, 62, 255))
+        appletBar_pallette.setColor(QPalette.Disabled, QPalette.Highlight, QColor(240, 240, 240, 255))
+        self.appletBar.setPalette(appletBar_pallette)
+        self.appletBar.setLineWidth(2)
+        self.appletBar.setMidLineWidth(2)
+
+        self.imageSelectionGroup = QWidget()
+        imageSelectionGroup_layout = QHBoxLayout()
+        imageSelectionGroup_layout.addWidget(QLabel("Current View:"))
+        self.imageSelectionCombo = QComboBox()
+        imageSelectionCombo_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        imageSelectionCombo_policy.setHorizontalStretch(0)
+        imageSelectionCombo_policy.setVerticalStretch(0)
+        self.imageSelectionCombo.setSizePolicy(imageSelectionCombo_policy)
+        imageSelectionGroup_layout.addWidget(self.imageSelectionCombo)
+        self.imageSelectionGroup.setLayout(imageSelectionGroup_layout)
+
+        self.viewerControlStack = QStackedWidget()
+        viewerControlStackpolicy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
+        viewerControlStackpolicy.setHorizontalStretch(2)
+        viewerControlStackpolicy.setVerticalStretch(2)
+        self.viewerControlStack.setSizePolicy(viewerControlStackpolicy)
+        self.viewerControlStack.setMinimumSize(310, 200)
+        self.viewerControlStack.setBaseSize(0, 0)
+        self.viewerControlStack.setFrameShape(QFrame.NoFrame)
+        self.viewerControlStack.setFrameShadow(QFrame.Plain)
+        self.viewerControlStack.setLineWidth(0)
+
+        verticalLayout = QVBoxLayout()
+        verticalLayout.setSpacing(0)
+        verticalLayout.addWidget(self.imageSelectionGroup)
+        verticalLayout.addWidget(self.viewerControlStack)
+        layoutWidget = QWidget()
+        layoutWidget.setLayout(verticalLayout)
+
+        self.addWidget(self.appletBar)
+        self.addWidget(layoutWidget)
+
+
+class HorizontalMainSplitter(QSplitter):
+    """Widget intended for the main GUI elements
+
+    Attrs:
+      * mainSplitter: Contains AppletDrawer and ViewerControlstack
+      * appletStack: Contains CentralWidget
+    """
+
+    def __init__(self, parent):
+        super().__init__(
+            orientation=Qt.Horizontal,
+            parent=parent,
+        )
+        self.setChildrenCollapsible(False)
+        self.mainSplitter = MainControls()
+        self.appletStack = CentralWidgetStack()
+
+        self.insertWidget(0, self.mainSplitter)
+        self.insertWidget(1, self.appletStack)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -18,7 +18,7 @@
 # on the ilastik web site at:
 #          http://ilastik.org/license.html
 ###############################################################################
-from typing import Optional
+from typing import Optional, Union
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QPalette
@@ -125,13 +125,49 @@ class HorizontalMainSplitter(QSplitter):
             parent=parent,
         )
         self.setChildrenCollapsible(False)
-        self.mainControls = MainControls()
-        self.viewerControlStack = self.mainControls.viewerControlStack
-        self.appletBar = self.mainControls.appletBar
-        self.imageSelectionGroup = self.mainControls.imageSelectionGroup
-        self.imageSelectionCombo = self.mainControls.imageSelectionCombo
+        self._mainControls = MainControls()
+        self._viewerControlStack = self._mainControls.viewerControlStack
+        self.appletBar = self._mainControls.appletBar
+        self._imageSelectionGroup = self._mainControls.imageSelectionGroup
+        self.imageSelectionCombo = self._mainControls.imageSelectionCombo
 
-        self.centralStack = CentralWidgetStack()
+        self._centralStack = CentralWidgetStack()
 
-        self.insertWidget(0, self.mainControls)
-        self.insertWidget(1, self.centralStack)
+        self.insertWidget(0, self._mainControls)
+        self.insertWidget(1, self._centralStack)
+
+        self._viewerControlPlaceholder = QWidget(self)
+        self._centralWidgetPlaceholder = QWidget(self)
+
+        self.setActiveViewerControls(self._viewerControlPlaceholder)
+        self.setActiveCentralWidget(self._centralWidgetPlaceholder)
+
+    def clearStackedWidgets(self):
+        for stacked_widget in [self._viewerControlStack, self._centralStack]:
+            for i in reversed(list(range(stacked_widget.count()))):
+                lastWidget = stacked_widget.widget(i)
+                stacked_widget.removeWidget(lastWidget)
+
+    @staticmethod
+    def _setActiveStackWidget(stack, widget):
+        if stack.indexOf(widget) == -1:
+            stack.addWidget(widget)
+        stack.setCurrentWidget(widget)
+
+    def setActiveViewerControls(self, viewerControlWidget: Union[QWidget, None]):
+        if viewerControlWidget is None:
+            viewerControlWidget = self._viewerControlPlaceholder
+
+        self._setActiveStackWidget(self._viewerControlStack, viewerControlWidget)
+
+    def setActiveCentralWidget(self, centralWidget: Union[QWidget, None]):
+        if centralWidget is None:
+            centralWidget = self._centralWidgetPlaceholder
+
+        self._setActiveStackWidget(self._centralStack, centralWidget)
+
+    def setMainControlsVisible(self, visible: bool):
+        self._mainControls.setVisible(visible)
+
+    def setImageSelectionGroupVisible(self, visible: bool):
+        self._imageSelectionGroup.setVisible(visible)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -115,8 +115,8 @@ class HorizontalMainSplitter(QSplitter):
     """Widget intended for the main GUI elements
 
     Attrs:
-      * mainSplitter: Contains AppletDrawer and ViewerControlstack
-      * appletStack: Contains CentralWidget
+      mainControls: Contains AppletDrawer and ViewerControlstack
+      centralStack: Contains CentralWidget
     """
 
     def __init__(self, parent):

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -467,160 +467,7 @@
          <widget class="QWidget" name="widget" native="true">
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QSplitter" name="sideSplitter">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="childrenCollapsible">
-              <bool>false</bool>
-             </property>
-             <widget class="QSplitter" name="mainSplitter">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <widget class="AppletDrawerToolBox" name="appletBar">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="palette">
-                <palette>
-                 <active>
-                  <colorrole role="Highlight">
-                   <brush brushstyle="SolidPattern">
-                    <color alpha="255">
-                     <red>62</red>
-                     <green>62</green>
-                     <blue>62</blue>
-                    </color>
-                   </brush>
-                  </colorrole>
-                 </active>
-                 <inactive>
-                  <colorrole role="Highlight">
-                   <brush brushstyle="SolidPattern">
-                    <color alpha="255">
-                     <red>62</red>
-                     <green>62</green>
-                     <blue>62</blue>
-                    </color>
-                   </brush>
-                  </colorrole>
-                 </inactive>
-                 <disabled>
-                  <colorrole role="Highlight">
-                   <brush brushstyle="SolidPattern">
-                    <color alpha="255">
-                     <red>240</red>
-                     <green>240</green>
-                     <blue>240</blue>
-                    </color>
-                   </brush>
-                  </colorrole>
-                 </disabled>
-                </palette>
-               </property>
-               <property name="lineWidth">
-                <number>2</number>
-               </property>
-               <property name="midLineWidth">
-                <number>2</number>
-               </property>
-              </widget>
-              <widget class="QWidget" name="layoutWidget">
-               <layout class="QVBoxLayout" name="verticalLayout">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QWidget" name="imageSelectionGroup" native="true">
-                  <layout class="QHBoxLayout" name="imageSelectionGroup_layout">
-                   <item>
-                    <widget class="QLabel" name="currentViewLabel">
-                     <property name="text">
-                      <string>Current View:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QComboBox" name="imageSelectionCombo">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QStackedWidget" name="viewerControlStack">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                    <horstretch>2</horstretch>
-                    <verstretch>2</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>310</width>
-                    <height>200</height>
-                   </size>
-                  </property>
-                  <property name="baseSize">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
-                  </property>
-                  <property name="frameShadow">
-                   <enum>QFrame::Plain</enum>
-                  </property>
-                  <property name="lineWidth">
-                   <number>0</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </widget>
-             <widget class="QStackedWidget" name="appletStack">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                <horstretch>2</horstretch>
-                <verstretch>2</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>500</width>
-                <height>100</height>
-               </size>
-              </property>
-              <property name="baseSize">
-               <size>
-                <width>500</width>
-                <height>100</height>
-               </size>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Plain</enum>
-              </property>
-              <property name="lineWidth">
-               <number>0</number>
-              </property>
-             </widget>
-            </widget>
+            <widget class="HorizontalMainSplitter" name="sideSplitter"/>
            </item>
           </layout>
          </widget>
@@ -654,6 +501,21 @@
    <class>StartupContainer</class>
    <extends>QWidget</extends>
    <header>ilastik.shell.gui.ilastikShell</header>
+  </customwidget>
+  <customwidget>
+   <class>MainControls</class>
+   <extends>QSplitter</extends>
+   <header>ilastik.shell.gui.shellWidgets</header>
+  </customwidget>
+  <customwidget>
+   <class>CentralWidgetStack</class>
+   <extends>QStackedWidget</extends>
+   <header>ilastik.shell.gui.shellWidgets</header>
+  </customwidget>
+  <customwidget>
+   <class>HorizontalMainSplitter</class>
+   <extends>QSplitter</extends>
+   <header>ilastik.shell.gui.shellWidgets</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -464,7 +464,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="HorizontalMainSplitter" name="sideSplitter"/>
+         <widget class="HorizontalMainSplitter" name="mainSplitter"/>
         </item>
        </layout>
       </widget>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -464,13 +464,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="widget" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <widget class="HorizontalMainSplitter" name="sideSplitter"/>
-           </item>
-          </layout>
-         </widget>
+         <widget class="HorizontalMainSplitter" name="sideSplitter"/>
         </item>
        </layout>
       </widget>

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -451,17 +451,8 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
+        <property name="margin">
+         <number>13</number>
         </property>
         <item>
          <widget class="HorizontalMainSplitter" name="mainSplitter"/>


### PR DESCRIPTION
This PR is mostly in preparation to add the secondary controls (currently the "label finder"). For this it will be nicer to have better control over the main splitter. I tried to hide direct widget access by the shell behind methods if practicable. Also the typing is now a bit nicer.

I also renamed some of the variables here because this was always confusing me:

 * `sideSplitter` -> `mainSplitter`
 * `mainSplitter` (applet + viewer controls were named that) -> `mainControls`

Here it might make sense to review in commit order.

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
