### PR TITLE
bump tiktorch, bump volumina

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -71,10 +71,10 @@ outputs:
         - z5py
         - zarr 2.*
       run_constrained:
-        - tiktorch 26.2.1
+        - tiktorch 26.3.0
         # TODO: investigate pytorch-3dunet dependency changes 1.9.3 and up #3079
         - pytorch-3dunet 1.9.2
-        - volumina >=1.3.20
+        - volumina >=1.3.24
         # TODO: sphericaltexture 0.1.1 currently times out in the tests
         - sphericaltexture 0.0.4
         # pyshtools 4.10 conflicts with pytorch via openmp on windows

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -55,7 +55,7 @@ dependencies:
   # - pytorch=*=*cuda*
   - pytorch 2.7.*
   - torchvision>=0.21
-  - tiktorch 26.2.1
+  - tiktorch 26.3.0
 
   # TODO: investigate pytorch-3dunet dependency changes 1.9.3 and up #3079
   - pytorch-3dunet 1.9.2


### PR DESCRIPTION
* `tiktorch`: more robust error propagation
* `volumina`: fixed screenshot export
