### PR TITLE
Fix crash in Pixel Classification mask display

### DIFF
--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -654,7 +654,6 @@ class PixelClassificationGui(LabelingGui):
         # Show the mask over everything except labels
         maskSlot = self.topLevelOperatorView.PredictionMasks
         if maskSlot.ready():
-            print("!!! DEBUG: I AM RUNNING THE NEW CODE !!!")
             op_cast_mask = OpPixelOperator(parent=maskSlot.operator)
             op_cast_mask.Input.connect(maskSlot)
             op_cast_mask.Function.setValue(lambda x: x.astype(numpy.uint32))

--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -57,6 +57,7 @@ from lazyflow.roi import slicing_to_string
 from lazyflow.operators.opReorderAxes import OpReorderAxes
 from lazyflow.operators.ioOperators import OpInputDataReader
 from lazyflow.operators import OpFeatureMatrixCache
+from lazyflow.operators.generic import OpPixelOperator
 
 # ilastik
 from ilastik.config import cfg as ilastik_config
@@ -653,7 +654,12 @@ class PixelClassificationGui(LabelingGui):
         # Show the mask over everything except labels
         maskSlot = self.topLevelOperatorView.PredictionMasks
         if maskSlot.ready():
-            maskLayer = self._create_binary_mask_layer_from_slot(maskSlot)
+            print("!!! DEBUG: I AM RUNNING THE NEW CODE !!!")
+            op_cast_mask = OpPixelOperator(parent=maskSlot.operator)
+            op_cast_mask.Input.connect(maskSlot)
+            op_cast_mask.Function.setValue(lambda x: x.astype(numpy.uint32))
+            maskLayer = self._create_binary_mask_layer_from_slot(op_cast_mask.Output)
+
             maskLayer.name = "Mask"
             maskLayer.visible = True
             maskLayer.opacity = 1.0


### PR DESCRIPTION
Fixes #3104 

Fixed the crash by converting the mask data from floats to integers (`uint32`) before the viewer displays it. This ensures the viewer gets the correct data type it expects.

## Checklist

- [x] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
