### PR TITLE
Fix high-DPI UI ilastik-side

### DIFF
--- a/ilastik/applets/dataSelection/addFileButton.py
+++ b/ilastik/applets/dataSelection/addFileButton.py
@@ -22,10 +22,7 @@ from qtpy.QtCore import Signal, QModelIndex
 from qtpy.QtWidgets import QMenu, QPushButton
 from qtpy.QtGui import QIcon
 
-# this is used to find the location of the icon file
-import os.path
-
-FILEPATH = os.path.split(__file__)[0]
+from ilastik.shell.gui.iconMgr import ilastikIcons
 
 # Is DVID available?
 try:
@@ -61,7 +58,7 @@ class AddFileButton(QPushButton):
             corresponding to an existing lane (such as prediction maps)
         """
         super(AddFileButton, self).__init__(
-            QIcon(FILEPATH + "/../../shell/gui/icons/16x16/actions/list-add.png"),
+            QIcon(ilastikIcons.AddSel),
             "Add..." if new == False else "Add New...",
             parent,
         )

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
@@ -38,11 +38,12 @@ from qtpy.QtWidgets import (
 )
 
 from .datasetDetailedInfoTableModel import DatasetColumn
-from .addFileButton import AddFileButton, FILEPATH
+from .addFileButton import AddFileButton
 
 from pathlib import Path
 from functools import partial
 
+from ilastik.shell.gui.iconMgr import ilastikIcons
 from ilastik.utility.gui import silent_qobject
 
 
@@ -53,7 +54,7 @@ class RemoveButtonOverlay(QPushButton):
 
     def __init__(self, parent=None):
         super().__init__(
-            QIcon(FILEPATH + "/../../shell/gui/icons/16x16/actions/list-remove.png"),
+            QIcon(ilastikIcons.RemSel),
             "",
             parent,
             clicked=self.removeButtonClicked,

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableView.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from functools import partial
 
 from ilastik.shell.gui.iconMgr import ilastikIcons
-from ilastik.utility.gui import silent_qobject
+from ilastik.utility.gui import silent_qobject, line_height
 
 
 class RemoveButtonOverlay(QPushButton):
@@ -267,6 +267,9 @@ class ScaleComboBoxDelegate(QStyledItemDelegate):
 
 
 class DatasetDetailedInfoTableView(QTableView):
+    _SHAPE_COL_WIDTH = 11
+    _SCALE_COL_WIDTH = 14
+
     dataLaneSelected = Signal(object)  # Signature: (laneIndex)
     scaleSelected = Signal(int, str)  # Signature: (lane_index, scale_key)
 
@@ -397,8 +400,8 @@ class DatasetDetailedInfoTableView(QTableView):
         # the "Add..." button spans last row
         self.setSpan(lastRow, 0, 1, model.columnCount())
 
-        self.setColumnWidth(DatasetColumn.TaggedShape, 215)
-        self.setColumnWidth(DatasetColumn.Scale, 250)
+        self.setColumnWidth(DatasetColumn.TaggedShape, line_height() * self._SHAPE_COL_WIDTH)
+        self.setColumnWidth(DatasetColumn.Scale, line_height() * self._SCALE_COL_WIDTH)
         self.horizontalHeader().setSectionResizeMode(DatasetColumn.Nickname, QHeaderView.Interactive)
         self.horizontalHeader().setSectionResizeMode(DatasetColumn.Location, QHeaderView.Interactive)
         self.horizontalHeader().setSectionResizeMode(DatasetColumn.InternalID, QHeaderView.Interactive)

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -45,7 +45,7 @@ from lazyflow.slot import InputSlot, OutputSlot
 
 # ilastik
 from ilastik.utility import bind, log_exception
-from ilastik.utility.gui import ThunkEventHandler, is_qt_dark_mode, threadRouted
+from ilastik.utility.gui import ThunkEventHandler, is_qt_dark_mode, threadRouted, line_height
 from ilastik.applets.layerViewer.layerViewerGui import LayerViewerGui, LayerPriority
 
 from ilastik.applets.labeling.labelingImport import import_labeling_layer
@@ -221,7 +221,7 @@ class LabelingGui(LayerViewerGui):
 
         # We own the applet bar ui
         self._labelControlUi = _labelControlUi
-        em = self._labelControlUi.fontMetrics().height()
+        em = line_height()
         pad_small = round(0.1 * em)
         pad_large = round(0.35 * em)
         height = round(1.4 * em)

--- a/ilastik/applets/labeling/labelingGui.py
+++ b/ilastik/applets/labeling/labelingGui.py
@@ -221,30 +221,38 @@ class LabelingGui(LayerViewerGui):
 
         # We own the applet bar ui
         self._labelControlUi = _labelControlUi
-        stylesheet_light = """
-            QToolButton#suggestFeaturesButton { padding: 2px; height: 24px; }
-            QToolButton#liveUpdateButton {
-                padding: 5px; height: 24px; border-style: solid; border-width: 1px; border-radius: 4px;
-                border-color: #aaccaa; background-color: #eeffee; }
-            QToolButton#liveUpdateButton:hover { border-color: #a0c0a0; background-color: #c0e0c0; }
-            QToolButton#liveUpdateButton:pressed { border-color: #557755; background-color: #779977; }
-            QToolButton#liveUpdateButton:checked { border-color: #aaccaa; background-color: #cceecc; }
-            QToolButton#liveUpdateButton:checked:hover { border-color: #b0d0b0; background-color: #d0f0d0; }
+        em = self._labelControlUi.fontMetrics().height()
+        pad_small = round(0.1 * em)
+        pad_large = round(0.35 * em)
+        height = round(1.4 * em)
+        radius = round(0.25 * em)
+        border = max(1, round(0.06 * em))
+        stylesheet_light = f"""
+            QToolButton#suggestFeaturesButton {{ padding: {pad_small}px; height: {height}px; }}
+            QToolButton#liveUpdateButton {{
+                padding: {pad_large}px; height: {height}px; border-width: {border}px; border-radius: {radius}px;
+                border-style: solid; border-color: #aaccaa; background-color: #eeffee; }}
+            QToolButton#liveUpdateButton:hover {{ border-color: #a0c0a0; background-color: #c0e0c0; }}
+            QToolButton#liveUpdateButton:pressed {{ border-color: #557755; background-color: #779977; }}
+            QToolButton#liveUpdateButton:checked {{ border-color: #aaccaa; background-color: #cceecc; }}
+            QToolButton#liveUpdateButton:checked:hover {{ border-color: #b0d0b0; background-color: #d0f0d0; }}
         """
 
