### PR TITLE
Add HDF5 export example and format guide to pixel classification notebook

### DIFF
--- a/notebooks/pixel_classification_api/pixel-classification-api.ipynb
+++ b/notebooks/pixel_classification_api/pixel-classification-api.ipynb
@@ -52,6 +52,36 @@
     "# show the foreground channel:\n",
     "plt.imshow(prediction[..., 0])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "export-format-guide",
+   "metadata": {},
+   "source": [
+    "## Exporting Results\n",
+    "\n",
+    "After running predictions, you will usually want to save the results to disk for use in other tools or pipelines.\n",
+    "\n",
+    "- **TIFF**: Best for tools like Fiji/ImageJ and napari. Keeps float data intact.\n",
+    "- **HDF5**: ilastik's native format. Best for large data or when you need to reload results back into ilastik.\n",
+    "- **Argmax (uint8)**: A single-channel segmentation map showing the most likely class per pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "export-hdf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save prediction as HDF5 (ilastik's native format)\n",
+    "import h5py\n",
+    "\n",
+    "with h5py.File(\"prediction.h5\", \"w\") as f:\n",
+    "    f.create_dataset(\"probabilities\", data=prediction.values)\n",
+    "\n",
+    "print(\"Saved probability map to prediction.h5\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds a markdown cell explaining when to use TIFF vs HDF5 vs argmax export formats, and a code cell demonstrating HDF5 export using h5py - ilastik's native format. Complements #3165.

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->
**Complements #3165 and relates to #2608.**
- ⬜ Format code and imports - not applicable, notebook addition only
- ✅ Add docstrings and comments -  added comments in the code cell
- ⬜ Add tests. - this was a notebook example only
- ✅ Reference relevant issues and other pull requests. - mentioned 3165
- ⬜ Rebase commits into a logical sequence. - Single commit only has been made
- ⬜  Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- ⬜ Add screenshots / screen recordings. - NA, code only additions have been made
