### PR TITLE
OME-Zarr: Ensure errors don't interrupt loading other formats

### DIFF
--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -490,7 +490,7 @@ def _fetch_and_validate_ome_zarr_spec(uri: str, sort_uri: Optional[str] = None) 
             # When we support v0.5, zarr.json should be the first attempt and .zattrs the fallback
             meta = json.loads(store["zarr.json"])
             version = meta["attributes"]["ome"]["version"]
-            raise NotImplementedError(f"This OME-Zarr store is version {version}. ilastik does not support this yet.")
+            raise NoOMEZarrMetaFound(f"This OME-Zarr store is version {version}. ilastik does not support this yet.")
         except KeyError:
             pass  # Raise the original error from .zattrs attempt
         raise NoOMEZarrMetaFound(

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -43,7 +43,6 @@ class PathComponents(object):
     HDF5_EXTS = [".ilp", ".h5", ".hdf5"]
     N5_EXTS = [".n5"]
     NPZ_EXTS = [".npz"]
-    ZARR_EXTS = [".zarr"]
 
     def __init__(self, totalPath, cwd=None):
         """
@@ -79,7 +78,7 @@ class PathComponents(object):
         totalPath = totalPath.replace("\\", "/")
 
         # For hdf5/n5 paths, split into external, extension, and internal paths
-        for x in self.HDF5_EXTS + self.NPZ_EXTS + self.N5_EXTS + self.ZARR_EXTS:
+        for x in self.HDF5_EXTS + self.NPZ_EXTS + self.N5_EXTS:
             if totalPath.find(x) > extIndex:
                 extIndex = totalPath.find(x)
                 ext = x


### PR DESCRIPTION
OpInputDataReader._attemptOpenAsOmeZarrUri only catches NoOMEZarrMetaFound. Other error types stop its try-all-formats loop.

Alternatively, we can also catch NotImplementedError in that method, but I thought this would be simpler.

### Reproduce

Prep: In some folder, place a `zarr.json` file containing e.g. (this is a marginally reduced copy of https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr/zarr.json):
```
{
  "attributes": {
    "ome": {
      "version": "0.5"
    }
  },
  "zarr_format": 3,
  "node_type": "group"
}
```

Put some TIFF file in the same folder as this zarr.json file.

On main, try to load the tiff in ilastik:
<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/282ace3b-eb2e-4929-82f2-0ec0bf8a02ab" />

- [X] Format code and imports.
- [X] Add docstrings and comments.
- [X] Add tests.
- [X] Reference relevant issues and other pull requests.
- [X] Rebase commits into a logical sequence.
- [X] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [X] Add screenshots / screen recordings.
