### PR TITLE
Add layer priority

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -72,7 +72,7 @@ outputs:
         - tiktorch 25.4.0
         # TODO: investigate pytorch-3dunet dependency changes 1.9.3 and up #3079
         - pytorch-3dunet 1.9.2
-        - volumina >=1.3.16
+        - volumina >=1.3.20
         # TODO: sphericaltexture 0.1.1 currently times out in the tests
         - sphericaltexture 0.0.4
         # pyshtools 4.10 conflicts with pytorch via openmp on windows

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -19,15 +19,12 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 # Built-in
-from builtins import range
-from builtins import filter
 from dataclasses import dataclass
 import os
 import re
 import logging
 from functools import partial
-from typing import Any, Optional, Union
-import warnings
+from typing import Optional, Union
 
 # Third-party
 import numpy
@@ -49,7 +46,7 @@ from lazyflow.slot import InputSlot, OutputSlot
 # ilastik
 from ilastik.utility import bind, log_exception
 from ilastik.utility.gui import ThunkEventHandler, is_qt_dark_mode, threadRouted
-from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui
+from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui, LayerPriority
 
 from ilastik.applets.labeling.labelingImport import import_labeling_layer
 
@@ -993,7 +990,9 @@ class LabelingGui(LayerViewerGui):
             # Add the layer to draw the labels, but don't add any labels
             labelsrc = LazyflowSinkSource(self._labelingSlots.labelOutput, self._labelingSlots.labelInput)
 
-            labellayer = ColortableLayer(labelsrc, colorTable=self._colorTable16, direct=direct)
+            labellayer = ColortableLayer(
+                labelsrc, colorTable=self._colorTable16, direct=direct, priority=LayerPriority.LABELS
+            )
             labellayer.name = "Labels"
             labellayer.ref_object = None
 
@@ -1039,7 +1038,7 @@ class LabelingGui(LayerViewerGui):
 
         # Raw Input Layer
         if self._rawInputSlot is not None and self._rawInputSlot.ready():
-            layer = self.createStandardLayerFromSlot(self._rawInputSlot, name="Raw Input")
+            layer = self.createStandardLayerFromSlot(self._rawInputSlot, name="Raw Input", priority=LayerPriority.RAW)
             layers.append(layer)
 
             if isinstance(layer, GrayscaleLayer):


### PR DESCRIPTION
This can be used, to e.g. favor the raw data layer.

While this does not change the performance of the full render of the full screen, for the user there might still be a benefit in seeing the raw data context first.

Before (current main branch):

https://github.com/user-attachments/assets/3fc7e4e2-04af-41e9-a57c-12087d59ec68


This PR:

https://github.com/user-attachments/assets/0edcd4f7-047c-4716-a445-13344216f7a2






Todos:
* [x] check which other workflows can benefit. Apparently modifying `LayerViewerGui` and `LabelingGui` goes a long way.
* [x] Needs https://github.com/ilastik/volumina/pull/338, tests will fail until then --> `volumina>=1.3.20`
