### PR TITLE
Better import project dialog

### DIFF
--- a/ilastik/experimental/parser/_projects.py
+++ b/ilastik/experimental/parser/_projects.py
@@ -25,13 +25,13 @@ from pydantic import BaseModel, Field
 from . import types
 
 
-class PixelClassificationProject(BaseModel):
+class PixelClassificationProject(types.ProjectBase):
     input_data: types.InputData = Field(alias="Input Data")
     feature_matrix: types.FeatureMatrix = Field(alias="FeatureSelections")
     classifier: types.Classifier = Field(alias="PixelClassification")
 
 
-class AutocontextProject(BaseModel):
+class AutocontextProject(types.ProjectBase):
     input_data: types.InputData = Field(alias="Input Data")
     feature_matrix_stage1: types.FeatureMatrix = Field(alias="FeatureSelections")
     classifier_stage1: types.Classifier = Field(alias="PixelClassification")

--- a/ilastik/experimental/parser/types.py
+++ b/ilastik/experimental/parser/types.py
@@ -19,6 +19,7 @@
 #          http://ilastik.org/license.html
 ###############################################################################
 # pyright: strict
+from codecs import decode
 from collections import OrderedDict
 from pathlib import Path
 from typing import Annotated, Dict, List, Literal, Optional, Tuple, Type
@@ -42,6 +43,38 @@ from lazyflow.classifiers import LazyflowVectorwiseClassifierABC, LazyflowVector
 
 NDShape = Annotated[Tuple[int, ...], annotated_types.Len(2, 6)]
 LaneName = Annotated[str, StringConstraints(pattern=r"lane\d{4}")]
+
+WorkflowName = Literal[
+    "Animal Conservation Tracking Workflow from Binary Image",
+    "Animal Conservation Tracking Workflow from Prediction Image",
+    "AutocontextTwoStage",
+    "Automatic Tracking Workflow (Conservation Tracking) from binary image",
+    "Automatic Tracking Workflow (Conservation Tracking) from prediction image",
+    "Carving",
+    "Cell Density Counting",
+    "Data Conversion",
+    "Edge Training With Multicut",
+    "Manual Tracking Workflow",
+    "Neural Network Classification (Local)",
+    "Neural Network Classification (Remote)",
+    "Object Classification (from binary image)",
+    "Object Classification (from label image)",
+    "Object Classification (from pixel classification)",
+    "Object Classification (from prediction image)",
+    "Pixel Classification",
+    "Structured Learning Tracking Workflow from binary image",
+    "Structured Learning Tracking Workflow from prediction image",
+    "Trainable Domain Adaptation (Local) (beta)",
+    "Trainable Domain Adaptation (Local)",
+]
+
+
+class ProjectBase(BaseModel):
+    workflow_name: Annotated[
+        WorkflowName,
+        BeforeValidator(decode),
+        BeforeValidator(deserialize_arraylike_from_h5),
+    ] = Field(alias="workflowName")
 
 
 class VigraAxisTags(BaseModel):

--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -29,7 +29,7 @@ import numbers
 import platform
 import threading
 import warnings
-from typing import Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 # SciPy
 import numpy
