### PR TITLE
Remove tiktorch for ilastik-core tests

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -94,7 +94,6 @@ outputs:
         - pytest >4
         - pytest-qt
         - volumina
-        - tiktorch
 
       commands:
         - pytest -v

--- a/ilastik/applets/serverConfiguration/serverConfigApplet.py
+++ b/ilastik/applets/serverConfiguration/serverConfigApplet.py
@@ -19,6 +19,7 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 import logging
+from typing import TYPE_CHECKING
 
 from ilastik.applets.base.standardApplet import StandardApplet
 from .opServerConfig import OpServerConfig
@@ -26,11 +27,13 @@ from .serverConfigSerializer import ServerConfigSerializer
 
 logger = logging.getLogger(__name__)
 
-from lazyflow.operators import tiktorch
+
+if TYPE_CHECKING:
+    from lazyflow.operators import tiktorch
 
 
 class ServerConfigApplet(StandardApplet):
-    def __init__(self, workflow, *, connectionFactory: tiktorch.IConnectionFactory):
+    def __init__(self, workflow, *, connectionFactory: "tiktorch.IConnectionFactory"):
         self._topLevelOperator = OpServerConfig(parent=workflow)
         super().__init__("Server configuration", workflow)
         self._serializableItems = [ServerConfigSerializer("ServerConfiguration", operator=self._topLevelOperator)]
@@ -45,7 +48,7 @@ class ServerConfigApplet(StandardApplet):
         self.appletStateUpdateRequested()
 
     @property
-    def connectionFactory(self) -> tiktorch.IConnectionFactory:
+    def connectionFactory(self) -> "tiktorch.IConnectionFactory":
         return self._connectionFactory
 
     @property

--- a/ilastik/applets/serverConfiguration/serverConfigGui.py
+++ b/ilastik/applets/serverConfiguration/serverConfigGui.py
@@ -43,7 +43,6 @@ from .serverListWidget import ServerListWidget, ServerListModel
 from .configStorage import SERVER_CONFIG
 from . import types
 from ilastik import config
-import tiktorch
 
 
 class ServerConfigGui(QWidget):

--- a/tests/test_ilastik/test_applets/trainableDomainAdaptation/test_ConfigurableChannelSelector.py
+++ b/tests/test_ilastik/test_applets/trainableDomainAdaptation/test_ConfigurableChannelSelector.py
@@ -20,6 +20,8 @@
 ###############################################################################
 import pytest
 
+_ = pytest.importorskip("tiktorch", reason="These tests require tiktorch")
+
 from ilastik.applets.trainableDomainAdaptation.trainableDomainAdaptationGui import ConfigurableChannelSelector
 
 

--- a/tests/test_ilastik/test_utility/test_bioimageio_utils.py
+++ b/tests/test_ilastik/test_utility/test_bioimageio_utils.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 
 import pytest
+
+_ = pytest.importorskip("bioimageio", reason="These tests require bioimageio")
+
 from attr import dataclass
 from bioimageio.spec.model.v0_5 import (
     AxisId,

--- a/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localHeadless.py
+++ b/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localHeadless.py
@@ -6,6 +6,8 @@ import h5py
 import numpy
 import pytest
 
+_ = pytest.importorskip("tiktorch", reason="These tests require tiktorch")
+
 from ilastik import app
 from ilastik.workflows.neuralNetwork import LocalWorkflow
 

--- a/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
+++ b/tests/test_ilastik/test_workflows/test_neuralNetwork/test_localLauncher.py
@@ -2,6 +2,9 @@ import grpc
 import os
 import platform
 import pytest
+
+_ = pytest.importorskip("tiktorch", reason="These tests require tiktorch")
+
 from unittest import mock
 
 from ilastik.workflows.neuralNetwork._localLauncher import LocalServerLauncher

--- a/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
+++ b/tests/test_lazyflow/test_operators/test_tiktorch/test_classifier.py
@@ -1,5 +1,9 @@
 from unittest import mock
 
+import pytest
+
+_ = pytest.importorskip("tiktorch", reason="These tests require tiktorch")
+
 from bioimageio.core import AxisId
 from bioimageio.spec import ModelDescr, ValidationContext
 from bioimageio.spec.common import FileDescr
@@ -21,7 +25,6 @@ from bioimageio.spec.model.v0_5 import (
 )
 from lazyflow.operators.tiktorch.classifier import ModelSession
 
-import pytest
 from tiktorch.proto import utils_pb2
 
 


### PR DESCRIPTION
Some tests that would require tiktorch (or transitive bioimageio libraries), are disabled explicitly by importskips.

These tests failed on gitub ci in the "ilastik-core" configuration bc of pytorch-3dunet (direct dependency of tiktorch) stopped explicitly depending on pytorch -> so pytorch was missing from the env. As there are ci configurations that both include pytorch and tiktorch as a dependency, the tests skipped here will run there ("ilastik", "ilastik-gpu" on gh-actions).