### PR TITLE
Fix OpObjectExtraction setup

### DIFF
--- a/lazyflow/operators/opLabelBase.py
+++ b/lazyflow/operators/opLabelBase.py
@@ -28,6 +28,8 @@ class OpLabelBase(Operator):
     Input = InputSlot()
     """Volume to (re)label, up to 5D"""
 
+    SerializationInput = InputSlot(optional=True)
+
     CachedOutput = OutputSlot()
     """Cached label image - internally always whole time slices are stored
     Axistags and shape are the same as on the Input, dtype is an integer

--- a/lazyflow/operators/opLabelVolume.py
+++ b/lazyflow/operators/opLabelVolume.py
@@ -127,6 +127,7 @@ class OpLabelVolume(OpLabelBase):
             self._opLabel = self._labelOps[method](parent=self)
             if method == "vigra":
                 self._opLabel.BypassModeEnabled.connect(self.BypassModeEnabled)
+                self._opLabel.SerializationInput.connect(self.SerializationInput)
 
         if input_dtype == np.uint16:
             self._opDtypeConvert.Function.setValue(lambda x: x.astype("uint32"))
@@ -202,6 +203,8 @@ class OpLabelingABC(with_metaclass(ABCMeta, Operator)):
     # Bypass cache (for headless mode)
     BypassModeEnabled = InputSlot(value=False)
 
+    SerializationInput = InputSlot(optional=True)
+
     Output = OutputSlot()
     CachedOutput = OutputSlot()
 
@@ -222,6 +225,9 @@ class OpLabelingABC(with_metaclass(ABCMeta, Operator)):
         self._cache.name = "OpLabelVolume.OutputCache"
         self._cache.BypassModeEnabled.connect(self.BypassModeEnabled)
         self._cache.Input.connect(self.Output)
+        if self.SerializationInput.ready():
+            # Setup LabelImageCacheInput for the serialization of the compressed cache
+            self._cache.Input.connect(self.SerializationInput)
         self.CachedOutput.connect(self._cache.Output)
         self.CleanBlocks.connect(self._cache.CleanBlocks)
 

--- a/lazyflow/operators/opRelabelConsecutive.py
+++ b/lazyflow/operators/opRelabelConsecutive.py
@@ -65,7 +65,6 @@ class OpRelabelConsecutive(OpLabelBase):
 
     CompressionEnabled = InputSlot(value=False)
 
-    SerializationInput = InputSlot(optional=True)
     SerializationOutput = OutputSlot()
 
     supportedDtypes = [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]


### PR DESCRIPTION
Since it looks like I won't be implementing cross-role metadata porting in `OpObjectExtraction` anymore, I figured we might still want this fix independently.

This fixes a bug where `OpObjectExtraction` never called `setupOutputs` because `LabelImageCacheInput` is never ready. The code looks like it's supposed to be used when saving/loading Tracking projects, but even there it doesn't seem this input is serialized. If it was, it would be broken, given that `setupOutputs` contains two errors :)

Now the setup is actually called, this might end up modifying the block shape in the cache, but it looks like a sensible modification to make...