### PR TITLE
wsdt: No unnecessary dirtiness on thresholded output (slot name: ThresholdedInput)

### DIFF
--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -309,11 +309,18 @@ class OpCachedWsdt(Operator):
         self.SelectedInput.connect(self._opMetaInjector.Output)
 
         self._opThreshold = OpPixelOperator(parent=self)
+        # Attribute to track changes to thresholding function -> reduce unnecessary dirtiness
+        # Any change to this operator triggers setting of the thresholding function
+        # The lambda cannot be compared in a meaningful way in setValue -> threshold gets always dirty
+        self._opThreshold._last_threshold = None
         self._opThreshold.Input.connect(self._opSelectedInput.Output)
         self.ThresholdedInput.connect(self._opThreshold.Output)
 
     def setupOutputs(self):
-        self._opThreshold.Function.setValue(lambda a: (a >= self.Threshold.value).astype(np.uint8))
+        threshold = self.Threshold.value
+        if threshold != self._opThreshold._last_threshold:
+            self._opThreshold._last_threshold = threshold
+            self._opThreshold.Function.setValue(lambda a: (a >= self.Threshold.value).astype(np.uint8))
 
     @property
     def debug_results(self):

--- a/tests/test_ilastik/test_applets/multicutWsdt/test_OpWsdt.py
+++ b/tests/test_ilastik/test_applets/multicutWsdt/test_OpWsdt.py
@@ -1,0 +1,88 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2026, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+from typing import Iterator
+
+import numpy
+import pytest
+import vigra
+
+from ilastik.applets.wsdt.opWsdt import OpCachedWsdt
+from lazyflow.operators.opArrayPiper import OpArrayPiper
+from lazyflow.utility.pipeline import Pipeline
+
+
+@pytest.fixture
+def data() -> vigra.VigraArray:
+    shape = (36, 64, 128, 1)
+    return vigra.taggedView(numpy.random.random(numpy.prod(shape)).astype("float32").reshape(shape), axistags="zyxc")
+
+
+@pytest.fixture
+def op_cached_wsdt(graph, data: vigra.VigraArray) -> Iterator[OpCachedWsdt]:
+    with Pipeline(graph=graph) as pipeline:
+        pipeline.add(OpArrayPiper, Input=data)
+        op = pipeline.add(OpCachedWsdt, FreezeCache=False)
+
+        yield op
+
+
+def test_threshold_not_dirty_when_threshold_doesnt_change(op_cached_wsdt: OpCachedWsdt):
+    threshold_expected_count = [(0.5, 0), (0.5, 0), (0.1, 1), (0.1, 1), (0.9, 2), (0.9, 2)]
+    dirty_probs = 0
+
+    def _inc_dirty_probps(*_, **__):
+        nonlocal dirty_probs
+        dirty_probs += 1
+
+    op_cached_wsdt.ThresholdedInput.notifyDirty(_inc_dirty_probps)
+
+    for threshold, expected_dirty_probs in threshold_expected_count:
+        op_cached_wsdt.Threshold.setValue(threshold)
+        assert dirty_probs == expected_dirty_probs
+
+
+def test_threshold_not_dirty_when_other_inputs_change(op_cached_wsdt: OpCachedWsdt):
+    dirty_probs = 0
+
+    def _inc_dirty_probps(*_, **__):
+        nonlocal dirty_probs
+        dirty_probs += 1
+
+    op_cached_wsdt.ThresholdedInput.notifyDirty(_inc_dirty_probps)
+
+    slot_values = [
+        (op_cached_wsdt.Alpha, 0.1),
+        (op_cached_wsdt.Alpha, 0.2),
+        (op_cached_wsdt.ApplyNonmaxSuppression, False),
+        (op_cached_wsdt.ApplyNonmaxSuppression, True),
+        (op_cached_wsdt.MinSize, 10),
+        (op_cached_wsdt.MinSize, 42),
+        (op_cached_wsdt.Sigma, 5.0),
+        (op_cached_wsdt.Sigma, 1.0),
+        (op_cached_wsdt.PixelPitch, [0, 1, 3]),
+        (op_cached_wsdt.PixelPitch, [10, 44, 2]),
+        (op_cached_wsdt.EnableDebugOutputs, True),
+        (op_cached_wsdt.EnableDebugOutputs, False),
+    ]
+
+    for slot, value in slot_values:
+        slot.setValue(value)
+        assert dirty_probs == 0


### PR DESCRIPTION
Added a private attribute to the op in order to track the last threshold. Reduce changes to thresholding function -> reduce unnecessary dirtiness. Any change to this operator triggers setting of the thresholding function. The lambda cannot be compared in a meaningful way in setValue -> threshold gets always dirty.
Now the thresholded output only gets dirty, if the output actually changed.

Before the output was set dirty multiple times for every ui interaction (in very close successsion).
The user-facing change is that it eliminates the volumina exceptions (slot not ready), at least for me.

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [n/a] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [n/a] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [n/a] Add screenshots / screen recordings.
