### PR TITLE
avoid overwriting input .h5 by defaulting feature table filename to {nickname}_table and preserving suffix on format change

### DIFF
--- a/ilastik/widgets/exportObjectInfoDialog.py
+++ b/ilastik/widgets/exportObjectInfoDialog.py
@@ -34,7 +34,11 @@ RAW_LAYER_SIZE_LIMIT = 1000000
 ALLOWED_EXTENSIONS = ["hdf5", "hd5", "h5", "csv"]
 DEFAULT_REQUIRED_FEATURES = ["Count", "Coord<Minimum>", "Coord<Maximum>", "RegionCenter"]
 DIALOG_FILTERS = {"h5": "HDF 5 (*.h5 *.hd5 *.hdf5)", "csv": "CSV (*.csv)", "any": "Any (*.*)"}
-DEFAULT_EXPORT_PATH = "{dataset_dir}/{nickname}.csv"
+# Use a suffix for feature table defaults to avoid accidentally overwriting
+# an input HDF5 file that has the same base name as the dataset nickname.
+# This will become {dataset_dir}/{nickname}_table.csv by default and will
+# correctly switch to .h5 when the user selects HDF5 in the dialog.
+DEFAULT_EXPORT_PATH = "{dataset_dir}/{nickname}_table.csv"
 
 
 class ExportObjectInfoDialog(QDialog):

--- a/ilastik/widgets/exportObjectInfoDialog.py
+++ b/ilastik/widgets/exportObjectInfoDialog.py
@@ -317,7 +317,16 @@ class ExportObjectInfoDialog(QDialog):
     def file_format_changed(self, index):
         path = str(self.ui.exportPath.text())
         match = path.rsplit(".", 1)
-        path = "%s.%s" % (match[0], FILE_TYPES[index])
+        base = match[0]
+
+        # If the path contains the {nickname} placeholder but does not
+        # include the _table suffix, prefer the safer {nickname}_table
+        # form so switching formats won't accidentally produce
+        # {nickname}.h5 which could overwrite the input file.
+        if "{nickname}" in base and "_table" not in base:
+            base = base.replace("{nickname}", "{nickname}_table", 1)
+
+        path = "%s.%s" % (base, FILE_TYPES[index])
         self.ui.exportPath.setText(path)
 
         for widget in (self.ui.includeRaw, self.ui.marginLabel, self.ui.addMargin):

--- a/tests/test_ilastik/test_applets/layerViewer/test_mask_layer_dtype.py
+++ b/tests/test_ilastik/test_applets/layerViewer/test_mask_layer_dtype.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+import ilastik.applets.layerViewer.layerViewerGui as lvmod
+
+
+class DummyMeta:
+    def __init__(self, dtype, normalizeDisplay=False, drange=None):
+        self.dtype = dtype
+        self.normalizeDisplay = normalizeDisplay
+        self.drange = drange
+
+
+class DummySlot:
+    def __init__(self, dtype):
+        self.meta = DummyMeta(dtype=dtype, normalizeDisplay=False, drange=None)
+        self.name = "dummy"
+
+
+def test_float_mask_uses_grayscale(monkeypatch):
+    created = {}
+
+    # Monkeypatch createDataSource to return a sentinel
+    monkeypatch.setattr(lvmod, "createDataSource", lambda slot: "SRC")
+
+    # Dummy GrayscaleLayer that records its args
+    class DummyGray:
+        def __init__(self, src, window_leveling=True, priority=None):
+            created['type'] = 'gray'
+            created['src'] = src
+            created['window_leveling'] = window_leveling
+            created['priority'] = priority
+
+        def set_normalize(self, channel, val):
+            created['normalize'] = (channel, val)
+
+    # Dummy ColortableLayer that records if it was created
+    class DummyCT:
+        def __init__(self, src, colortable, priority=None):
+            created['type'] = 'colortable'
+            created['src'] = src
+            created['colortable_len'] = len(colortable)
+            created['priority'] = priority
+
+    monkeypatch.setattr(lvmod, 'GrayscaleLayer', DummyGray)
+    monkeypatch.setattr(lvmod, 'ColortableLayer', DummyCT)
+
+    slot = DummySlot(np.dtype('float32'))
+
+    layer = lvmod.LayerViewerGui._create_binary_mask_layer_from_slot(slot)
+
+    assert created.get('type') == 'gray', f"expected grayscale layer for float dtype, got {created}"
+    assert created.get('src') == 'SRC'
+    # normalization default for floats should be set to (0.0, 1.0) unless meta specifies otherwise
+    assert created.get('normalize') == (0, (0.0, 1.0))
+
+
+def test_integer_mask_uses_colortable(monkeypatch):
+    created = {}
+    monkeypatch.setattr(lvmod, "createDataSource", lambda slot: "SRC")
+
+    class DummyGray:
+        def __init__(self, src, window_leveling=True, priority=None):
+            created['type'] = 'gray'
+
+    class DummyCT:
+        def __init__(self, src, colortable, priority=None):
+            created['type'] = 'colortable'
+            created['src'] = src
+            created['colortable_len'] = len(colortable)
+
+    monkeypatch.setattr(lvmod, 'GrayscaleLayer', DummyGray)
+    monkeypatch.setattr(lvmod, 'ColortableLayer', DummyCT)
+
+    slot = DummySlot(np.dtype('uint8'))
+    layer = lvmod.LayerViewerGui._create_binary_mask_layer_from_slot(slot)
+
+    assert created.get('type') == 'colortable', f"expected colortable layer for integer dtype, got {created}"
+    assert created.get('src') == 'SRC'
+    assert created.get('colortable_len') == 256


### PR DESCRIPTION
Summary When the dataset nickname equals an input HDF5 filename (e.g. test_data.h5), the old default export path for feature tables was {dataset_dir}/{nickname}.csv. If the user confirmed that and later switched export format to HDF5 (or accepted defaults), the default became {dataset_dir}/{nickname}.h5 and could overwrite the original input file. This change prevents that data-loss scenario.

What I changed

Default export path now uses {dataset_dir}/{nickname}_table.csv instead of {dataset_dir}/{nickname}.csv.
File: [exportObjectInfoDialog.py](vscode-file://vscode-app/private/var/folders/57/xkrbhh5x4sd2nd524g0l77tc0000gn/T/AppTranslocation/7528DDE9-257A-4FA4-9360-A9DAD0F50FA1/d/Visual%20Studio%20Code-11.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
When the export format is changed in the dialog, if the current path contains the {nickname} placeholder and does not contain [_table](vscode-file://vscode-app/private/var/folders/57/xkrbhh5x4sd2nd524g0l77tc0000gn/T/AppTranslocation/7528DDE9-257A-4FA4-9360-A9DAD0F50FA1/d/Visual%20Studio%20Code-11.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), the code replaces {nickname} with {nickname}_table before swapping the extension. This ensures format switches yield {nickname}_table.h5 instead of {nickname}.h5.
Why this fixes the bug

The export filename no longer defaults to a plain {nickname} + .h5, so the export dialog will not suggest an output filename that is identical to the input .h5 file.
The change is conservative: it only adjusts placeholder-based defaults and user-chosen filenames remain untouched (so we don't silently rewrite intentionally chosen names).
How to test

Manual UI:
Open Object Classification → Export → Configure Feature Table Export.
Confirm default path is .../{nickname}_table.csv.
Switch format to HDF5; confirm path becomes .../{nickname}_table.h5.
Optionally run an export and confirm input file is not overwritten.
CI: Run unit tests / full test-suite (no behavior changes expected elsewhere).
