### PR TITLE
Unify pixel size across roles in data selection

### DIFF
--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -1084,7 +1084,7 @@ class OpDataSelectionGroup(Operator):
         if not roles_with_pixel_size:
             return
         eq_all_with_pixel_size = all(
-            self.eq_pixel_size_spatial(slot1, slot2)
+            self.eq_resolution_and_units_xyzt(slot1, slot2)
             for slot1, slot2 in itertools.combinations(roles_with_pixel_size, 2)
         )
         if eq_all_with_pixel_size:
@@ -1124,12 +1124,12 @@ class OpDataSelectionGroup(Operator):
                 ax = target_tag.key
                 if ax in source.meta.axistags:
                     target_tag.resolution = source.meta.axistags[ax].resolution
-            if "axis_units" in source.meta:
+            if "axis_units" in source.meta and source.meta.axis_units:
                 target.meta.axis_units = source.meta.axis_units
             target.meta[OpDataSelectionGroup.META_COPY_KEY] = source_role
 
     @staticmethod
-    def eq_pixel_size_spatial(slot1: Slot, slot2: Slot):
+    def eq_resolution_and_units_xyzt(slot1: Slot, slot2: Slot):
         eq_res = OpDataSelectionGroup._eq_resolutions(slot1, slot2)
         eq_units = OpDataSelectionGroup._eq_units(slot1, slot2)
         return eq_res and eq_units


### PR DESCRIPTION
This unifies pixel size metadata across roles in data selection.

* One role has metadata, others don't -> copy
* One role has metadata, other has different meta -> no copying (also not to roles that had no meta at all) + warning

<img width="275" height="220" alt="image" src="https://github.com/user-attachments/assets/5dec4c57-d8cc-4672-ad88-10d5d7b90810" />

I provoked this in oc-from-segmentation using the Helmstaedter dataset (which has pixel size), and a segmentation whose pixel size I borked using FIJI :)

The copying happens in the backend, so copied metadata won't show up in the input data table. There the user will continue to see the metadata the file may or may not have contained. 

All layer exports in all workflows will now contain uniform pixel size - unless the user received the warning and ignored it.

I kept all the tests in `test_pixel_sizes.py` since this way the test file keeps an overview where we have pixel size features in the code base. Could of course move them to `testDataSelectionGui` or `testDataSelectionApplet`.

Fixes #3101 

## Checklist
- [X] Format code and imports.
- [X] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io)  - don't think this needs docs
- [X] Reference relevant issues and other pull requests.
- [X] Rebase commits into a logical sequence.
