### PR TITLE
Don't block user from using network if spatial axis too small

### DIFF
--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -616,7 +616,7 @@ class NNClassGui(LabelingGui):
         # validationlayer = AlphaModulatedLayer()
 
         for channel, predictionSlot in enumerate(self.topLevelOperatorView.PredictionProbabilityChannels):
-            logger.info(f"prediction_slot: {predictionSlot}")
+            logger.debug(f"prediction_slot: {predictionSlot}")
             if predictionSlot.ready() and channel < len(labels):
                 ref_label = labels[channel]
                 layers.append(self._createPredLayer(predictionSlot, ref_label))

--- a/ilastik/utility/bioimageio_utils.py
+++ b/ilastik/utility/bioimageio_utils.py
@@ -352,5 +352,5 @@ class InputValidator:
             else:
                 if target_axis_size < min_size:
                     warnings.warn(
-                        f"Image shape for spacial axis with expected {axis} too small ({target_axis_size}). Image will be padded."
+                        f"Image shape for spatial axis with expected {axis} too small ({target_axis_size}). Image will be padded."
                     )

--- a/ilastik/utility/bioimageio_utils.py
+++ b/ilastik/utility/bioimageio_utils.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from functools import partial
 import pathlib
 import tempfile
+import warnings
 from typing_extensions import TypeGuard, assert_never
 
 import numpy as np
@@ -350,4 +351,6 @@ class InputValidator:
                     )
             else:
                 if target_axis_size < min_size:
-                    raise ValueError(f"Incompatible axis {axis}: {target_axis_size} < {min_size}")
+                    warnings.warn(
+                        f"Image shape for spacial axis with expected {axis} too small ({target_axis_size}). Image will be padded."
+                    )


### PR DESCRIPTION
For spatial axes we can (and do) pad, this shouldn't result in a failure. Right now a warning will be added to the log.
Also decreased logging of setupLayers which spammed the log before.

Example warning from log
```
WARNING 2026-05-12 11:05:07,458 logger 83610 8789453888 bioimageio_utils.py:(354): UserWarning: UserWarning("Image shape for spacial axis with expected size=512 id='y' description='' type='space' unit=None scale=1.0 concatenable=False too small (480). Image will be padded.")
```

fixes #3198

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [x] Format code and imports.
- [na] Add docstrings and comments.
- [na] Add tests.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [na] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [na] Add screenshots / screen recordings.