-        stylesheet_dark = """
-            QToolButton#suggestFeaturesButton { padding: 2px; height: 24px; }
-            QToolButton#liveUpdateButton {
-                padding: 5px; height: 24px; border-style: solid; border-width: 1px; border-radius: 4px;
-                border-color: #97b6b7; background-color: #638182; }
-            QToolButton#liveUpdateButton:hover { border-color: #befcfe; background-color: #7ab5b8; }
-            QToolButton#liveUpdateButton:pressed { border-color: #a0acbd; background-color: #637a95; }
-            QToolButton#liveUpdateButton:checked { border-color: #aaa6cb; background-color: #757295; }
-            QToolButton#liveUpdateButton:checked:hover { border-color: #f1edff; background-color: #aaa6cb; }
+        stylesheet_dark = f"""
+            QToolButton#suggestFeaturesButton {{ padding: {pad_small}px; height: {height}px; }}
+            QToolButton#liveUpdateButton {{
+                padding: {pad_large}px; height: {height}px; border-width: {border}px; border-radius: {radius}px;
+                border-color: #97b6b7; background-color: #638182; }}
+            QToolButton#liveUpdateButton:hover {{ border-color: #befcfe; background-color: #7ab5b8; }}
+            QToolButton#liveUpdateButton:pressed {{ border-color: #a0acbd; background-color: #637a95; }}
+            QToolButton#liveUpdateButton:checked {{ border-color: #aaa6cb; background-color: #757295; }}
+            QToolButton#liveUpdateButton:checked:hover {{ border-color: #f1edff; background-color: #aaa6cb; }}
         """
 
         stylesheet = stylesheet_dark if is_qt_dark_mode() else stylesheet_light
         _labelControlUi.setStyleSheet(stylesheet)
+        if hasattr(self.labelingDrawerUi, "liveUpdateButton"):
+            self.labelingDrawerUi.liveUpdateButton.setIcon(QIcon(ilastikIcons.Play))
 
         # Initialize the label list model
         model = LabelListModel()

--- a/ilastik/applets/neuralNetwork/modelStateControl.py
+++ b/ilastik/applets/neuralNetwork/modelStateControl.py
@@ -183,12 +183,14 @@ class ModelStateControl(QWidget):
 
     def _setup_ui(self):
         layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
 
         self.modelSourceEdit = ModelSourceEdit(self)
         self.statusLabel = QLabel(self)
         self.modelControlButton = QToolButton(self)
 
         bottom_layout = QHBoxLayout()
+        bottom_layout.setContentsMargins(0, 0, 0, 0)
         bottom_layout.addWidget(self.statusLabel)
         bottom_layout.addStretch()
         bottom_layout.addWidget(self.modelControlButton)

--- a/ilastik/applets/neuralNetwork/nnClass.ui
+++ b/ilastik/applets/neuralNetwork/nnClass.ui
@@ -2,25 +2,11 @@
 <ui version="4.0">
  <class>containingWidget</class>
  <widget class="QWidget" name="containingWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>256</width>
-    <height>731</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>1</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="baseSize">
    <size>

--- a/ilastik/applets/objectClassification/labelingDrawer.ui
+++ b/ilastik/applets/objectClassification/labelingDrawer.ui
@@ -2,25 +2,11 @@
 <ui version="4.0">
  <class>containingWidget</class>
  <widget class="QWidget" name="containingWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>288</width>
-    <height>418</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>1</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="baseSize">
    <size>

--- a/ilastik/applets/pixelClassification/labelingDrawer.ui
+++ b/ilastik/applets/pixelClassification/labelingDrawer.ui
@@ -2,25 +2,11 @@
 <ui version="4.0">
  <class>containingWidget</class>
  <widget class="QWidget" name="containingWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>256</width>
-    <height>359</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>1</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="baseSize">
    <size>
@@ -183,7 +169,7 @@
        </property>
           <property name="sizeHint" stdset="0">
               <size>
-                  <width>20</width>
+                  <width>0</width>
                   <height>20</height>
               </size>
           </property>
@@ -192,8 +178,8 @@
      <item>
       <widget class="QToolButton" name="suggestFeaturesButton">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>1</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
@@ -230,12 +216,6 @@
        </property>
        <property name="toolButtonStyle">
         <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-       <property name="icon">
-        <iconset>
-          <normalon>../../shell/gui/icons/16x16/actions/media-playback-pause.png</normalon>
-          <normaloff>../../shell/gui/icons/16x16/actions/media-playback-start.png</normaloff>
-        </iconset>
        </property>
       </widget>
      </item>

--- a/ilastik/applets/pixelClassification/viewerControls.ui
+++ b/ilastik/applets/pixelClassification/viewerControls.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>Form</class>
  <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>623</width>
-    <height>300</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -18,7 +10,7 @@
     <number>0</number>
    </property>
    <property name="topMargin">
-    <number>15</number>
+    <number>13</number>
    </property>
    <property name="rightMargin">
     <number>0</number>

--- a/ilastik/applets/tracking/annotations/drawerObjects.ui
+++ b/ilastik/applets/tracking/annotations/drawerObjects.ui
@@ -16,12 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="baseSize">
    <size>
     <width>0</width>

--- a/ilastik/applets/tracking/conservation/conservationTrackingGui.py
+++ b/ilastik/applets/tracking/conservation/conservationTrackingGui.py
@@ -3,6 +3,7 @@ from builtins import range
 from past.utils import old_div
 from qtpy import uic
 from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QAbstractSpinBox, QLineEdit, QSizePolicy
 import os
 import logging
 import sys
@@ -66,6 +67,10 @@ class ConservationTrackingGui(TrackingBaseGui, ExportingGui):
         # Load the ui file (find it in our own directory)
         localDir = os.path.split(__file__)[0]
         self._drawer = uic.loadUi(localDir + "/drawer.ui")
+
+        # SpinBoxes set min-size by their max value, which is huge because one box has max value 2147483647
+        for input_widget in self._drawer.findChildren(QAbstractSpinBox) + self._drawer.findChildren(QLineEdit):
+            input_widget.setSizePolicy(QSizePolicy.Ignored, input_widget.sizePolicy().verticalPolicy())
 
         parameters = self.topLevelOperatorView.Parameters.value
         if "maxDist" in list(parameters.keys()):

--- a/ilastik/applets/tracking/conservation/drawer.ui
+++ b/ilastik/applets/tracking/conservation/drawer.ui
@@ -16,12 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="baseSize">
    <size>
     <width>0</width>
@@ -334,17 +328,17 @@
      </item>
      <item>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="9" column="1">
+       <item row="9" column="2">
         <widget class="QLineEdit" name="timeoutBox"/>
        </item>
-       <item row="11" column="0">
+       <item row="11" column="0" colspan="2">
         <widget class="QLabel" name="label_24">
          <property name="text">
           <string>MotionModel Weight</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="10" column="2">
         <widget class="QSpinBox" name="bordWidthBox">
          <property name="maximum">
           <number>999999</number>
@@ -354,7 +348,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="9" column="0" colspan="2">
         <widget class="QLabel" name="label_21">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Timeout in seconds for the &lt;span style=&quot; font-weight:600;&quot;&gt;optimization&lt;/span&gt;. Leave empty for not specifying a timeout (then, the best solution will be found no matter how long it takes). Note that the tracking can take much longer due to pre- and post-processing steps.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -364,7 +358,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="5" column="0" colspan="2">
         <widget class="QLabel" name="label_6">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The weight to&lt;span style=&quot; font-weight:600;&quot;&gt; balance division probabilities&lt;/span&gt; against transitions and detections. High values (≥10) give more weight to the division classifier, low values (≤10) will weigh the transition and detection probabilities higher than the division probabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -374,7 +368,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="12" column="2">
         <widget class="QSpinBox" name="maxNearestNeighborsSpinBox">
          <property name="minimum">
           <number>1</number>
@@ -387,7 +381,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="7" column="0" colspan="2">
         <widget class="QLabel" name="label_22">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Costs to allow one object to &lt;span style=&quot; font-weight:600;&quot;&gt;appear&lt;/span&gt;, i.e. to start a new track other than at the beginning of the time range or the borders of the field of view. High values (≥500) forbid object appearances if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -397,7 +391,7 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="8" column="0" colspan="2">
         <widget class="QLabel" name="label_23">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Costs to allow one object to &lt;span style=&quot; font-weight:600;&quot;&gt;disappear&lt;/span&gt;, i.e. to terminate an existing track other than at the end of the time range or the borders of the field of view. High values (≥500) forbid object disappearances if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -407,14 +401,14 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="1" column="0" colspan="2">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Maximal Distance</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="8" column="2">
         <widget class="QSpinBox" name="disappearanceBox">
          <property name="maximum">
           <number>9999999</number>
@@ -424,7 +418,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="0" colspan="2">
         <widget class="QLabel" name="label_3">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify how many objects are maximally contained in one connected component. For instance, if all objects are segmented without any occlusions (or merging), choose 1. If maximally 2 objects are touching in the segmentation, choose 2... Note that this number has to be consistent with the number of classes chosen in the object count classification if the count classifier is selected below.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -434,7 +428,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="3" column="2">
         <widget class="QSpinBox" name="maxObjectsBox">
          <property name="minimum">
           <number>1</number>
@@ -447,14 +441,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="4" column="0" colspan="2">
         <widget class="QLabel" name="label_25">
          <property name="text">
           <string>Avg. Object Size</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="6" column="0" colspan="2">
         <widget class="QLabel" name="label_7">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The weight to&lt;span style=&quot; font-weight:600;&quot;&gt; balance transition probabilities&lt;/span&gt; against divisions and detections. High values (≥10) will make transitions overrule division and detection probabilities, low values (≤10) will weigh detection and division classifier higher than transition probabilities.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -464,7 +458,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="2" column="2">
         <widget class="QDoubleSpinBox" name="divThreshBox">
          <property name="maximum">
           <double>1.000000000000000</double>
@@ -477,7 +471,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="12" column="0" colspan="2">
         <widget class="QLabel" name="MaxNearestNeighbourLabel">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of the transition neighbourhood determines the number of objects considered in the next time frame as successors and the number of objects considered in the previous time frame as predecessors on a track.&lt;/pre&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -487,7 +481,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="13" column="0" colspan="2">
         <widget class="QLabel" name="numFramesPerSplitLabel">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of frames per video split (0 no splits).&lt;/pre&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -497,7 +491,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="13" column="2">
         <widget class="QSpinBox" name="numFramesPerSplitSpinBox">
          <property name="minimum">
           <number>0</number>
@@ -507,7 +501,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="11" column="2">
         <widget class="QSpinBox" name="motionModelWeightBox">
          <property name="maximum">
           <number>1000</number>
@@ -517,7 +511,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="5" column="2">
         <widget class="QDoubleSpinBox" name="divWeightBox">
          <property name="maximum">
           <double>300.000000000000000</double>
@@ -527,7 +521,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="7" column="2">
         <widget class="QSpinBox" name="appearanceBox">
          <property name="maximum">
           <number>9999999</number>
@@ -537,7 +531,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="10" column="0" colspan="2">
         <widget class="QLabel" name="label_20">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Absolute number of pixels at the border of the field of view where appearance and disappearance cost less (linearly).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -547,14 +541,14 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="2" column="0" colspan="2">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Division Threshold</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="6" column="2">
         <widget class="QDoubleSpinBox" name="transWeightBox">
          <property name="maximum">
           <double>300.000000000000000</double>
@@ -564,7 +558,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="1" column="2">
         <widget class="QSpinBox" name="maxDistBox">
          <property name="maximum">
           <number>99999</number>
@@ -574,7 +568,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="4" column="2">
         <widget class="QDoubleSpinBox" name="avgSizeBox">
          <property name="maximum">
           <double>100000.000000000000000</double>
@@ -584,7 +578,7 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="14" column="1" colspan="2">
         <widget class="QComboBox" name="solverComboBox">
          <item>
           <property name="text">
@@ -762,7 +756,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1" colspan="2">
+       <item row="5" column="1">
         <widget class="QSpinBox" name="from_size">
          <property name="maximum">
           <number>2147483647</number>
@@ -778,7 +772,7 @@
        <item row="3" column="2" colspan="2">
         <widget class="QSpinBox" name="to_y"/>
        </item>
-       <item row="5" column="3">
+       <item row="5" column="2" colspan="2">
         <widget class="QSpinBox" name="to_size">
          <property name="maximum">
           <number>2147483647</number>

--- a/ilastik/applets/tracking/manual/drawer.ui
+++ b/ilastik/applets/tracking/manual/drawer.ui
@@ -16,12 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="baseSize">
    <size>
     <width>0</width>

--- a/ilastik/applets/tracking/structured/drawer.ui
+++ b/ilastik/applets/tracking/structured/drawer.ui
@@ -2,25 +2,11 @@
 <ui version="4.0">
  <class>containingWidget</class>
  <widget class="QWidget" name="containingWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>615</width>
-    <height>1968</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>1</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="baseSize">
    <size>
@@ -998,7 +984,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="2" colspan="2">
+   <item row="9" column="1" colspan="3">
     <widget class="QComboBox" name="solverComboBox">
      <item>
       <property name="text">

--- a/ilastik/applets/tracking/structured/structuredTrackingGui.py
+++ b/ilastik/applets/tracking/structured/structuredTrackingGui.py
@@ -1,8 +1,9 @@
 from __future__ import division
 from builtins import range
 from past.utils import old_div
-from qtpy import uic, QtWidgets
+from qtpy import uic
 from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QAbstractSpinBox, QLineEdit, QMessageBox, QSizePolicy
 
 import os
 import logging
@@ -84,6 +85,10 @@ class StructuredTrackingGui(TrackingBaseGui, ExportingGui):
     def _loadUiFile(self):
         localDir = os.path.split(__file__)[0]
         self._drawer = uic.loadUi(localDir + "/drawer.ui")
+
+        # SpinBoxes set min-size by their max value, which is huge because one box has max value 2147483647
+        for input_widget in self._drawer.findChildren(QAbstractSpinBox) + self._drawer.findChildren(QLineEdit):
+            input_widget.setSizePolicy(QSizePolicy.Ignored, input_widget.sizePolicy().verticalPolicy())
 
         parameters = self.topLevelOperatorView.Parameters.value
         if "maxDist" in list(parameters.keys()):
@@ -684,4 +689,4 @@ class StructuredTrackingGui(TrackingBaseGui, ExportingGui):
 
     @threadRouted
     def postInformationMessage(self, prompt):
-        QtWidgets.QMessageBox.information(self, "Info:", prompt, QtWidgets.QMessageBox.Ok)
+        QMessageBox.information(self, "Info:", prompt, QMessageBox.Ok)

--- a/ilastik/shell/gui/iconMgr.py
+++ b/ilastik/shell/gui/iconMgr.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2023, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -82,6 +82,8 @@ class ilastikIcons(object):
     New = iconPath + "actions/document-new.png"
     Open = iconPath + "actions/document-open.png"
     OpenFolder = iconPath + "status/folder-open.png"
+    GoUp = iconPath + "actions/go-up.png"
+    GoDown = iconPath + "actions/go-down.png"
     GoNext = iconPath + "actions/go-next.png"
     Save = iconPath + "actions/document-save.png"
     SaveAs = iconPath + "actions/document-save-as.png"

--- a/ilastik/shell/gui/ilastik-style.qss
+++ b/ilastik/shell/gui/ilastik-style.qss
@@ -8,7 +8,6 @@ ImageView2D { background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
 /* Applet bar */
 QToolBox {
   border: 1px inset gray;
-  icon-size: 18px;
 }
 
 QToolBox::tab {
@@ -33,8 +32,8 @@ QToolBox::tab:hover {
 }
 
 /********************************************
-The entries below are now commented out because it is better 
-to defer to the user's system color settings than to hard-code 
+The entries below are now commented out because it is better
+to defer to the user's system color settings than to hard-code
 specific colors.  If you want to change a widget's background color,
 try something like this:
 

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -123,7 +123,7 @@ class CentralWidgetStack(QStackedWidget):
 class MainControls(QSplitter):
     """The widget home to the applet drawer and viewer control stack"""
 
-    _MAIN_CONTROLS_MIN_WIDTH = 17  # Enforced for the whole splitter by the viewer controls
+    _MAIN_CONTROLS_MIN_WIDTH = 18  # Enforced for the whole splitter by the viewer controls
     _VIEWER_CONTROLS_MIN_HEIGHT = 10
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2025, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -23,7 +23,6 @@ from typing import Optional, Union
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QColor, QMouseEvent, QPaintEvent, QPalette, QResizeEvent
 from qtpy.QtWidgets import (
-    QApplication,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -40,17 +39,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from ilastik.utility.gui import line_height
 from ilastik.widgets.appletDrawerToolBox import AppletDrawerToolBox
-
-
-_CENTRAL_WIDGET_MIN_WIDTH = 30
-_CENTRAL_WIDGET_MIN_HEIGHT = 30
-_MAIN_CONTROLS_MIN_WIDTH = 20
-_MAIN_CONTROLS_MIN_HEIGHT = 10
-
-
-def em():
-    return QApplication.instance().fontMetrics().ascent()
 
 
 class VerticalButton(QPushButton):
@@ -108,6 +98,9 @@ class CentralWidgetStack(QStackedWidget):
     usually volumina, sometimes also additional elements, e.g. in DataSelection
     """
 
