### PR TITLE
Limit progress value to a maximum of 1.0

### DIFF
--- a/ilastik/utility/gui/progress.py
+++ b/ilastik/utility/gui/progress.py
@@ -70,6 +70,7 @@ class TrackProgressDialog(QDialog):
 
     @threadRouted
     def __onCurrentStepProgressChanged(self, progress):
+        progress = min(progress, 1.0)
         timesHundred = round(1000.0 * progress)
         timesTen = round(100.0 * progress)
         if (not self.currentStepProgress.value() == timesTen) and (timesHundred - 10 * timesTen) == 0:


### PR DESCRIPTION
## issue no: 3174
## Fix: Limit progress value to a maximum of 1.0

### Problem
Progress values can exceed 1.0, causing the progress bar to display values greater than 100%.

### Solution
Clamp the progress value to a maximum of 1.0 before updating the UI.

### Related Issue
Fixes #3174 

### Impact
- Prevents UI inconsistency  
- Ensures correct progress display

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Add screenshots / screen recordings.
