### PR TITLE
PixelLabelExplorer: Ensure anchor is an actual annotated pixel

### DIFF
--- a/ilastik/applets/labeling/connectBlockedLabels.py
+++ b/ilastik/applets/labeling/connectBlockedLabels.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from enum import IntEnum, StrEnum
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
+import numpy
 import vigra
 from vigra.analysis import extractRegionFeatures
 
@@ -140,8 +141,9 @@ class Region:
     axistags: Sequence[str]
     slices: Tuple[slice, ...]
     label: int
+    pixel_anchor: Dict[str, float]
 
-    __slots__ = "axistags", "slices", "label"
+    __slots__ = "axistags", "slices", "label", "pixel_anchor"
 
     def __post_init__(self):
         if len(self.axistags) != len(self.slices):
@@ -161,6 +163,14 @@ class Region:
         Stop element is assumed to be exclusive.
         """
         return {k: (sl.stop - 1 - sl.start) / 2 + sl.start for k, sl in self.tagged_slicing.items()}
+
+    @property
+    def tagged_pixel_anchor(self) -> Dict[str, float]:
+        """Returns the center of the interval defined by slicing
+
+        Stop element is assumed to be exclusive.
+        """
+        return {k: sl.start + self.pixel_anchor.get(k, 0) for k, sl in self.tagged_slicing.items()}
 
     def is_at_boundary(self, boundary: BoundaryDescr) -> bool:
         """Return True if any bounding box coordinates match given integer in boundary description
@@ -192,7 +202,7 @@ class Region:
     def with_slices(self, tagged_slices: Dict[str, slice]) -> "Region":
         axistags = [k for k in tagged_slices]
         slices = tuple([v for v in tagged_slices.values()])
-        return Region(axistags=axistags, slices=slices, label=self.label)
+        return Region(axistags=axistags, slices=slices, label=self.label, pixel_anchor=self.pixel_anchor)
 
 
 @dataclass(frozen=True)
@@ -340,6 +350,9 @@ def extract_annotations(labels_data: vigra.VigraArray) -> Tuple[Region, ...]:
         features=["RegionCenter", "Coord<Maximum>", "Coord<Minimum>", "Minimum"],
     )
 
+    # we pass the label image as "image", so minimum will be the same label
+    labels = feats["Minimum"][1:].astype("uint32")
+    spatial_at = [at for at in axistags if at in SPATIAL_AXES]
     # shape: (n_objs, ndim), we +1 the maximum bounding box value to make it
     # compatible with slice objects, where the stop is exclusive
     # first object is ignored -> background object.
@@ -347,14 +360,17 @@ def extract_annotations(labels_data: vigra.VigraArray) -> Tuple[Region, ...]:
     min_bb = feats["Coord<Minimum>"][1:].astype("uint32")
 
     slices: list[Tuple[slice, ...]] = []
