### PR TITLE
Add PR guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,23 @@
 <!-- Thank you very much for opening a PR!
 
-     Please summarize your your pull request in 1-2 sentences. -->
+     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)
+
+     Your PR description should include what *behavior* you changed, and how this improves ilastik.
+     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
+     Don't describe what *code* you changed - we can see your code changes.
+     Do explain *why* you chose to go about it as you did.-->
 
 ## Checklist
 
-<!-- Checking off an item means that an action has been successfully completed.
-     Some items might not be applicable - you can remove those if you decide
-     that this is the case.
+<!-- Check off the items in this list to show your PR meets our guidelines.
+     Some items might not be applicable.
+     Leave these unchecked and add a few words to explain why.
 -->
 
 - [ ] Format code and imports.
 - [ ] Add docstrings and comments.
 - [ ] Add tests.
-- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
 - [ ] Reference relevant issues and other pull requests.
 - [ ] Rebase commits into a logical sequence.
+- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
+- [ ] Add screenshots / screen recordings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ Therefore, *for some changes you need to repeat the instructions twice in the co
 
    - If your changes require feedback, create a draft pull request (select the type from the dropdown list on the green button).
 
+1. Our CI pipeline will run the test suite on your code changes. If it turns up red, click on the respective CI step to find out what went wrong. The interface can be a bit overwhelming at first, so feel free to ask for clarifications if you're not sure what a failure means.
+
 1. Discuss your work with the other people, and wait for the approval from maintainers.
 
 1. After your pull request has been merged, remove your local branches:
@@ -138,6 +140,20 @@ Therefore, *for some changes you need to repeat the instructions twice in the co
    ```
    git push --delete origin your-branch-name-here
    ```
+
+## Pull request guidelines
+
+When you start a PR, the description will show a template with a checklist.
+Check your PR against these steps.
+If you notice that any of them require some more changes to your code, proceed as you feel more comfortable:
+You can either
+- hold off on opening the PR until it is ready, or
+- choose "Create draft pull request", make the changes, check the boxes in the description, and then mark the PR as ready for review.
+
+Your PR description should include what *behavior* you changed, and how this improves ilastik.
+If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
+Don't describe what *code* you changed - we can see your code changes.
+Do explain *why* you chose to go about it as you did.
 
 ## Coding style
 


### PR DESCRIPTION
The motivation for this was to provide something we can point to when we receive PRs with similar issues as recently (unhelpful descriptions, lack of evidence that ilastik was ever actually run during development)