### PR TITLE
Update readme installation from conda

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ ilastik is also available as a conda package on our `ilastik-forge` conda channe
 You can install it from the commandline using [conda][conda]:
 
 ```bash
-conda create -n ilastik --override-channels -c pytorch -c ilastik-forge -c conda-forge ilastik
+ conda create -n ilastik --override-channels -c ilastik-forge/label/patched-2 -c conda-forge -c ilastik-forge ilastik
 
 # activate ilastik environment and start ilastik
 conda activate ilastik


### PR DESCRIPTION
Minor commit without code changes so that we can have the `1.4.2b1` tag on a different commit than `1.4.2a3`. setuptools_scm picked up the wrong tag in https://github.com/ilastik/ilastik/actions/runs/18586685117/job/52995434007, I'm guessing due to alphabetical sort. There are probably workaround for this, but it's simpler just to add another commit and remove the b1 tag from the other one.

(Updating the readme instructions because the command as shown failed to solve the env when I tried it)