### PR TITLE
Add result export examples to pixel classification notebook

### DIFF
--- a/notebooks/pixel_classification_api/pixel-classification-api.ipynb
+++ b/notebooks/pixel_classification_api/pixel-classification-api.ipynb
@@ -52,6 +52,51 @@
     "# show the foreground channel:\n",
     "plt.imshow(prediction[..., 0])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "export-heading",
+   "metadata": {},
+   "source": [
+    "### Saving the results\n",
+    "\n",
+    "The prediction is an `xarray.DataArray` with shape `(y, x, c)` where `c` is the number of label classes.\n",
+    "Each channel holds the probability (0\u20131) that a given pixel belongs to that class.\n",
+    "\n",
+    "Below are a few common ways to write results to disk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export-probabilities",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the full probability map as a multi-channel TIFF.\n",
+    "# TIFF handles float data natively and is widely supported\n",
+    "# by scientific imaging tools (Fiji / ImageJ, napari, etc.).\n",
+    "iio.imwrite(\"probabilities.tiff\", prediction.values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export-segmentation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For a simple segmentation, pick the most likely class per pixel\n",
+    "# and save as a single-channel image.\n",
+    "segmentation = numpy.argmax(prediction.values, axis=-1).astype(numpy.uint8)\n",
+    "iio.imwrite(\"segmentation.tiff\", segmentation)\n",
+    "\n",
+    "# Quick visual check\n",
+    "plt.imshow(segmentation, cmap=\"tab10\")\n",
+    "plt.title(\"Segmentation (argmax of probabilities)\")\n",
+    "plt.colorbar(label=\"class\")\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {
@@ -68,7 +113,7 @@
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
+   "nbformat_minor": 5,
    "pygments_lexer": "ipython3",
    "version": "3.9.18"
   }

--- a/notebooks/pixel_classification_api/pixel-classification-api.ipynb
+++ b/notebooks/pixel_classification_api/pixel-classification-api.ipynb
@@ -60,10 +60,12 @@
    "source": [
     "### Saving the results\n",
     "\n",
-    "The prediction is an `xarray.DataArray` with shape `(y, x, c)` where `c` is the number of label classes.\n",
-    "Each channel holds the probability (0\u20131) that a given pixel belongs to that class.\n",
+    "The prediction is an `xarray.DataArray` with named dimensions.\n",
+    "The exact dimensions depend on the trained project and input data.\n",
+    "For this 2D single-channel example the result has dimensions `(y, x, c)`,\n",
+    "where `c` holds the per-class probabilities (0\u20131).\n",
     "\n",
-    "Below are a few common ways to write results to disk."
+    "Below are two ways to write results to disk."
    ]
   },
   {
@@ -74,9 +76,32 @@
    "outputs": [],
    "source": [
     "# Save the full probability map as a multi-channel TIFF.\n",
-    "# TIFF handles float data natively and is widely supported\n",
-    "# by scientific imaging tools (Fiji / ImageJ, napari, etc.).\n",
+    "# Depending on how the TIFF metadata is interpreted,\n",
+    "# Fiji/ImageJ may show this as a multi-channel stack.\n",
     "iio.imwrite(\"probabilities.tiff\", prediction.values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export-npy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Alternatively, save as a NumPy .npy file for quick reloading in Python.\n",
+    "numpy.save(\"probabilities.npy\", prediction.values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "segmentation-heading",
+   "metadata": {},
+   "source": [
+    "### Deriving a segmentation\n",
+    "\n",
+    "Often you want a single label per pixel rather than a full probability map.\n",
+    "Taking the `argmax` across the channel axis assigns each pixel to its most\n",
+    "likely class, giving you a simple segmentation mask."
    ]
   },
   {
@@ -86,8 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# For a simple segmentation, pick the most likely class per pixel\n",
-    "# and save as a single-channel image.\n",
+    "# For this example the channel axis is last, so axis=-1 selects it.\n",
     "segmentation = numpy.argmax(prediction.values, axis=-1).astype(numpy.uint8)\n",
     "iio.imwrite(\"segmentation.tiff\", segmentation)\n",
     "\n",
@@ -112,7 +136,6 @@
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
-   "name": "python",
    "nbformat_minor": 5,
    "pygments_lexer": "ipython3",
    "version": "3.9.18"


### PR DESCRIPTION
The notebook ends after displaying the prediction with `plt.imshow`, but most users will want to write the result to disk for downstream analysis.

This adds two cells after the existing visualization:

1. **Save probability map as TIFF** — `iio.imwrite("probabilities.tiff", prediction.values)` keeps the float data and all channels intact, which is what tools like Fiji/ImageJ and napari expect.

2. **Derive and save an argmax segmentation** — takes the most likely class per pixel, casts to `uint8`, writes it out, and shows a quick `tab10` colormap check so you can eyeball the result.

Both use `imageio.v3.imwrite` which is already imported in the notebook. No new dependencies.

Closes #2608