-    for min_, max_ in zip(min_bb, max_bb):
-        slices.append(tuple(slice(mi, ma) for mi, ma in zip(min_, max_)))
+    anchors: list[Tuple[float, ...]] = []
+    for min_, max_, label, oid in zip(min_bb, max_bb, labels, range(1, len(labels) + 1)):
+        local_slicing = tuple(slice(mi, ma) for mi, ma in zip(min_, max_))
+        annot_pixels = numpy.argwhere(connected_components[local_slicing] == oid)
+        anchors.append(dict(zip(spatial_at, annot_pixels[len(annot_pixels) // 2])))
+        slices.append(local_slicing)
 
-    # we pass the label image as "image", so minimum will be the same label
-    labels = feats["Minimum"][1:].astype("uint32")
-
-    spatial_at = [at for at in axistags if at in SPATIAL_AXES]
-    regions = tuple(Region(axistags=spatial_at, slices=sl, label=label) for sl, label in zip(slices, labels))
+    regions = tuple(
+        Region(axistags=spatial_at, slices=sl, label=label, pixel_anchor=anchor)
+        for sl, label, anchor in zip(slices, labels, anchors)
+    )
 
     return regions
 

--- a/ilastik/applets/labeling/pixelLabelExplorer.py
+++ b/ilastik/applets/labeling/pixelLabelExplorer.py
@@ -147,5 +147,5 @@ class PixelLabelExplorerWidget(LabelExplorerBase):
         annotation_anchors: list[AnnotationAnchor] = []
         for k, v in self._regions_dict.items():
             if k == v:
-                annotation_anchors.append(AnnotationAnchor(label=k.label, position=k.tagged_center))
+                annotation_anchors.append(AnnotationAnchor(label=k.label, position=k.tagged_pixel_anchor))
         return annotation_anchors

--- a/tests/test_ilastik/widgets/test_connectBlockedLabels.py
+++ b/tests/test_ilastik/widgets/test_connectBlockedLabels.py
@@ -61,22 +61,27 @@ def test_add_tagged_coordinates_raises():
 
 def test_region_construction_raises_on_axistags_slices_mismatch():
     with pytest.raises(ValueError):
-        _ = Region(axistags="z", slices=(slice(0, 1), slice(1, 2)), label=1)
+        _ = Region(axistags="z", slices=(slice(0, 1), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
 
 
 def test_region_construction_raises_on_unbound_slicing():
     with pytest.raises(ValueError):
-        _ = Region(axistags="z", slices=(slice(None, 1),), label=1)
+        _ = Region(axistags="z", slices=(slice(None, 1),), label=1, pixel_anchor={"x": 0, "y": 0})
 
 
 def test_region_center():
-    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1)
+    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1, pixel_anchor={"x": 0, "y": 0})
     assert region.tagged_center == dict(x=1.0, y=20.5)
 
 
-def test_region_with_slices():
-    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1)
+def test_pixel_anchor():
+    pixel_anchor = dict(x=1.0, y=20.5)
+    region = Region(axistags="xy", slices=(slice(1, 2), slice(5, 42)), label=1, pixel_anchor=pixel_anchor)
+    assert region.tagged_pixel_anchor == dict(x=2.0, y=25.5)
 
+
+def test_region_with_slices():
+    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1, pixel_anchor={"x": 0, "y": 0})
     new_slices = {"x": slice(5, 6), "y": slice(42, 10)}
     region2 = region.with_slices(tagged_slices=new_slices)
     assert region2.tagged_slicing == new_slices
@@ -98,7 +103,7 @@ def test_region_with_slices():
     ],
 )
 def test_region_at_boundary(boundary_descr: BoundaryDescr, result: bool):
-    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1)
+    region = Region(axistags="xy", slices=(slice(1, 2), slice(0, 42)), label=1, pixel_anchor={"x": 0, "y": 0})
     assert region.is_at_boundary(boundary_descr) == result
 
 
@@ -148,9 +153,9 @@ def test_block_neighborhood_types(neighborhood: Neighborhood, expected_neighbors
 )
 def test_block_no_region_at_boundary_2d(boundary: BoundaryDescrRelative):
     axistags = "yx"
