### PR TITLE
Fix placeholder resolution in Feature Table export

### DIFF
--- a/ilastik/applets/objectClassification/opObjectClassification.py
+++ b/ilastik/applets/objectClassification/opObjectClassification.py
@@ -118,8 +118,15 @@ class TableExporter(ExportingOperator):
         obj_count = list(objects_per_frame(label_image))
         ids = list(ilastik_ids(obj_count))
 
-        file_path = settings["file path"]
-        file_path = self.format_path(lane_index, file_path)
+        #file_path = settings["file path"]
+        #file_path = self.format_path(lane_index, file_path)
+
+        if self._path_formatter_factory is not None:
+            formatter = self._path_formatter_factory.for_lane(lane_index)
+            file_path = formatter.format_path(settings["file path"])
+        else:
+            file_path = settings["file path"]
+
 
         export_file = ExportFile(file_path)
         export_file.ExportProgress.subscribe(progress_slot)


### PR DESCRIPTION
This PR fixes an issue where placeholder syntax (e.g. {dataset_dir}, {nickname}, {result_type})
was not properly resolved in Feature Table export.

Previously, the export logic did not use the DataExportPathFormatter, which caused files to be
saved in incorrect locations or placeholders to remain unresolved.

This change ensures that the correct path formatter is used via the path formatter factory,
making Feature Table export consistent with other export settings.

Fixes #1874
