### PR TITLE
Export dialog on selected lane

### DIFF
--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -240,7 +240,7 @@ class DataExportGui(QWidget):
         self.showSelectedDataset()
 
     def _chooseSettings(self):
-        opExportModelOp, opSubRegion = get_model_op(self.topLevelOperator)
+        opExportModelOp, opSubRegion = get_model_op(self.topLevelOperator, self.batchOutputTableWidget.currentRow())
         if opExportModelOp is None:
             QMessageBox.information(
                 self,

--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -254,27 +254,14 @@ class DataExportGui(QWidget):
         settingsDlg = DataExportOptionsDlg(self, opExportModelOp, cfg["ilastik"]["output_filename_format"])
 
         if settingsDlg.exec_() == DataExportOptionsDlg.Accepted:
-            # Copy the settings from our 'model op' into the real op
-            setting_slots = [
-                opExportModelOp.RegionStart,
-                opExportModelOp.RegionStop,
-                opExportModelOp.InputMin,
-                opExportModelOp.InputMax,
-                opExportModelOp.ExportMin,
-                opExportModelOp.ExportMax,
-                opExportModelOp.ExportDtype,
-                opExportModelOp.OutputAxisOrder,
-                opExportModelOp.OutputFilenameFormat,
-                opExportModelOp.OutputInternalPath,
-                opExportModelOp.OutputFormat,
-            ]
-
             # Disconnect the special 'transaction' slot to prevent these
             #  settings from triggering many calls to setupOutputs.
             self.topLevelOperator.TransactionSlot.disconnect()
 
-            for model_slot in setting_slots:
-                real_inslot = getattr(self.topLevelOperator, model_slot.name)
+            # Copy the settings from our 'model op' into the real op
+            for slot_name in opExportModelOp.CONFIGURABLE_SETTINGS_SLOTS:
+                real_inslot = getattr(self.topLevelOperator, slot_name)
+                model_slot = getattr(opExportModelOp, slot_name)
                 if model_slot.ready():
                     real_inslot.setValue(model_slot.value)
                 else:

--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -240,7 +240,9 @@ class DataExportGui(QWidget):
         self.showSelectedDataset()
 
     def _chooseSettings(self):
-        opExportModelOp, opSubRegion = get_model_op(self.topLevelOperator, self.batchOutputTableWidget.currentRow())
+        opExportModelOp, exportSubregionMax = get_model_op(
+            self.topLevelOperator, self.batchOutputTableWidget.currentRow()
+        )
         if opExportModelOp is None:
             QMessageBox.information(
                 self,
@@ -251,7 +253,9 @@ class DataExportGui(QWidget):
             )
             return
 
-        settingsDlg = DataExportOptionsDlg(self, opExportModelOp, cfg["ilastik"]["output_filename_format"])
+        settingsDlg = DataExportOptionsDlg(
+            self, opExportModelOp, cfg["ilastik"]["output_filename_format"], exportSubregionMax
+        )
 
         if settingsDlg.exec_() == DataExportOptionsDlg.Accepted:
             # Disconnect the special 'transaction' slot to prevent these
@@ -272,7 +276,6 @@ class DataExportGui(QWidget):
 
             # Discard the temporary model op
             opExportModelOp.cleanUp()
-            opSubRegion.cleanUp()
 
             # Update the gui with the new export paths
             for index, slot in enumerate(self.topLevelOperator.ExportPath):

--- a/lazyflow/operators/ioOperators/opFormattedDataExport.py
+++ b/lazyflow/operators/ioOperators/opFormattedDataExport.py
@@ -116,6 +116,21 @@ class OpFormattedDataExport(Operator):
     TargetScales = OutputSlot()  # Scaling parameter for multi-scale OME-Zarr
     FormatSelectionErrorMsg = OutputSlot()  # bool, True if currently selected format can support the export data
 
+    # This op's slots that are user-configurable through DataExportOptionsDlg
+    CONFIGURABLE_SETTINGS_SLOTS = [
+        "RegionStart",
+        "RegionStop",
+        "InputMin",
+        "InputMax",
+        "ExportMin",
+        "ExportMax",
+        "ExportDtype",
+        "OutputAxisOrder",
+        "OutputFilenameFormat",
+        "OutputInternalPath",
+        "OutputFormat",
+    ]
+
     ALL_FORMATS = OpExportSlot.ALL_FORMATS
 
     # Simplified block diagram:                                          -> ConvertedImage                -> FormatSelectionErrorMsg

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -58,13 +58,21 @@ SPATIAL_AXES: List[Axiskey] = ["z", "y", "x"]
 SINGE_SCALE_DEFAULT_KEY = "s0"
 
 
+def _rescale_size(size: int, factor: float) -> int:
+    """
+    Rescale a single dimension of a shape.
+    Floor-round to match behavior of OpResize, and ensure minimum size is 1.
+    """
+    return max(int(size / factor), 1)
+
+
 def match_target_scales_to_input_excluding_upscales(
     export_shape: TaggedShape, input_scales: Multiscales, input_key: str
 ) -> Multiscales:
     """We assume people don't generally want to upscale lower-resolution segmentations to raw scale."""
     # Since Multiscales is ordered largest-to-smallest, simply drop matching scales before input_key.
     all_matching_scales = _match_target_scales_to_input(export_shape, input_scales, input_key)
-    assert input_key in all_matching_scales
+    assert input_key in all_matching_scales, "generated scales don't include source scale"
     start = list(all_matching_scales.keys()).index(input_key)
     keep_scales = list(all_matching_scales.keys())[start:]
     return ODict((k, all_matching_scales[k]) for k in keep_scales)
@@ -72,7 +80,9 @@ def match_target_scales_to_input_excluding_upscales(
 
 def _match_target_scales_to_input(export_shape: TaggedShape, input_scales: Multiscales, input_key: str) -> Multiscales:
     def _eq_shape_permissive(test: TaggedShape, ref: TaggedShape) -> bool:
-        """Check if two shapes are equal, but allow reference shape to be missing axes, and ignore channel."""
+        """
+        Check if two shapes are equal. Ignore channel and allow `test` to have additional axes (but no dropped axes).
+        """
         return all(a not in ref or a == "c" or test[a] == ref[a] for a in test.keys())
 
     source_scale_shape = input_scales[input_key]
@@ -84,14 +94,14 @@ def _match_target_scales_to_input(export_shape: TaggedShape, input_scales: Multi
         # Get source multiscale's scaling factors relative to the (uncropped) input shape and compute cropped scale
         # shapes from that.
         input_scalings = _multiscales_to_scalings(input_scales, source_scale_shape, export_shape.keys())
-        target_shapes = []
+        target_scales_items = []
         for scale_key, scale_factors in input_scalings.items():
-            scaled_shape = ODict([(a, int(size / scale_factors[a])) for a, size in export_shape.items()])
+            scaled_shape = ODict([(a, _rescale_size(size, scale_factors[a])) for a, size in export_shape.items()])
             spatials = [a for a in SPATIAL_AXES if a in scaled_shape]
-            if all(scaled_shape[a] <= 1 for a in spatials):
-                break
-            target_shapes.append(scaled_shape)
-        target_scales = ODict(zip(input_scales.keys(), target_shapes))
+            if all(scaled_shape[a] <= 1 for a in spatials) and scale_key != input_key:
+                break  # Exclude scales that would be just 1px, but make sure the source scale itself is included
+            target_scales_items.append((scale_key, scaled_shape))
+        target_scales = ODict(target_scales_items)
 
     scales_items = []
     for scale_key, target_shape in target_scales.items():
@@ -118,7 +128,7 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Multis
         scaled_shape = []
         for axis, size in unscaled.items():
             if axis in SPATIAL_AXES:
-                scaled_shape.append(max(int(size // scale_factor), 1))
+                scaled_shape.append(_rescale_size(size, scale_factor))
             else:
                 scaled_shape.append(size)
         scaled_shape_tagged = ODict(zip(OME_ZARR_AXES, scaled_shape))

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -656,21 +656,37 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
                 ]
             ),
         ),
-        (  # Export is cropped so tiny that matching downscales would be degenerate
-            tagged_shape("zyxc", (10, 7, 5, 3)),
+        (  # Export is cropped tiny (matching all downscales would lead to 0 shapes) + drops an axis
+            tagged_shape("zyxc", (19, 7, 1, 3)),
             OrderedDict(
                 [
                     ("0", tagged_shape("czyx", (2, 225, 225, 225))),
                     ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
                     ("2", tagged_shape("czyx", (2, 25, 25, 25))),
                     ("3", tagged_shape("czyx", (2, 8, 8, 8))),
+                    ("4", tagged_shape("czyx", (2, 2, 2, 2))),
                 ]
             ),
             OrderedDict(
                 [
-                    ("source_scale", tagged_shape("tczyx", (1, 3, 10, 7, 5))),
-                    ("2", tagged_shape("tczyx", (1, 3, 3, 2, 1))),  # Include even if one axis is singleton
-                    # "3" excluded because all axes become singleton (or 0 in case of x)
+                    ("source_scale", tagged_shape("tczyx", (1, 3, 19, 7, 1))),
+                    ("2", tagged_shape("tczyx", (1, 3, 6, 2, 1))),
+                    ("3", tagged_shape("tczyx", (1, 3, 2, 1, 1))),
+                ]
+            ),
+        ),
+        (  # Export reduces to 1px
+            tagged_shape("zyxc", (1, 1, 1, 2)),
+            OrderedDict(
+                [
+                    ("0", tagged_shape("czyx", (2, 225, 225, 225))),
+                    ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
+                    ("2", tagged_shape("czyx", (2, 25, 25, 25))),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("source_scale", tagged_shape("tczyx", (1, 2, 1, 1, 1))),
                 ]
             ),
         ),


### PR DESCRIPTION
Export dialog fixes:

* Base the export off the currently selected lane rather than the last
* Remove the pre-cropping of the dialog's "model operator" so that the export shape preview can be correct when there are smaller lanes than the one the dialog is based on. The bounds for the subregion widgets are now passed explicitly to the dialog (which was previously using the model op's cropped shape to obtain the bounds).
* Also hopefully finally got the scale matching right >.<
<img width="290" height="112" alt="image" src="https://github.com/user-attachments/assets/05a548ae-1591-4ac5-be6e-7f334a56a325" />

Fixes #3064