-    r1 = Region(axistags=axistags, slices=(slice(1, 8), slice(1, 8)), label=1)
-    r2 = Region(axistags=axistags, slices=(slice(1, 2), slice(1, 2)), label=1)
-    r3 = Region(axistags=axistags, slices=(slice(5, 9), slice(1, 2)), label=2)
+    r1 = Region(axistags=axistags, slices=(slice(1, 8), slice(1, 8)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r2 = Region(axistags=axistags, slices=(slice(1, 2), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r3 = Region(axistags=axistags, slices=(slice(5, 9), slice(1, 2)), label=2, pixel_anchor={"x": 0, "y": 0})
 
     b = Block(axistags=axistags, slices=(slice(10, 20), slice(20, 30)), regions=(r1, r2, r3))
 
@@ -163,57 +168,130 @@ def test_block_no_region_at_boundary_2d(boundary: BoundaryDescrRelative):
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.NONE},
             [
-                Region(axistags="xy", slices=(slice(0, 9, None), slice(1, 2, None)), label=1),
-                Region(axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3),
-                Region(axistags="xy", slices=(slice(0, 3, None), slice(4, 10, None)), label=6),
+                Region(
+                    axistags="xy", slices=(slice(0, 9, None), slice(1, 2, None)), label=1, pixel_anchor={"x": 0, "y": 0}
+                ),
+                Region(
+                    axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3, pixel_anchor={"x": 0, "y": 0}
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(0, 3, None), slice(4, 10, None)),
+                    label=6,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
             ],
             id="left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.NONE},
             [
-                Region(axistags="xy", slices=(slice(1, 10, None), slice(1, 2, None)), label=1),
-                Region(axistags="xy", slices=(slice(5, 10, None), slice(0, 4, None)), label=4),
-                Region(axistags="xy", slices=(slice(1, 10, None), slice(5, 10, None)), label=7),
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(1, 2, None)),
+                    label=1,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(5, 10, None), slice(0, 4, None)),
+                    label=4,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(5, 10, None)),
+                    label=7,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
             ],
             id="right",
         ),
         pytest.param(
             {"x": BlockBoundary.NONE, "y": BlockBoundary.START},
             [
-                Region(axistags="xy", slices=(slice(3, 6, None), slice(0, 4, None)), label=2),
-                Region(axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3),
-                Region(axistags="xy", slices=(slice(5, 10, None), slice(0, 4, None)), label=4),
+                Region(
+                    axistags="xy", slices=(slice(3, 6, None), slice(0, 4, None)), label=2, pixel_anchor={"x": 0, "y": 0}
+                ),
+                Region(
+                    axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3, pixel_anchor={"x": 0, "y": 0}
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(5, 10, None), slice(0, 4, None)),
+                    label=4,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
             ],
             id="top",
         ),
         pytest.param(
             {"x": BlockBoundary.NONE, "y": BlockBoundary.STOP},
             [
-                Region(axistags="xy", slices=(slice(2, 4, None), slice(1, 10, None)), label=42),
-                Region(axistags="xy", slices=(slice(0, 3, None), slice(4, 10, None)), label=6),
-                Region(axistags="xy", slices=(slice(1, 10, None), slice(5, 10, None)), label=7),
+                Region(
+                    axistags="xy",
+                    slices=(slice(2, 4, None), slice(1, 10, None)),
+                    label=42,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(0, 3, None), slice(4, 10, None)),
+                    label=6,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(5, 10, None)),
+                    label=7,
+                    pixel_anchor={"x": 0, "y": 0},
+                ),
             ],
             id="bottom",
         ),
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.START},
-            [Region(axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3)],
+            [
+                Region(
+                    axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=3, pixel_anchor={"x": 0, "y": 0}
+                )
+            ],
             id="top-left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.START},
-            [Region(axistags="xy", slices=(slice(5, 10, None), slice(0, 4, None)), label=4)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(5, 10, None), slice(0, 4, None)),
+                    label=4,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="top-right",
         ),
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.STOP},
-            [Region(axistags="xy", slices=(slice(0, 3, None), slice(4, 10, None)), label=6)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(0, 3, None), slice(4, 10, None)),
+                    label=6,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="bottom-left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.STOP},
-            [Region(axistags="xy", slices=(slice(1, 10, None), slice(5, 10, None)), label=7)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(5, 10, None)),
+                    label=7,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="bottom-right",
         ),
     ],
@@ -221,16 +299,18 @@ def test_block_no_region_at_boundary_2d(boundary: BoundaryDescrRelative):
 def test_block_boundary_regions_2d(boundary: BoundaryDescrRelative, expected_regions: List[Region]):
     axistags = "xy"
 
