### PR TITLE
Bump tiktorch to 26.5.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
         - z5py
         - zarr 2.*
       run_constrained:
-        - tiktorch 26.3.1
+        - tiktorch 26.5.0
         # TODO: investigate pytorch-3dunet dependency changes 1.9.3 and up #3079
         - pytorch-3dunet 1.9.2
         - volumina >=1.3.24

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -55,7 +55,7 @@ dependencies:
   # - pytorch=*=*cuda*
   - pytorch 2.7.*
   - torchvision>=0.21
-  - tiktorch 26.3.1
+  - tiktorch 26.5.0
 
   # TODO: investigate pytorch-3dunet dependency changes 1.9.3 and up #3079
   - pytorch-3dunet 1.9.2


### PR DESCRIPTION
Would be nice to have the latest version going for the next stable. Nothing to see here I guess, I tested manually, too.