### PR TITLE
Fix conda CI

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -17,13 +17,14 @@ jobs:
           fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict
           miniforge-version: latest
           conda-solver: libmamba
           conda-remove-defaults: "true"
+      - name: update conda
+        run: conda update -n base -c conda-forge conda conda-libmamba-solver
       - name: install xvfb/deps
         run: |
           sudo apt-get update
@@ -85,7 +86,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         if: matrix.os != 'windows-latest'
         with:
-          auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict
@@ -98,7 +98,6 @@ jobs:
         # ref: https://github.com/conda-incubator/setup-miniconda/issues/380
         if: matrix.os == 'windows-latest'
         with:
-          auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict
@@ -106,6 +105,8 @@ jobs:
           conda-solver: libmamba
           conda-remove-defaults: "true"
           run-post: false
+      - name: update conda
+        run: conda update -n base -c conda-forge conda conda-libmamba-solver
       - name: install xvfb/deps
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,13 @@ jobs:
           fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
           auto-activate-base: true
           activate-environment: ""
           miniforge-version: latest
           conda-solver: libmamba
           conda-remove-defaults: "true"
+      - name: update conda
+        run: conda update -n base -c conda-forge conda conda-libmamba-solver
       - name: install build dependencies
         run: |
           conda install -n base -c conda-forge conda-build setuptools_scm anaconda-client -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
         }
   - cmd: set PATH=%MINIFORGE%;%MINIFORGE%\Scripts;%MINIFORGE%\Library\bin;%PATH%
   - cmd: conda config --set always_yes yes --set changeps1 no --set channel_priority strict
-  - cmd: conda update -n base -c conda-forge conda
+  - cmd: conda update -n base -c conda-forge conda conda-libmamba-solver
   - cmd: conda install -n base -c conda-forge setuptools_scm
   - |
     conda env create --name %ENV_NAME% --file dev\environment-dev.yml


### PR DESCRIPTION
Atm it seems both miniforge and setup-miniconda ship a slightly-outdated `conda` 25.3.1 and a slightly-outdated `conda-libmamba-solver` 25.3.0 (I guess setup-miniconda has the same because it just installs miniforge...).

When the workflows update `conda` to 25.9.0, this removes a "Spinner" class that `conda-libmamba-solver` 25.3.0 depends on (cf. https://github.com/conda/conda/releases/tag/25.9.0: `Remove class conda.common.io.Spinner. Use conda.reporters.get_spinner instead. (https://github.com/conda/conda/pull/15221)`). This leads to:
```
>>> conda install -n base -c conda-forge setuptools_scm
Error while loading conda entry point: conda-libmamba-solver (cannot import name 'Spinner' from 'conda.common.io' (C:\Miniforge\Lib\site-packages\conda\common\io.py))
CondaValueError: You have chosen a non-default solver backend (libmamba) but it was not recognized. Choose one of: classi
```
(on appveyor https://ci.appveyor.com/project/ilastik/ilastik/builds/52841385 and github actions https://github.com/ilastik/ilastik/actions/runs/18186833710/job/51772778076)
reproducible locally by downloading & installing miniforge3, followed by `conda update -n base -c conda-forge conda` and then erroring on any further conda commands.

Updating `conda-libmamba-solver` to 25.4.0 along with conda fixes this.

We should be able to revert this when the versions shipped with miniforge / setup-miniconda are newer.