### PR TITLE
Add requests to env

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -56,6 +56,8 @@ outputs:
         - pyqt 5.15.*
         # previous versions would set thread limits globally with side effects
         - python-elf >=0.4.8
+        # for neuroglancer precomputed chunks
+        - requests
         # s3fs allows zarr.storage.FSStore to read s3:// URIs
         - s3fs >=2022.8.2
         - scikit-image


### PR DESCRIPTION
Seems `requests` isn't pulled into ilastik-core anymore (but we need it for the precomputed chunks loader): https://github.com/ilastik/ilastik/actions/runs/18166140752

Probably a consequence of #3074, not sure why it's only surfacing a few days later