@@ -46,6 +46,7 @@ from qtpy.QtGui import (
     QPixmap,
 )
 from qtpy.QtWidgets import (
+    QDialog,
     QMainWindow,
     QWidget,
     QMenu,
@@ -103,6 +104,7 @@ from ilastik.shell.gui.awsCredentialsDialog import AwsCredentialsDialog
 from ilastik.shell.gui.aboutDialog import AboutDialog
 from ilastik.shell.gui.licenseDialog import LicenseDialog
 from ilastik.shell.gui.reportIssueDialog import ReportIssueDialog
+from ilastik.shell.gui.importProjectDialog import ImportProjectDialog
 
 from ilastik.widgets.appletDrawerToolBox import AppletDrawerToolBox, AppletBarManager
 from ilastik.widgets.filePathButton import FilePathButton
@@ -117,6 +119,9 @@ try:
     _has_dvid_support = True
 except:
     _has_dvid_support = False
+
+if TYPE_CHECKING:
+    import h5py
 
 logger = logging.getLogger(__name__)
 
@@ -622,12 +627,16 @@ class IlastikShell(QMainWindow):
     def loadWorkflow(self, workflow_class):
         self.onNewProjectActionTriggered(workflow_class)
 
-    def getWorkflow(self, w: Optional[str] = None) -> Type[Workflow]:
-        listOfItems = [
+    def getWorkflowList(self) -> list[str]:
+        list_of_workflows = [
             workflowDisplayName
             for wf_class, __, workflowDisplayName in getAvailableWorkflows()
             if getattr(wf_class, "show_in_startup_menu", True)
         ]
+        return list_of_workflows
+
+    def getWorkflow(self, w: Optional[str] = None) -> Type[Workflow]:
+        listOfItems = self.getWorkflowList()
         if w is not None and w in listOfItems:
             cur = listOfItems.index(w)
         else:
@@ -1598,24 +1607,30 @@ class IlastikShell(QMainWindow):
         else:
             defaultDirectory = os.path.expanduser("~")
 
-        # Select the paths to the ilp to import and the name of the new one we'll create
-        importedFilePath = self.getProjectPathToOpen(defaultDirectory)
-        if importedFilePath is None:  # User cancelled
+        workflow_list = self.getWorkflowList()
+
+        dlg = ImportProjectDialog(
+            parent=self, workflow_list=sorted(workflow_list), base_path=pathlib.Path(defaultDirectory)
+        )
+        status = dlg.exec()
+
+        if status != QDialog.Accepted:
             return
 
-        preferences.set("shell", "recently imported", importedFilePath)
-        defaultFile, ext = os.path.splitext(importedFilePath)
-        defaultFile += "_imported"
-        defaultFile += ext
-        newProjectFilePath = self.getProjectPathToCreate(defaultFile)
-        if newProjectFilePath is None or not self.ensureNoCurrentProject():
-            return
+        src_project, dst_project, workflow_name = dlg.get_values()
 
-        newProjectFile = ProjectManager.createBlankProjectFile(newProjectFilePath)
+        newProjectFile = ProjectManager.createBlankProjectFile(dst_project)
+
+        workflow_cls = getWorkflowFromName(workflow_name)
+        assert workflow_cls
 
         # workflow_class=None triggers a prompt for the user to choose a workflow type
         self._loadProject(
-            newProjectFile, newProjectFilePath, workflow_class=None, readOnly=False, importFromPath=importedFilePath
+            newProjectFile,
+            str(dst_project),
+            workflow_class=workflow_cls,
+            readOnly=False,
+            importFromPath=str(src_project),
         )
 
     def onDownloadProjectFromDvidActionTriggered(self):
@@ -1736,7 +1751,14 @@ class IlastikShell(QMainWindow):
             QApplication.restoreOverrideCursor()
             self.statusBar.clearMessage()
 
-    def _loadProject(self, hdf5File, projectFilePath, workflow_class, readOnly, importFromPath=None):
+    def _loadProject(
+        self,
+        hdf5File: "h5py.File",
+        projectFilePath: str,
+        workflow_class: Union[Type[Workflow], None],
+        readOnly: bool,
+        importFromPath: Optional[str] = None,
+    ):
         """
         Load the data from the given hdf5File (which should already be open).
         Instantiate a ProjectManager and have it either load hdf5File,

--- a/ilastik/shell/gui/importProjectDialog.py
+++ b/ilastik/shell/gui/importProjectDialog.py
@@ -47,11 +47,11 @@ logger = logging.getLogger(__name__)
 class ImportProjectDialog(QDialog):
 
     class Messages(StrEnum):
-        DESTINATION_PLACEHOLDER = "Click the button to the right to select a new project file name to import to."
+        DESTINATION_PLACEHOLDER = "Click Browse button to select new project file."
         IMPORTING_TO = "Importing from workflow type {workflow_name}."
         INVALID_DEST_NAME = "File name must have the `.ilp` suffix."
         INVALID_SRC_ILP = "Not a valid ilastik project (`.ilp`) file."
-        SOURCE_PLACEHOOLDER = "Click the button to the right to select an existing ilastik project to import from."
+        SOURCE_PLACEHOLDER = "Click Browse button select an existing ilastik project to import from."
         SRC_DEST_EQ = "Cannot import into the same project file."
 
     def __init__(self, workflow_list: list[str], base_path: Path, parent=None):
@@ -68,7 +68,7 @@ class ImportProjectDialog(QDialog):
 
         src_layout = QHBoxLayout()
         self.src_edit = QLineEdit()
-        self.src_edit.setPlaceholderText(self.Messages.SOURCE_PLACEHOOLDER)
+        self.src_edit.setPlaceholderText(self.Messages.SOURCE_PLACEHOLDER)
         self.src_edit.setReadOnly(True)
         self.src_button = QPushButton("Browse...")
         src_layout.addWidget(self.src_edit)
@@ -196,5 +196,4 @@ class ImportProjectDialog(QDialog):
         self.ok_button.setEnabled(valid)
 
     def get_values(self) -> tuple[Path, Path, str]:
-        # if self.re
         return Path(self.src_edit.text()), Path(self.dst_edit.text()), self.combo.currentText()

--- a/ilastik/shell/gui/importProjectDialog.py
+++ b/ilastik/shell/gui/importProjectDialog.py
@@ -1,0 +1,200 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2026, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+#          http://ilastik.org/license.html
+###############################################################################
+import logging
+from enum import StrEnum
+from pathlib import Path
+from typing import Union
+
+import h5py
+import pydantic
+from qtpy.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from ilastik.experimental.parser.types import ProjectBase
+from ilastik.utility import log_exception
+
+logger = logging.getLogger(__name__)
+
+
+class ImportProjectDialog(QDialog):
+
+    class Messages(StrEnum):
+        DESTINATION_PLACEHOLDER = "Click the button to the right to select a new project file name to import to."
+        IMPORTING_TO = "Importing from workflow type {workflow_name}."
+        INVALID_DEST_NAME = "File name must have the `.ilp` suffix."
+        INVALID_SRC_ILP = "Not a valid ilastik project (`.ilp`) file."
+        SOURCE_PLACEHOOLDER = "Click the button to the right to select an existing ilastik project to import from."
+        SRC_DEST_EQ = "Cannot import into the same project file."
+
+    def __init__(self, workflow_list: list[str], base_path: Path, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Import project file...")
+        self.setMinimumWidth(800)
+        self.setModal(True)
+
+        self._base_path = base_path
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        form.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+
+        src_layout = QHBoxLayout()
+        self.src_edit = QLineEdit()
+        self.src_edit.setPlaceholderText(self.Messages.SOURCE_PLACEHOOLDER)
+        self.src_edit.setReadOnly(True)
+        self.src_button = QPushButton("Browse...")
+        src_layout.addWidget(self.src_edit)
+        src_layout.addWidget(self.src_button)
+        src_layout.setContentsMargins(0, 0, 0, 0)
+        form.addRow(QLabel("Import from project:"), src_layout)
+        self.src_hint_label = QLabel()
+        form.addRow(QLabel(), self.src_hint_label)
+
+        form.addRow(QLabel())
+
+        new_layout = QHBoxLayout()
+        self.dst_edit = QLineEdit()
+        self.dst_edit.setPlaceholderText(self.Messages.DESTINATION_PLACEHOLDER)
+        self.dst_edit.setReadOnly(True)
+        self.dst_button = QPushButton("Browse...")
+        new_layout.addWidget(self.dst_edit)
+        new_layout.addWidget(self.dst_button)
+        new_layout.setStretch(2, 0)
+        new_layout.setContentsMargins(0, 0, 0, 0)
+        form.addRow(QLabel("New file:"), new_layout)
+        self.dst_hint_label = QLabel()
+        form.addRow(QLabel(), self.dst_hint_label)
+
+        form.addRow(QLabel())
+
+        combo_layout = QHBoxLayout()
+        self.combo = QComboBox()
+        self.combo.addItems(["-- Select workflow type --"] + workflow_list)
+        self.combo.setPlaceholderText("Workflow type")
+        combo_layout.addWidget(self.combo)
+        combo_layout.setContentsMargins(0, 0, 0, 0)
+        form.addRow(QLabel("Workflow type:"), combo_layout)
+
+        form.setVerticalSpacing(0)
+
+        layout.addLayout(form)
+        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        layout.addStretch()
+        layout.addWidget(self.button_box)
+
+        self.ok_button = self.button_box.button(QDialogButtonBox.Ok)
+        self.setLayout(layout)
+
+        self.src_button.clicked.connect(self.choose_src)
+        self.dst_button.clicked.connect(self.choose_dst)
+
+        self.src_edit.textChanged.connect(self.validate)
+        self.dst_edit.textChanged.connect(self.validate)
+        self.combo.currentIndexChanged.connect(self.validate)
+
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+        self.validate()
+
+    def choose_src(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select existing file", directory=str(self._base_path), filter="*.ilp"
+        )
+        if path:
+            self.src_edit.setText(path)
+
+    def choose_dst(self):
+        src: Union[Path, None] = None
+        if self.src_edit.text() != "":
+            src = Path(self.src_edit.text())
+
+        default_name = src.parent / f"{src.stem}_imported.ilp" if src else self._base_path / "imported.ilp"
+        path, _ = QFileDialog.getSaveFileName(self, "Select new file", directory=str(default_name), filter="*.ilp")
+        if path:
+            self.dst_edit.setText(path)
+
+    def _is_source_valid(self) -> bool:
+        if self.src_edit.text() != "":
+            src = Path(self.src_edit.text())
+        else:
+            self.dst_hint_label.setText("")
+            return False
+
+        if not src.exists() or not src.is_file() or src.suffix != ".ilp":
+            self.src_hint_label.setText(self.Messages.INVALID_SRC_ILP)
+            return False
+
+        try:
+            with h5py.File(src, "r") as f:
+                try:
+                    m = ProjectBase.model_validate(f)
+                except pydantic.ValidationError as e:
+                    log_exception(logger, str(e))
+                    self.src_hint_label.setText(self.Messages.INVALID_SRC_ILP)
+                    return False
+                else:
+                    self.src_hint_label.setText(self.Messages.IMPORTING_TO.format(workflow_name=m.workflow_name))
+                    return True
+        except OSError as e:
+            log_exception(logger, str(e))
+            self.src_hint_label.setText(self.Messages.INVALID_SRC_ILP)
+            return False
+
+    def _is_dest_valid(self) -> bool:
+        src = Path(self.src_edit.text())
+        if self.dst_edit.text() != "":
+            dst = Path(self.dst_edit.text())
+        else:
+            self.dst_hint_label.setText("")
+            return False
+
+        if dst == src:
+            self.dst_hint_label.setText(self.Messages.SRC_DEST_EQ)
+            return False
+        elif dst.suffix != ".ilp":
+            self.dst_hint_label.setText(self.Messages.INVALID_DEST_NAME)
+            return False
+
+        self.dst_hint_label.setText("")
+        return True
+
+    def validate(self):
+        valid = self._is_source_valid()
+        valid &= self._is_dest_valid()
+
+        self.combo.setEnabled(valid)
+
+        valid &= self.combo.currentIndex() != 0
+        self.ok_button.setEnabled(valid)
+
+    def get_values(self) -> tuple[Path, Path, str]:
+        # if self.re
+        return Path(self.src_edit.text()), Path(self.dst_edit.text()), self.combo.currentText()

--- a/ilastik/shell/projectManager.py
+++ b/ilastik/shell/projectManager.py
@@ -129,7 +129,7 @@ class ProjectManager(object):
     @staticmethod
     def createBlankProjectFile(
         projectFilePath, workflow_class=None, workflow_cmdline_args=None, h5_file_kwargs: Optional[Dict] = None
-    ):
+    ) -> h5py.File:
         """Create a new ilp file at the given path and initialize it with a project version.
 
         Class method. If a file already exists at the location, it

--- a/tests/test_ilastik/test_experimental/test_parser/test_projects.py
+++ b/tests/test_ilastik/test_experimental/test_parser/test_projects.py
@@ -3,12 +3,30 @@ import numpy as np
 import pytest
 
 from ilastik.experimental.parser import AutocontextProject, PixelClassificationProject
+from ilastik.experimental.parser.types import ProjectBase
 from lazyflow.classifiers.parallelVigraRfLazyflowClassifier import (
     ParallelVigraRfLazyflowClassifier,
     ParallelVigraRfLazyflowClassifierFactory,
 )
 
 from ..types import ApiTestDataLookup, TestProjects
+
+
+@pytest.mark.parametrize(
+    "proj, expected_workflow_name",
+    [
+        (TestProjects.PIXEL_CLASS_1_CHANNEL_XYC, "Pixel Classification"),
+        (TestProjects.PIXEL_CLASS_3_CHANNEL, "Pixel Classification"),
+        (TestProjects.AUTOCONTEXT_2D, "AutocontextTwoStage"),
+        (TestProjects.AUTOCONTEXT_3D, "AutocontextTwoStage"),
+    ],
+)
+def test_project_workflow_name(test_data_lookup: ApiTestDataLookup, proj, expected_workflow_name):
+    project_path = test_data_lookup.find_project(proj)
+    with h5py.File(project_path, "r") as f:
+        project = ProjectBase.model_validate(f)
+
+    assert project.workflow_name == expected_workflow_name
 
 
 class TestIlastikPixelClassificationParser:

--- a/tests/test_ilastik/test_shell/test_import_project_dialog.py
+++ b/tests/test_ilastik/test_shell/test_import_project_dialog.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import h5py
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
+
+from ilastik.shell.gui.importProjectDialog import ImportProjectDialog
+
+
+@pytest.fixture
+def workflow_list() -> list[str]:
+    return ["workflow 1", "workflow 2"]
+
+
+@pytest.fixture
+def base_path(tmp_path: Path) -> Path:
+    p = tmp_path / "base_path"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def valid_ilp(base_path: Path) -> Path:
+    fout = base_path / "valid_ilp.ilp"
+    with h5py.File(fout, "w") as f:
+        f.create_dataset("workflowName", data=b"Pixel Classification")
+    return fout
+
+
+@pytest.fixture
+def invalid_ilp(base_path: Path) -> Path:
+    fout = base_path / "invalid_ilp.ilp"
+    with h5py.File(fout, "w") as f:
+        f.create_dataset("some_other_h5", data=b"blah")
+    return fout
+
+
+@pytest.fixture
+def dialog(qtbot, workflow_list: list[str], base_path: Path):
+    dlg = ImportProjectDialog(workflow_list=workflow_list, base_path=base_path)
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    return dlg
+
+
+def test_construct(qtbot, workflow_list: list[str], base_path: Path):
+    dlg = ImportProjectDialog(workflow_list=workflow_list, base_path=base_path)
+    qtbot.addWidget(dlg)
+
+    assert not dlg.isVisible()
+
+
+def test_initial_state(dialog: ImportProjectDialog):
+    assert dialog.src_edit.text() == ""
+    assert dialog.dst_edit.text() == ""
+    assert not dialog.combo.isEnabled()
+    assert not dialog.ok_button.isEnabled()
+
+
+@patch("qtpy.QtWidgets.QFileDialog.getOpenFileName", new=lambda *_, **__: ("test.ilp", None))
+def test_add_src_button(qtbot, dialog: ImportProjectDialog):
+    qtbot.mouseClick(dialog.src_button, Qt.MouseButton.LeftButton)
+    assert dialog.src_edit.text() == "test.ilp"
+
+
+@patch("qtpy.QtWidgets.QFileDialog.getOpenFileName", new=lambda *_, **__: ("", None))
+def test_add_src_button_cancel(qtbot, dialog: ImportProjectDialog):
+    dialog.src_edit.setText("some_file.ilp")
+    qtbot.mouseClick(dialog.src_button, Qt.MouseButton.LeftButton)
+    assert dialog.src_edit.text() == "some_file.ilp"
+
+
+@patch("qtpy.QtWidgets.QFileDialog.getSaveFileName", new=lambda *_, directory, **__: (directory, None))
+def test_add_dst_button_empty_src(qtbot, dialog: ImportProjectDialog, base_path: Path):
+    qtbot.mouseClick(dialog.dst_button, Qt.MouseButton.LeftButton)
+    assert dialog.dst_edit.text() == str(base_path / "imported.ilp")
+
+
+@patch("qtpy.QtWidgets.QFileDialog.getSaveFileName", new=lambda *_, directory, **__: (directory, None))
+def test_add_dst_button_with_src(qtbot, dialog: ImportProjectDialog, base_path: Path):
+    dialog.src_edit.setText(str(base_path / "inner" / "some_file.ilp"))
+    qtbot.mouseClick(dialog.dst_button, Qt.MouseButton.LeftButton)
+    assert dialog.dst_edit.text() == str(base_path / "inner" / "some_file_imported.ilp")
+
+
+@patch("qtpy.QtWidgets.QFileDialog.getSaveFileName", new=lambda *_, **__: (None, None))
+def test_add_dst_button_cancel(qtbot, dialog: ImportProjectDialog):
+    dialog.dst_edit.setText("test.ilp")
+    qtbot.mouseClick(dialog.dst_button, Qt.MouseButton.LeftButton)
+    assert dialog.dst_edit.text() == "test.ilp"
+
+
+def test_valid_src(dialog: ImportProjectDialog, valid_ilp: Path):
+    dialog.src_edit.setText(str(valid_ilp))
+    assert dialog.src_hint_label.text() == ImportProjectDialog.Messages.IMPORTING_TO.format(
+        workflow_name="Pixel Classification"
+    )
+
+
+@pytest.mark.parametrize("fname", ["some_file_pretending_to_be.ilp", "not_ilp.txt"])
+def test_invalid_src_no_h5(dialog: ImportProjectDialog, base_path: Path, fname: str):
+    ilp = base_path / fname
+    ilp.touch()
+    dialog.src_edit.setText(str(ilp))
+    assert dialog.src_hint_label.text() == ImportProjectDialog.Messages.INVALID_SRC_ILP
+
+
+def test_invalid_src_h5(dialog: ImportProjectDialog, invalid_ilp: Path):
+    dialog.src_edit.setText(str(invalid_ilp))
+    assert dialog.src_hint_label.text() == ImportProjectDialog.Messages.INVALID_SRC_ILP
+
+
+@pytest.mark.parametrize("fname", ["some-file-no-ext", "not_ilp.txt"])
+def test_invalid_dst(dialog: ImportProjectDialog, base_path: Path, fname: str):
+    ilp = base_path / fname
+    dialog.dst_edit.setText(str(ilp))
+    assert dialog.dst_hint_label.text() == ImportProjectDialog.Messages.INVALID_DEST_NAME
+
+
+def test_same_src_and_dest(dialog: ImportProjectDialog, valid_ilp: Path):
+    dialog.src_edit.setText(str(valid_ilp))
+    dialog.dst_edit.setText(str(valid_ilp))
+    assert dialog.dst_hint_label.text() == ImportProjectDialog.Messages.SRC_DEST_EQ
+
+
+def test_get_values(dialog: ImportProjectDialog, base_path: Path, valid_ilp: Path):
+    dialog.src_edit.setText(str(valid_ilp))
+    dialog.dst_edit.setText(str(base_path / "good_import.ilp"))
+    dialog.combo.setCurrentIndex(2)
+
+    src_path, dst_path, workflow_name = dialog.get_values()
+    assert src_path == valid_ilp
+    assert dst_path == base_path / "good_import.ilp"
+    assert workflow_name == "workflow 2"


### PR DESCRIPTION
I had a lot of waiting time during travel so I entertained myself a bit rewriting the project import after seeing that it was missing documentation anyway (https://github.com/ilastik/ilastik.github.io/issues/191). It's nothing spectacular, but much better than the three step approach before...

<img width="800" height="270" alt="image" src="https://github.com/user-attachments/assets/9dec548e-faa1-44e3-a56d-2cf8e1f0f8ac" />

- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [x] Add screenshots / screen recordings.
