### PR TITLE
Handle input unreadyness only if relevant for operator output

### DIFF
--- a/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
+++ b/ilastik/workflows/pixelClassification/pixelClassificationWorkflow.py
@@ -235,7 +235,7 @@ class PixelClassificationWorkflow(Workflow):
         """
         # Restore classifier we saved in prepareForNewLane() (if any)
         if self.stored_classifier:
-            self.pcApplet.topLevelOperator.classifier_cache.forceValue(self.stored_classifier)
+            self.pcApplet.topLevelOperator.classifier_cache.forceValue(self.stored_classifier, set_dirty=False)
             # Release reference
             self.stored_classifier = None
 


### PR DESCRIPTION
Some operators produce an Output drawing from only some of the subslots in one of the multi-level inputs. Disconnecting one of the subslots that are not used does not unready these ops. With 18dfbe71d584a539cf86ca78924575c3b52ea870 unreadyness of subslots would propagate to the encompassing slot - which for some operators is correct. E.g. anything that draws from all subslots to produce an output such as OpMultiArrayStacker.

Other Operators, however would too eagerly throw out their results, such as classifier operators. E.g. in batch processing subslots are added and removed, without any influence on the classifier. Removal signals unreadyness - so for such operators it needs to be tracked which slot indices currently contribute to the output.

In `handleInputBecameUnready` we can now check if the slot contributed to the output (via `self._touched_slots`).

I also unified the `handle_new_lane` implementations to all go for indices only - this allows flexibility across slots.

Fixes #3134 #2468
Also fixes retraining in Pixel Classification before processing the second batch lane - for which there was no issue yet.

Supersedes #3135 (opened this new PR because of different approach)

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [no change relevant to user docs] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [hard to document with a screenshot] Add screenshots / screen recordings.
