### PR TITLE
Add keyboard shortcut to toggle probability layers in pixel classification

### DIFF
--- a/ilastik/applets/pixelClassification/pixelClassificationGui.py
+++ b/ilastik/applets/pixelClassification/pixelClassificationGui.py
@@ -593,6 +593,18 @@ class PixelClassificationGui(LabelingGui):
         )
 
         mgr.register(
+            "b",
+            ActionInfo(
+                shortcutGroupName,
+                "Toggle Probabilities",
+                "Toggle Probabilities Layer Visibility",
+                self._viewerControlUi.checkShowPredictions.click,
+                self._viewerControlUi.checkShowPredictions,
+                self._viewerControlUi.checkShowPredictions,
+            ),
+        )
+
+        mgr.register(
             "s",
             ActionInfo(
                 shortcutGroupName,


### PR DESCRIPTION
**Fixes #2107** 

Added a new keyboard shortcut (b) in pixel classification to toggle probability layer visibility, matching the existing prediction toggle. This lets users quickly cycle raw, uncertainty, and probability views without clicking multiple per-channel toggles.