-    r_left = Region(axistags=axistags, slices=(slice(0, 9), slice(1, 2)), label=1)
-    r_right = Region(axistags=axistags, slices=(slice(1, 10), slice(1, 2)), label=1)
-    r_top = Region(axistags=axistags, slices=(slice(3, 6), slice(0, 4)), label=2)
-    r_bottom = Region(axistags=axistags, slices=(slice(2, 4), slice(1, 10)), label=42)
+    r_left = Region(axistags=axistags, slices=(slice(0, 9), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r_right = Region(axistags=axistags, slices=(slice(1, 10), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r_top = Region(axistags=axistags, slices=(slice(3, 6), slice(0, 4)), label=2, pixel_anchor={"x": 0, "y": 0})
+    r_bottom = Region(axistags=axistags, slices=(slice(2, 4), slice(1, 10)), label=42, pixel_anchor={"x": 0, "y": 0})
 
-    r_topleft = Region(axistags=axistags, slices=(slice(0, 3), slice(0, 2)), label=3)
-    r_topright = Region(axistags=axistags, slices=(slice(5, 10), slice(0, 4)), label=4)
+    r_topleft = Region(axistags=axistags, slices=(slice(0, 3), slice(0, 2)), label=3, pixel_anchor={"x": 0, "y": 0})
+    r_topright = Region(axistags=axistags, slices=(slice(5, 10), slice(0, 4)), label=4, pixel_anchor={"x": 0, "y": 0})
 
-    r_bottomleft = Region(axistags=axistags, slices=(slice(0, 3), slice(4, 10)), label=6)
-    r_bottomright = Region(axistags=axistags, slices=(slice(1, 10), slice(5, 10)), label=7)
+    r_bottomleft = Region(axistags=axistags, slices=(slice(0, 3), slice(4, 10)), label=6, pixel_anchor={"x": 0, "y": 0})
+    r_bottomright = Region(
+        axistags=axistags, slices=(slice(1, 10), slice(5, 10)), label=7, pixel_anchor={"x": 0, "y": 0}
+    )
 
     block = Block(
         axistags=axistags,
@@ -247,52 +327,99 @@ def test_block_boundary_regions_2d(boundary: BoundaryDescrRelative, expected_reg
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.NONE},
             1,
-            [Region(axistags="xy", slices=(slice(0, 9, None), slice(1, 2, None)), label=1)],
+            [
+                Region(
+                    axistags="xy", slices=(slice(0, 9, None), slice(1, 2, None)), label=1, pixel_anchor={"x": 0, "y": 0}
+                )
+            ],
             id="left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.NONE},
             1,
-            [Region(axistags="xy", slices=(slice(1, 10, None), slice(1, 2, None)), label=1)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(1, 2, None)),
+                    label=1,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="right",
         ),
         pytest.param(
             {"x": BlockBoundary.NONE, "y": BlockBoundary.START},
             2,
             [
-                Region(axistags="xy", slices=(slice(3, 6, None), slice(0, 4, None)), label=2),
-                Region(axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=2),
+                Region(
+                    axistags="xy", slices=(slice(3, 6, None), slice(0, 4, None)), label=2, pixel_anchor={"x": 0, "y": 0}
+                ),
+                Region(
+                    axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=2, pixel_anchor={"x": 0, "y": 0}
+                ),
             ],
             id="top",
         ),
         pytest.param(
             {"x": BlockBoundary.NONE, "y": BlockBoundary.STOP},
             42,
-            [Region(axistags="xy", slices=(slice(2, 4, None), slice(1, 10, None)), label=42)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(2, 4, None), slice(1, 10, None)),
+                    label=42,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="bottom",
         ),
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.START},
             2,
-            [Region(axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=2)],
+            [
+                Region(
+                    axistags="xy", slices=(slice(0, 3, None), slice(0, 2, None)), label=2, pixel_anchor={"x": 0, "y": 0}
+                )
+            ],
             id="top-left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.START},
             4,
-            [Region(axistags="xy", slices=(slice(5, 10, None), slice(0, 4, None)), label=4)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(5, 10, None), slice(0, 4, None)),
+                    label=4,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="top-right",
         ),
         pytest.param(
             {"x": BlockBoundary.START, "y": BlockBoundary.STOP},
             6,
-            [Region(axistags="xy", slices=(slice(0, 3, None), slice(4, 10, None)), label=6)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(0, 3, None), slice(4, 10, None)),
+                    label=6,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="bottom-left",
         ),
         pytest.param(
             {"x": BlockBoundary.STOP, "y": BlockBoundary.STOP},
             7,
-            [Region(axistags="xy", slices=(slice(1, 10, None), slice(5, 10, None)), label=7)],
+            [
+                Region(
+                    axistags="xy",
+                    slices=(slice(1, 10, None), slice(5, 10, None)),
+                    label=7,
+                    pixel_anchor={"x": 0, "y": 0},
+                )
+            ],
             id="bottom-right",
         ),
     ],
@@ -302,16 +429,18 @@ def test_block_boundary_regions_per_label_2d(
 ):
     axistags = "xy"
 
-    r_left = Region(axistags=axistags, slices=(slice(0, 9), slice(1, 2)), label=1)
-    r_right = Region(axistags=axistags, slices=(slice(1, 10), slice(1, 2)), label=1)
-    r_top = Region(axistags=axistags, slices=(slice(3, 6), slice(0, 4)), label=2)
-    r_bottom = Region(axistags=axistags, slices=(slice(2, 4), slice(1, 10)), label=42)
+    r_left = Region(axistags=axistags, slices=(slice(0, 9), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r_right = Region(axistags=axistags, slices=(slice(1, 10), slice(1, 2)), label=1, pixel_anchor={"x": 0, "y": 0})
+    r_top = Region(axistags=axistags, slices=(slice(3, 6), slice(0, 4)), label=2, pixel_anchor={"x": 0, "y": 0})
+    r_bottom = Region(axistags=axistags, slices=(slice(2, 4), slice(1, 10)), label=42, pixel_anchor={"x": 0, "y": 0})
 
-    r_topleft = Region(axistags=axistags, slices=(slice(0, 3), slice(0, 2)), label=2)
-    r_topright = Region(axistags=axistags, slices=(slice(5, 10), slice(0, 4)), label=4)
+    r_topleft = Region(axistags=axistags, slices=(slice(0, 3), slice(0, 2)), label=2, pixel_anchor={"x": 0, "y": 0})
+    r_topright = Region(axistags=axistags, slices=(slice(5, 10), slice(0, 4)), label=4, pixel_anchor={"x": 0, "y": 0})
 
-    r_bottomleft = Region(axistags=axistags, slices=(slice(0, 3), slice(4, 10)), label=6)
-    r_bottomright = Region(axistags=axistags, slices=(slice(1, 10), slice(5, 10)), label=7)
+    r_bottomleft = Region(axistags=axistags, slices=(slice(0, 3), slice(4, 10)), label=6, pixel_anchor={"x": 0, "y": 0})
+    r_bottomright = Region(
+        axistags=axistags, slices=(slice(1, 10), slice(5, 10)), label=7, pixel_anchor={"x": 0, "y": 0}
+    )
 
     block = Block(
         axistags=axistags,
@@ -342,6 +471,8 @@ def test_extract_annotations():
     assert all(a == b for a, b in zip_longest(r_2.axistags, axistags))
     assert r_2.tagged_slicing["x"] == slice(3, 5)
     assert r_2.tagged_slicing["y"] == slice(3, 7)
+
+    assert r_2.tagged_pixel_anchor == {"y": 5, "x": 3}
 
 
 def test_connect_label_blocks():


### PR DESCRIPTION
the previous implementation took region centers as anchor points, which often led to anchor points not being on an actual annotation. Usually good enough to identify the annotation, but it could still lead to ambiguity.
This commit ensures that the anchor point is an actual pixel of the connected annotated block.
The point is kind of random, but it's guaranteed to point to an annotated pixel.

Adds a `tagged_pixel_anchor` property to Regions that maps to an annotated pixel.

Before:

<img width="227" height="249" alt="Screenshot 2026-03-17 at 16 06 37" src="https://github.com/user-attachments/assets/dcb30470-c766-4038-9188-34a14dc61ca1" />

With this PR:

<img width="275" height="252" alt="Screenshot 2026-03-17 at 16 07 12" src="https://github.com/user-attachments/assets/941cc7d4-4cf0-405e-ad62-4c3944a91a2a" />

anchor in the center of the "crosshairs" (checkbox must be checked to see the crosshairs).

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [x] Format code and imports.
- [na] Add docstrings and comments.
- [x] Add tests.
- [na] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [na] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [x] Add screenshots / screen recordings.