+    _CENTRAL_WIDGET_MIN_WIDTH = 25
+    _CENTRAL_WIDGET_MIN_HEIGHT = 25
+
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
 
@@ -116,8 +109,9 @@ class CentralWidgetStack(QStackedWidget):
         policy.setVerticalStretch(2)
         self.setSizePolicy(policy)
 
-        width = em() * _CENTRAL_WIDGET_MIN_WIDTH
-        height = em() * _CENTRAL_WIDGET_MIN_HEIGHT
+        em = line_height()
+        width = em * self._CENTRAL_WIDGET_MIN_WIDTH
+        height = em * self._CENTRAL_WIDGET_MIN_HEIGHT
         self.setMinimumSize(width, height)
         self.setBaseSize(width, height)
 
@@ -128,6 +122,9 @@ class CentralWidgetStack(QStackedWidget):
 
 class MainControls(QSplitter):
     """The widget home to the applet drawer and viewer control stack"""
+
+    _MAIN_CONTROLS_MIN_WIDTH = 17  # Enforced for the whole splitter by the viewer controls
+    _VIEWER_CONTROLS_MIN_HEIGHT = 10
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(Qt.Vertical, parent)
@@ -161,8 +158,9 @@ class MainControls(QSplitter):
         viewerControlStackpolicy.setHorizontalStretch(2)
         viewerControlStackpolicy.setVerticalStretch(2)
         self.viewerControlStack.setSizePolicy(viewerControlStackpolicy)
