### PR TITLE
Carving: Fix loading objects

### DIFF
--- a/ilastik/workflows/carving/opCarving.py
+++ b/ilastik/workflows/carving/opCarving.py
@@ -388,8 +388,8 @@ class OpCarving(Operator):
             logger.info("Loading seeds....")
             z = numpy.zeros(bounding_box_shape, dtype=dtype)
             logger.info("Allocating seed array took {} seconds".format(timer.seconds()))
-            z[fgVoxels] = Labels.FOREGROUND
-            z[bgVoxels] = Labels.BACKGROUND
+            z[*fgVoxels] = Labels.FOREGROUND
+            z[*bgVoxels] = Labels.BACKGROUND
             self.WriteSeeds[(slice(0, 1),) + bounding_box_slicing + (slice(0, 1),)] = z[
                 numpy.newaxis, :, :, :, numpy.newaxis
             ]

--- a/tests/test_ilastik/test_workflows/testCarvingGui.py
+++ b/tests/test_ilastik/test_workflows/testCarvingGui.py
@@ -251,6 +251,10 @@ class TestCarvingGui(ShellGuiTestCaseBase):
             op_carving.saveObjectAs("Object 1")
             op_carving.deleteObject("<not saved yet>")
 
+            op_carving.loadObject("Object 1")
+            # Need to save back because loading removes it from the completed segments layer (which we assert below...)
+            op_carving.saveObjectAs("Object 1")
+
             # export the mesh:
             req = gui.currentGui()._exportMeshes(["Object 1"], [self.output_obj_file])
             req.wait()


### PR DESCRIPTION
The test change of course doesn't make sure the op loaded the _correct_ labels, but at least it makes sure the function can run...

Fixes #3069 