### PR TITLE
Fix Github CI for linux-gpu: Pin pytorch/libtorch version in Github CI via conda recipe

### DIFF
--- a/.github/workflows/core-conda-bld.yml
+++ b/.github/workflows/core-conda-bld.yml
@@ -79,6 +79,20 @@ jobs:
         if: |
           matrix.os == 'windows-latest' &&
           matrix.ilastik_variant == 'ilastik-gpu'
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        # Need to free up space for the GPU job to finish - pytorch/libtorch got quite big from 2.8.0
+        if: |
+          matrix.os == 'ubuntu-latest' &&
+          matrix.ilastik_variant == 'ilastik-gpu'
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
~~need to pin pytorch/libtorch version for Github CI - newer versions are almost twice as large (compressed) and make our tests run out of space (and sometimes running out of space leads to segfaults).~~

thx to @FynnBe's comments this can be mitigated by removing some junk from the image.

@FynnBe: did you see problems with jobs failing to disk space with pytorch 2.8.0, 2.9.0 (with cuda)?