### PR TITLE
Batch GUI: Satisfy AppletGuiInterface

### DIFF
--- a/ilastik/applets/batchProcessing/batchProcessingGui.py
+++ b/ilastik/applets/batchProcessing/batchProcessingGui.py
@@ -144,6 +144,9 @@ class BatchProcessingGui(QTabWidget):
     def viewerControlWidget(self):
         return QWidget(parent=self)  # No viewer, so no viewer controls.
 
+    def secondaryControlsWidget(self):
+        return None
+
     # This applet doesn't care what image is selected in the interactive flow
     def setImageIndex(self, index):
         pass

--- a/ilastik/applets/serverConfiguration/serverConfigGui.py
+++ b/ilastik/applets/serverConfiguration/serverConfigGui.py
@@ -60,6 +60,9 @@ class ServerConfigGui(QWidget):
     def viewerControlWidget(self):
         return None
 
+    def secondaryControlsWidget(self):
+        return None
+
     def getServerIdFromOp(self):
         if self.topLevelOp.ServerId.ready():
             return self.topLevelOp.ServerId.value


### PR DESCRIPTION
Quite small but critical fix after 3e3b5ef1 - forgot to add the placeholder function in BatchProcessingGui and this now crashes the gui thread when the batch applet is opened :) I've checked all gui classes again and this should be the only omission.


```pytb
ERROR 2025-10-27 14:25:33,879 excepthooks 10888 14568 Unhandled exception in thread: 'MainThread'
ERROR 2025-10-27 14:25:33,883 excepthooks 10888 14568 Traceback (most recent call last):
  File "\ilastik\ilastik\shell\gui\ilastikShell.py", line 1361, in handleAppletBarItemExpanded
    self.setSelectedAppletDrawer(modelIndex)
  File "\ilastik\ilastik\shell\gui\ilastikShell.py", line 1382, in setSelectedAppletDrawer
    self.showSecondaryControls(applet_index)
  File "\ilastik\ilastik\shell\gui\ilastikShell.py", line 1415, in showSecondaryControls
    secondaryControlsWidget = self._applets[applet_index].getMultiLaneGui().secondaryControlsWidget()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'BatchProcessingGui' object has no attribute 'secondaryControlsWidget'
```