-        width = em() * _MAIN_CONTROLS_MIN_WIDTH
-        height = em() * _MAIN_CONTROLS_MIN_HEIGHT
+        em = line_height()
+        width = em * self._MAIN_CONTROLS_MIN_WIDTH
+        height = em * self._VIEWER_CONTROLS_MIN_HEIGHT
         self.viewerControlStack.setMinimumSize(width, height)
         self.viewerControlStack.setBaseSize(0, 0)
         self.viewerControlStack.setFrameShape(QFrame.NoFrame)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -23,6 +23,7 @@ from typing import Optional, Union
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QColor, QMouseEvent, QPaintEvent, QPalette, QResizeEvent
 from qtpy.QtWidgets import (
+    QApplication,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -148,7 +149,10 @@ class MainControls(QSplitter):
         viewerControlStackpolicy.setHorizontalStretch(2)
         viewerControlStackpolicy.setVerticalStretch(2)
         self.viewerControlStack.setSizePolicy(viewerControlStackpolicy)
-        self.viewerControlStack.setMinimumSize(310, 200)
+        em = QApplication.instance().fontMetrics().ascent()
+        width = em * 18
+        height = em * 12
+        self.viewerControlStack.setMinimumSize(width, height)
         self.viewerControlStack.setBaseSize(0, 0)
         self.viewerControlStack.setFrameShape(QFrame.NoFrame)
         self.viewerControlStack.setFrameShadow(QFrame.Plain)

--- a/ilastik/shell/gui/shellWidgets.py
+++ b/ilastik/shell/gui/shellWidgets.py
@@ -43,6 +43,16 @@ from qtpy.QtWidgets import (
 from ilastik.widgets.appletDrawerToolBox import AppletDrawerToolBox
 
 
+_CENTRAL_WIDGET_MIN_WIDTH = 30
+_CENTRAL_WIDGET_MIN_HEIGHT = 30
+_MAIN_CONTROLS_MIN_WIDTH = 20
+_MAIN_CONTROLS_MIN_HEIGHT = 10
+
+
+def em():
+    return QApplication.instance().fontMetrics().ascent()
+
+
 class VerticalButton(QPushButton):
 
     def sizeHint(self) -> QSize:
@@ -106,8 +116,10 @@ class CentralWidgetStack(QStackedWidget):
         policy.setVerticalStretch(2)
         self.setSizePolicy(policy)
 
-        self.setMinimumSize(500, 100)
-        self.setBaseSize(500, 100)
+        width = em() * _CENTRAL_WIDGET_MIN_WIDTH
+        height = em() * _CENTRAL_WIDGET_MIN_HEIGHT
+        self.setMinimumSize(width, height)
+        self.setBaseSize(width, height)
 
         self.setFrameShape(QFrame.NoFrame)
         self.setFrameShadow(QFrame.Plain)
@@ -149,9 +161,8 @@ class MainControls(QSplitter):
         viewerControlStackpolicy.setHorizontalStretch(2)
         viewerControlStackpolicy.setVerticalStretch(2)
         self.viewerControlStack.setSizePolicy(viewerControlStackpolicy)
-        em = QApplication.instance().fontMetrics().ascent()
-        width = em * 18
-        height = em * 12
+        width = em() * _MAIN_CONTROLS_MIN_WIDTH
+        height = em() * _MAIN_CONTROLS_MIN_HEIGHT
         self.viewerControlStack.setMinimumSize(width, height)
         self.viewerControlStack.setBaseSize(0, 0)
         self.viewerControlStack.setFrameShape(QFrame.NoFrame)

--- a/ilastik/shell/gui/ui/ilastikShell.ui
+++ b/ilastik/shell/gui/ui/ilastikShell.ui
@@ -16,13 +16,13 @@
   <widget class="QWidget" name="mainLayout">
    <layout class="QGridLayout" name="gridLayout_3">
     <property name="leftMargin">
-     <number>5</number>
+     <number>1</number>
     </property>
     <property name="topMargin">
-     <number>5</number>
+     <number>1</number>
     </property>
     <property name="rightMargin">
-     <number>5</number>
+     <number>1</number>
     </property>
     <property name="bottomMargin">
      <number>0</number>

--- a/ilastik/utility/gui/__init__.py
+++ b/ilastik/utility/gui/__init__.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -19,7 +19,6 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 from qtpy.QtWidgets import QApplication
-
 
 from .roi import roi2rect
 from .threadRouter import ThreadRouter, threadRouted, threadRoutedWithRouter
@@ -39,3 +38,8 @@ def is_qt_dark_mode() -> bool:
     Returns True if in dark mode, False if light mode
     """
     return QApplication.palette().windowText().color().value() > QApplication.palette().window().color().value()
+
+
+def line_height() -> int:
+    """Relative base unit for responsive UI sizing. Similar to CSS `em`"""
+    return QApplication.fontMetrics().height()

--- a/ilastik/widgets/appletDrawerToolBox.py
+++ b/ilastik/widgets/appletDrawerToolBox.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple, Union
 from qtpy.QtCore import Signal, QObject
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QToolBox, QWidget, QStackedWidget
+from qtpy.QtWidgets import QToolBox, QWidget, QStackedWidget, QApplication
 
 from ilastik.shell.gui.iconMgr import ilastikIcons
 
@@ -11,6 +11,8 @@ class AppletDrawerToolBox(QToolBox):
         super().__init__(*args, **kwargs)
         self.ICON_CLOSED = QIcon(ilastikIcons.ChevronRight)
         self.ICON_OPEN = QIcon(ilastikIcons.ChevronDown)
+        icon_size = int(QApplication.instance().fontMetrics().ascent())
+        self.setStyleSheet(f"QToolBox {{ icon-size: {icon_size}px; }}")
 
         self._prevActive = None
         self.currentChanged.connect(self._toggleCollapsedMarker)

--- a/ilastik/widgets/appletDrawerToolBox.py
+++ b/ilastik/widgets/appletDrawerToolBox.py
@@ -1,9 +1,30 @@
+###############################################################################
+#   ilastik: interactive learning and segmentation toolkit
+#
+#       Copyright (C) 2011-2026, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# In addition, as a special exception, the copyright holders of
+# ilastik give you permission to combine ilastik with applets,
+# workflows and plugins which are not covered under the GNU
+# General Public License.
+#
+# See the LICENSE file for details. License information is also available
+# on the ilastik web site at:
+# 		   http://ilastik.org/license.html
+###############################################################################
 from typing import List, Tuple, Union
 from qtpy.QtCore import Signal, QObject
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QToolBox, QWidget, QStackedWidget, QApplication
+from qtpy.QtWidgets import QToolBox, QWidget, QStackedWidget
 
 from ilastik.shell.gui.iconMgr import ilastikIcons
+from ilastik.utility.gui import line_height
 
 
 class AppletDrawerToolBox(QToolBox):
@@ -11,7 +32,7 @@ class AppletDrawerToolBox(QToolBox):
         super().__init__(*args, **kwargs)
         self.ICON_CLOSED = QIcon(ilastikIcons.ChevronRight)
         self.ICON_OPEN = QIcon(ilastikIcons.ChevronDown)
-        icon_size = int(QApplication.instance().fontMetrics().ascent())
+        icon_size = line_height()
         self.setStyleSheet(f"QToolBox {{ icon-size: {icon_size}px; }}")
 
         self._prevActive = None

--- a/ilastik/widgets/listView.py
+++ b/ilastik/widgets/listView.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -18,20 +18,17 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from builtins import range
 from qtpy.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QStackedWidget, QLabel, QSizePolicy
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QSize
 
 import logging
 
 logger = logging.getLogger(__name__)
 
-# ===============================================================================
-# Common base class that can be used by the labelListView and the boxListView
-# ===============================================================================
-
 
 class ListView(QStackedWidget):
+    """Common base class for LabelListView and BoxListView"""
+
     PAGE_EMPTY = 0
     PAGE_LISTVIEW = 1
 
@@ -137,16 +134,26 @@ class ListView(QStackedWidget):
         vHeader = t.verticalHeader()
         hHeader = t.horizontalHeader()
         doubleFrame = 2 * t.frameWidth()
-        w = hHeader.length() + vHeader.width() + doubleFrame
+        contentW = 0
+        if t.model():
+            for column in range(t.model().columnCount()):
+                if t.isColumnHidden(column):
+                    continue
+                contentW += max(
+                    t.sizeHintForColumn(column),
+                    hHeader.sectionSizeHint(column),
+                    hHeader.minimumSectionSize(),
+                )
+        w = vHeader.width() + contentW + doubleFrame
 
-        contentH = 0
-        if self._table.model():
-            for i in range(self._table.model().rowCount()):
-                contentH += self._table.rowHeight(i)
-        contentH = max(90, contentH)
-
-        h = hHeader.height() + contentH + doubleFrame
-        from qtpy.QtCore import QSize
+        if self.currentIndex() == self.PAGE_EMPTY:
+            h = self.emptyMessage.minimumSizeHint().height()
+        else:
+            contentH = 0
+            if t.model():
+                for i in range(t.model().rowCount()):
+                    contentH += t.rowHeight(i)
+            h = hHeader.height() + contentH + doubleFrame
 
         return QSize(w, h)
 

--- a/ilastik/widgets/viewerControls.py
+++ b/ilastik/widgets/viewerControls.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   ilastik: interactive learning and segmentation toolkit
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -23,7 +23,10 @@ import os
 
 # Third-party
 from qtpy import uic
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QWidget
+
+from ilastik.shell.gui.iconMgr import ilastikIcons
 
 from volumina.widgets.exportHelper import prompt_export_settings_and_export_layer
 
@@ -31,8 +34,15 @@ from volumina.widgets.exportHelper import prompt_export_settings_and_export_laye
 class ViewerControls(QWidget):
     def __init__(self, parent=None, model=None):
         QWidget.__init__(self, parent)
+        self.setup_ui()
+
+    def setup_ui(self):
         localDir = os.path.split(__file__)[0]
         uic.loadUi(os.path.join(localDir, "viewerControls.ui"), self)
+
+        self.UpButton.setIcon(QIcon(ilastikIcons.GoUp))
+        self.DownButton.setIcon(QIcon(ilastikIcons.GoDown))
+        self.SaveButton.setIcon(QIcon(ilastikIcons.Save))
 
     def setupConnections(self, model):
         # The editor's layerstack is in charge of which layer movement buttons are enabled

--- a/ilastik/widgets/viewerControls.ui
+++ b/ilastik/widgets/viewerControls.ui
@@ -46,10 +46,6 @@
        <property name="text">
         <string>Up</string>
        </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../shell/gui/icons/16x16/actions/go-up.png</normaloff>../shell/gui/icons/16x16/actions/go-up.png</iconset>
-       </property>
       </widget>
      </item>
      <item>
@@ -59,10 +55,6 @@
        </property>
        <property name="text">
         <string>Down</string>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../shell/gui/icons/16x16/actions/go-down.png</normaloff>../shell/gui/icons/16x16/actions/go-down.png</iconset>
        </property>
       </widget>
      </item>
@@ -85,11 +77,7 @@
         <string>save layer</string>
        </property>
        <property name="text">
-        <string>Remove</string>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../shell/gui/icons/16x16/actions/document-save.png</normaloff>../shell/gui/icons/16x16/actions/document-save.png</iconset>
+        <string>Save</string>
        </property>
       </widget>
      </item>

--- a/ilastik/workflows/carving/carvingDrawer.ui
+++ b/ilastik/workflows/carving/carvingDrawer.ui
@@ -2,46 +2,11 @@
 <ui version="4.0">
  <class>containingWidget</class>
  <widget class="QWidget" name="containingWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>338</width>
-    <height>766</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-    <horstretch>1</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
-  </property>
-  <property name="baseSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>317</width>
-       <height>0</height>
-      </size>
      </property>
     </spacer>
    </item>
@@ -78,9 +43,6 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>...</string>
-       </property>
        <property name="autoRaise">
         <bool>false</bool>
        </property>
@@ -108,9 +70,6 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>...</string>
-       </property>
       </widget>
      </item>
      <item row="0" column="2">
@@ -120,9 +79,6 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="text">
-        <string>...</string>
        </property>
       </widget>
      </item>

--- a/ilastik/workflows/carving/carvingDrawer.ui
+++ b/ilastik/workflows/carving/carvingDrawer.ui
@@ -205,10 +205,6 @@
        <property name="text">
         <string>Segment</string>
        </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../shell/gui/icons/16x16/actions/media-playback-start.png</normaloff>../../shell/gui/icons/16x16/actions/media-playback-start.png</iconset>
-       </property>
        <property name="toolButtonStyle">
         <enum>Qt::ToolButtonTextBesideIcon</enum>
        </property>
@@ -224,10 +220,6 @@
        </property>
        <property name="text">
         <string>Clear</string>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../shell/gui/icons/16x16/actions/edit-clear.png</normaloff>../../shell/gui/icons/16x16/actions/edit-clear.png</iconset>
        </property>
        <property name="toolButtonStyle">
         <enum>Qt::ToolButtonTextBesideIcon</enum>
@@ -247,71 +239,11 @@
      <property name="text">
       <string>Save current object</string>
      </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>../../shell/gui/icons/16x16/actions/document-save.png</normaloff>../../shell/gui/icons/16x16/actions/document-save.png</iconset>
-     </property>
      <property name="toolButtonStyle">
       <enum>Qt::ToolButtonTextBesideIcon</enum>
      </property>
     </widget>
    </item>
-<!--    <item>
-    <widget class="QLabel" name="label_9">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Uncertainty:</string>
-     </property>
-    </widget>
-   </item> -->
-<!--    <item>
-    <widget class="QComboBox" name="uncertaintyCombo">
-     <item>
-      <property name="text">
-       <string>None</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Local Margin</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Exchange Count</string>
-      </property>
-     </item>
-    </widget>
-   </item> -->
-<!--    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="pushButtonUncertaintyFG">
-       <property name="toolTip">
-        <string>Goto position of maximal uncertainty (Foreground)</string>
-       </property>
-       <property name="text">
-        <string>Max Uncer. FG</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButtonUncertaintyBG">
-       <property name="toolTip">
-        <string>Goto position of maximal uncertainty (Background)</string>
-       </property>
-       <property name="text">
-        <string>Max Uncer. BG</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item> -->
    <item>
     <widget class="QLabel" name="label_7">
      <property name="font">
@@ -404,20 +336,12 @@
        <property name="text">
         <string>Browse objects</string>
        </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../shell/gui/icons/16x16/actions/document-open.png</normaloff>../../shell/gui/icons/16x16/actions/document-open.png</iconset>
-       </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="exportAllMeshesButton">
        <property name="text">
         <string>Export All Meshes</string>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normaloff>../../shell/gui/icons/16x16/actions/document-save-as.png</normaloff>../../shell/gui/icons/16x16/actions/document-save-as.png</iconset>
        </property>
       </widget>
      </item>

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -29,7 +29,7 @@ import numpy
 
 # PyQt
 from qtpy import uic
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QIcon
 from qtpy.QtWidgets import QMenu, QMessageBox, QFileDialog
 
 # lazyflow
@@ -44,8 +44,9 @@ from volumina.view3d.meshgenerator import mesh_to_obj, labeling_to_mesh
 from volumina.view3d.volumeRendering import RenderingManager
 
 # ilastik
-from ilastik.utility import bind
 from ilastik.applets.labeling.labelingGui import LabelingGui, LabelingSlots
+from ilastik.shell.gui.iconMgr import ilastikIcons
+from ilastik.utility import bind
 
 
 import logging
@@ -91,6 +92,11 @@ class CarvingGui(LabelingGui):
         super(CarvingGui, self).__init__(
             parentApplet, labelingSlots, topLevelOperatorView, drawerUiPath, is_3d_widget_visible=is_3d
         )
+        self.labelingDrawerUi.segment.setIcon(QIcon(ilastikIcons.Play))
+        self.labelingDrawerUi.clear.setIcon(QIcon(ilastikIcons.Clear))
+        self.labelingDrawerUi.save.setIcon(QIcon(ilastikIcons.Save))
+        self.labelingDrawerUi.namesButton.setIcon(QIcon(ilastikIcons.Open))
+        self.labelingDrawerUi.exportAllMeshesButton.setIcon(QIcon(ilastikIcons.Save))
 
         self.parentApplet = parentApplet
         self.labelingDrawerUi.currentObjectLabel.setText(DEFAULT_OBJECT_NAME)

--- a/ilastik/workflows/carving/carvingGui.py
+++ b/ilastik/workflows/carving/carvingGui.py
@@ -30,7 +30,7 @@ import numpy
 # PyQt
 from qtpy import uic
 from qtpy.QtGui import QColor, QIcon
-from qtpy.QtWidgets import QMenu, QMessageBox, QFileDialog
+from qtpy.QtWidgets import QMenu, QMessageBox, QFileDialog, QSizePolicy
 
 # lazyflow
 from lazyflow.request import Request
@@ -97,6 +97,7 @@ class CarvingGui(LabelingGui):
         self.labelingDrawerUi.save.setIcon(QIcon(ilastikIcons.Save))
         self.labelingDrawerUi.namesButton.setIcon(QIcon(ilastikIcons.Open))
         self.labelingDrawerUi.exportAllMeshesButton.setIcon(QIcon(ilastikIcons.Save))
+        self.labelingDrawerUi.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
         self.parentApplet = parentApplet
         self.labelingDrawerUi.currentObjectLabel.setText(DEFAULT_OBJECT_NAME)

--- a/ilastik/workflows/carving/preprocessingDrawer.ui
+++ b/ilastik/workflows/carving/preprocessingDrawer.ui
@@ -2,25 +2,11 @@
 <ui version="4.0">
  <class>PreprocessDrawer</class>
  <widget class="QWidget" name="PreprocessDrawer">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>772</width>
-    <height>668</height>
-   </rect>
-  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>1</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>PreprocessDrawer</string>
@@ -29,10 +15,10 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <property name="spacing">
-      <number>6</number>
+      <number>4</number>
      </property>
      <property name="rightMargin">
-      <number>10</number>
+      <number>8</number>
      </property>
      <item>
       <widget class="QLabel" name="label_2">


### PR DESCRIPTION
In ilastik the primary problems were:

* Shell, splitter and viewer enforcing excessive minimum sizes
* Applet drawers specifying 256px minimum width, which is often more than necessary and didn't scale well
* Custom-built buttons loading direct PNGs instead of using the icon manager and QIcons
* Pixel classification: Main issue were the label list making itself a bit too wide and tall (so much time wasted finding this 😭) , and the custom styled buttons with hard-coded sizes.

I returned us to a narrower minimum drawer width, got rid of the drawer-internal scroll bars this caused, and switched to 32x32 icons from the icon manager in a bunch of places.

The main shell still enforces a minimum height that's larger than previously, but not problematically so. Technically, our previous minimum height was too small anyway (it allowed the ilastik logo on the main menu to get squished).

The label explorer handle remains a bit ugly but I assume that's just my display and looks fine on others.

One of these days maybe we'll find some SVGs or higher-res PNGs for those main labelling tool buttons eh?

Here's a bunch of screenshots, always with ilastik 1.4.2b9 (pre-high-dpi) on the left. I'm always showing the minimum possible UI size (except for tracking because it's such a tall stack)

<details>
  <summary>Non-high-DPI vs main</summary>
Main menu:
<img width="1798" height="885" alt="image" src="https://github.com/user-attachments/assets/8a4d8992-65a6-4194-b219-bb3e52948474" />
Pixel classification labelling:
<img width="862" height="508" alt="image" src="https://github.com/user-attachments/assets/4568fa65-c3f7-40e7-be30-3dc454129e72" />
Carving labelling:
<img width="854" height="498" alt="image" src="https://github.com/user-attachments/assets/d850c71d-6c13-42a7-aac1-460b6021eb3b" />
NN model selection:
<img width="865" height="496" alt="image" src="https://github.com/user-attachments/assets/78107bb0-3ea6-4edc-bb82-79d524501e77" />
Structured tracking:
<img width="861" height="593" alt="image" src="https://github.com/user-attachments/assets/66c0c38a-41d4-434d-91e7-41e96fae05f0" />
Layer stack footer:
<img width="851" height="146" alt="image" src="https://github.com/user-attachments/assets/7cf32a18-ed43-490e-9bb7-87ad2b9b184c" />
</details>

<details>
  <summary>Non-high-DPI vs PR</summary>
Main menu:
<img width="1741" height="912" alt="image" src="https://github.com/user-attachments/assets/941ab2c3-18ec-4a3d-8555-172d61a416f3" />

Pixel classification labelling:

<img width="733" height="701" alt="image" src="https://github.com/user-attachments/assets/f974c279-1da0-4e81-8b3a-33cb7c654c44" />

Carving labelling:

<img width="728" height="569" alt="image" src="https://github.com/user-attachments/assets/cf4a2f2b-f495-4e37-87e7-1f0e04c26d2b" />

NN model selection:

<img width="717" height="498" alt="image" src="https://github.com/user-attachments/assets/048c7827-b9a5-4aa4-9471-964fc55ebbc0" />

Structured tracking:

<img width="726" height="926" alt="image" src="https://github.com/user-attachments/assets/d40a10b3-69e0-4f01-9e71-cc4e7e7d148b" />

Layer stack footer:

<img width="733" height="71" alt="image" src="https://github.com/user-attachments/assets/dd81a7ba-cd74-4f32-a25d-11c9511e5ad1" />
</details>