### PR TITLE
Enable loading features from h5 files again (debug mode)

### DIFF
--- a/ilastik/applets/featureSelection/featureSelectionGui.py
+++ b/ilastik/applets/featureSelection/featureSelectionGui.py
@@ -297,7 +297,7 @@ class FeatureSelectionGui(LayerViewerGui):
         # the Output.meta.NOTREADY flag
         dummy_matrix = numpy.zeros((6, 7), dtype=bool)
         dummy_matrix[0, 0] = True
-        self.parentApplet.topLevelOperator.SelectionMatrix.setValue(True)
+        self.parentApplet.topLevelOperator.SelectionMatrix.setValue(dummy_matrix)
 
         # Notify the workflow that some applets may have changed state now.
         # (For example, the downstream pixel classification applet can

--- a/ilastik/applets/featureSelection/opFeatureSelection.py
+++ b/ilastik/applets/featureSelection/opFeatureSelection.py
@@ -131,8 +131,6 @@ class OpFeatureSelectionNoCache(Operator):
 
         # Get features from external file
         if self.FeatureListFilename.ready() and len(self.FeatureListFilename.value) > 0:
-            raise NotImplementedError("Not simplified yet!")
-
             self.OutputImage.disconnect()
             self.FeatureLayers.disconnect()
 


### PR DESCRIPTION
Hey @FynnBe, you disabled this - I guess in plans of further working on that particular code path in 2018 (c5c5491d1b8a80db265a2f9cb75f75bd32549fd1). I want to test some stuff with features - as this is only available in debug mode I think it's safe to enable it again. Do you remember what plans you had?
