### PR TITLE
Show dock icon also in development setup (macos)

### DIFF
--- a/ilastik/shell/gui/startShellGui.py
+++ b/ilastik/shell/gui/startShellGui.py
@@ -25,6 +25,8 @@ from pathlib import Path
 # make the program quit on Ctrl+C
 import signal
 
+from ilastik.shell.gui.iconMgr import ilastikIcons
+
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 from qtpy.QtWidgets import QApplication, QSplashScreen
@@ -66,7 +68,7 @@ def startShellGui(workflow_cmdline_args, preinit_funcs, postinit_funcs):
 
     app = QApplication(["ilastik"])
     _applyStyleSheet(app)
-
+    app.setWindowIcon(ilastikIcons.Ilastik())
     splash = getSplashScreen()
     splash.show()
     app.processEvents()


### PR DESCRIPTION
tiny fix for development versions (or conda installed) on mac. It wasn't showing a proper icon before and that doesn't look so nice :D

<img width="141" height="100" alt="image" src="https://github.com/user-attachments/assets/3bee11e3-82dd-4a28-8cfb-eb4d6c58f1e2" />


with this PR one gets a proper little logo :)

<img width="142" height="60" alt="image" src="https://github.com/user-attachments/assets/07da798d-d25b-4239-9e0c-e2b7390dc586" />
