### PR TITLE
Set CUDA during deploy process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   package:
     runs-on: ubuntu-latest
     environment: conda-deploy
+    env:
+      CONDA_OVERRIDE_CUDA: "12.6"
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Fixes deployment pipeline for now. Needed to override CUDA version to force installation on non-gpu machine (for tests)