### PR TITLE
Fix Python 3 incompatibility: replace basestring with str

### DIFF
--- a/ilastik/utility/commands.py
+++ b/ilastik/utility/commands.py
@@ -36,7 +36,7 @@ def setViewerPos(shell, data):
 
 
 def connectToServer(shell, data):
-    if "port" in data and "name" in data and isinstance(data["port"], int) and isinstance(data["name"], basestring):
+    if "port" in data and "name" in data and isinstance(data["port"], int) and isinstance(data["name"], str):
         if "host" in data:
             host = data["host"]
         else:

--- a/ilastik/utility/simple_predict.py
+++ b/ilastik/utility/simple_predict.py
@@ -40,7 +40,7 @@ def main():
 def load_and_predict(
     input_data_or_path, classifier_filepath, feature_list_json_path, output_path=None, compute_blockwise=False
 ):
-    assert output_path is None or isinstance(output_path, basestring)
+    assert output_path is None or isinstance(output_path, str)
 
     # Load
     input_data = load_data(input_data_or_path)
@@ -378,7 +378,7 @@ def load_data(input_data):
     Read from .h5 or .npy, drop channel axis (if any), and convert to float32.
     """
     # Load input data
-    if isinstance(input_data, basestring):
+    if isinstance(input_data, str):
         logger.info("Loading {}".format(input_data))
         input_path = input_data
         if ".h5" in input_path:


### PR DESCRIPTION
<!-- Thank you very much for opening a PR!

     Please summarize your your pull request in 1-2 sentences. -->
basestring was removed in Python 3, which can cause runtime errors. Fixed Python 3 incompatibility by replacing deprecated basestring checks with str.

Supporting Docs: [ What’s New In Python 3.0 ](https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit:~:text=The%20builtin%20basestring%20abstract%20type%20was%20removed.%20Use%20str%20instead.%20The%20str%20and%20bytes%20types%20don%E2%80%99t%20have%20functionality%20enough%20in%20common%20to%20warrant%20a%20shared%20base%20class.%20The%202to3%20tool%20(see%20below)%20replaces%20every%20occurrence%20of%20basestring%20with%20str.)

As per this document: 

> The builtin basestring abstract type was removed. Use str instead. The str and bytes types don’t have functionality enough in common to warrant a shared base class. The 2to3 tool (see below) replaces every occurrence of basestring with str.

## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
