### PR TITLE
Ensure dev environment set up does not hide fetch_layer_tile exceptions

### DIFF
--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -72,3 +72,9 @@ dependencies:
   - pre-commit
   - pytest >4
   - pytest-qt
+
+variables:
+  # Slightly different behavior for developers:
+  # volumina.is_in_development_env() checks this flag and returns True if set
+  # used in volumina.tiling.TileProvider._fetch_layer_tile
+  ILASTIK_DEVELOPMENT_ENV: "1"


### PR DESCRIPTION
We used to do special releases of volumina for stable versions where exceptions that occur during fetch_layer_tile in volumina would be ignored. These exceptions seem to be triggered by temporary inconsistencies in the graph and are so far transient in nature - no need to inform users about this. But in development mode we do want to see them in order to further identify and reduce such cases.

Environment setup now also sets the environment variable `ILASTIK_DEVELOPMENT_ENV`, which is used to determine if such exceptions should be only logged, or raised.

xref: https://github.com/ilastik/volumina/pull/356
