### PR TITLE
Fix the incorrect progress bar scaling in batch processing 

### DIFF
--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -154,10 +154,10 @@ class BatchProcessingApplet(Applet):
             for batch_index, lane_config in enumerate(lane_configs):
 
                 def lerpProgressSignal(a, b, p):
-                    self.progressSignal((100 - p) * a + p * b)
+                    self.progressSignal(a + (b - a) * (p / 100))
 
-                global_progress_start = batch_index / len(lane_configs)
-                global_progress_end = (batch_index + 1) / len(lane_configs)
+                global_progress_start = (batch_index / len(lane_configs)) * 100
+                global_progress_end = ((batch_index + 1) / len(lane_configs)) * 100
 
                 result = self.export_dataset(
                     lane_config,


### PR DESCRIPTION
Fixed issue #3151 of process bar scaling.
Improve logic to avoid misleading progress jumps earlier.

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Add screenshots / screen recordings.
