### PR TITLE
Hytra refactor

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,7 @@ outputs:
         - greenlet
         - grpcio !=1.42.*
         - h5py
-        - hytra >=1.1.5
+        - hytra >=1.2.0
         - ilastik-feature-selection
         - ilastikrag >=0.1.4
         - ilastiktools
@@ -72,6 +72,7 @@ outputs:
         - tifffile >=2022
         - vigra 1.12.2
         - xarray !=2023.8.0,!=2023.9.0,!=2023.10.0
+        - yapsy
         - z5py
         - zarr 2.*
       run_constrained:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -61,7 +61,8 @@ outputs:
         # pyqtgraph 0.14.0 results in non-functional 3dvp on win, no mesh display on mac
         - pyqtgraph <0.14
         # previous versions would set thread limits globally with side effects
-        - python-elf >=0.4.8
+        # 0.9 breaks compatibility and results in test failures
+        - python-elf >=0.4.8,<0.9
         # for neuroglancer precomputed chunks
         - requests
         # s3fs allows zarr.storage.FSStore to read s3:// URIs

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - greenlet
   - grpcio >=1.49.1
   - h5py
-  - hytra
+  - hytra >=1.2.0
   - ilastik-feature-selection
   - ilastikrag >=0.1.4
   - ilastiktools

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -31,7 +31,8 @@ dependencies:
   # pyqtgraph 0.14.0 results in non-functional 3dvp on win, no mesh display on mac
   - pyqtgraph <0.14
   # previous versions would set thread limits globally with side effects
-  - python-elf >= 0.4.8
+  # 0.9 breaks compatibility and results in test failures
+  - python-elf >=0.4.8,<0.9
   - qimage2ndarray
   - qtpy
   - scikit-image

--- a/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
+++ b/ilastik/applets/tracking/base/pluginExportOptionsDlg.py
@@ -27,13 +27,6 @@ from qtpy.QtCore import Qt, QEvent
 from qtpy.QtWidgets import QDialog, QFileDialog, QMessageBox
 from ilastik.plugins.manager import pluginManager
 
-try:
-    from lazyflow.graph import Operator, InputSlot, OutputSlot
-
-    _has_lazyflow = True
-except:
-    _has_lazyflow = False
-
 
 # **************************************************************************
 # DataExportOptionsDlg
@@ -48,8 +41,6 @@ class PluginExportOptionsDlg(QDialog):
                              temporary operator that can be discarded in case the user clicked 'cancel'.
                              If the user clicks 'OK', then copy the slot settings from the temporary op to your real one.
         """
-        global _has_lazyflow
-        assert _has_lazyflow, "This widget requires lazyflow."
         super(PluginExportOptionsDlg, self).__init__(parent)
         uic.loadUi(os.path.splitext(__file__)[0] + ".ui", self)
 
@@ -129,9 +120,6 @@ class PluginExportOptionsDlg(QDialog):
         Returns the list of available plugins
         """
         try:
-            import hytra
-
-            # export plugins only available with hytra backend
             exportPlugins = pluginManager.getPluginsOfCategory("TrackingExportFormats")
             availableExportPlugins = [pluginInfo.name for pluginInfo in exportPlugins]
 

--- a/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
+++ b/ilastik/applets/tracking/base/trackingBaseDataExportGui.py
@@ -93,9 +93,6 @@ class TrackingBaseDataExportGui(DataExportGui, ExportingGui):
         Returns the list of available plugins
         """
         try:
-            import hytra
-
-            # export plugins only available with hytra backend
             exportPlugins = pluginManager.getPluginsOfCategory("TrackingExportFormats")
             availableExportPlugins = [pluginInfo.name for pluginInfo in exportPlugins]
 
@@ -200,7 +197,6 @@ class TrackingBaseDataExportGui(DataExportGui, ExportingGui):
         self.topLevelOperator.SelectedExportSource.setValue(sourceName)
 
     def set_default_export_filename(self, filename):
-        # TODO: remove once tracking is hytra-only
         self._default_export_filename = filename
 
     def exportAsync(self, laneViewList) -> None:

--- a/ilastik/applets/tracking/base/trackingSerializer.py
+++ b/ilastik/applets/tracking/base/trackingSerializer.py
@@ -20,14 +20,11 @@
 ###############################################################################
 from ilastik.applets.base.appletSerializer import AppletSerializer, SerialDictSlot, SerialPickleableSlot
 
-import hytra
-
 
 class TrackingSerializer(AppletSerializer):
     VERSION = 1  # Make sure to bump the version in case you make any changes in the serialization
 
     def __init__(self, mainOperator, projectFileGroupName):
-        # Serialization for the new pipeline (HyTra)
         slots = [
             SerialDictSlot(mainOperator.Parameters, selfdepends=True),
             SerialDictSlot(mainOperator.FilteredLabels, transform=str, selfdepends=True),

--- a/ilastik/applets/tracking/conservation/conservationTrackingApplet.py
+++ b/ilastik/applets/tracking/conservation/conservationTrackingApplet.py
@@ -5,7 +5,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import hytra
 from ilastik.applets.tracking.conservation.opConservationTracking import OpConservationTracking
 
 

--- a/ilastik/applets/tracking/conservation/conservationTrackingGui.py
+++ b/ilastik/applets/tracking/conservation/conservationTrackingGui.py
@@ -15,20 +15,15 @@ from ilastik.utility.exportingOperator import ExportingGui
 from ilastik.utility.gui.threadRouter import threadRouted
 from ilastik.utility.gui.titledMenu import TitledMenu
 from ilastik.config import cfg as ilastik_config
-from ilastik.plugins.manager import pluginManager
 
 
 from lazyflow.request.request import Request
 
 from ilastik.utility.gui.progress import TrackProgressDialog
 from ilastik.utility.gui.progress import GuiProgressVisitor
-from ilastik.utility.progress import DefaultProgressVisitor
 
 logger = logging.getLogger(__name__)
 
-import hytra
-
-# Import solvers for HyTra
 import dpct
 
 try:

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -32,7 +32,8 @@ from hytra.core.fieldofview import FieldOfView
 from hytra.core.ilastikmergerresolver import IlastikMergerResolver
 from hytra.core.probabilitygenerator import ProbabilityGenerator
 from hytra.core.probabilitygenerator import Traxel
-from hytra.pluginsystem.plugin_manager import TrackingPluginManager
+from hytra.ops.gmm_merger_resolver import GMMMergerResolver
+
 from ilastik.utility.progress import DefaultProgressVisitor, CommandLineProgressVisitor
 
 import vigra
@@ -325,7 +326,7 @@ class OpConservationTracking(Operator):
         # supply random_state for reproducible merger resolving
         # random_state will be used in gmm-based merger resolving
         mergerResolver = IlastikMergerResolver(
-            originalGraph, pluginPaths=self.pluginPaths, withFullGraph=withFullGraph, random_state=randomSeedMerger
+            originalGraph, withFullGraph=withFullGraph, random_state=randomSeedMerger
         )
 
         # Check if graph contains mergers, otherwise skip merger resolving
@@ -612,7 +613,7 @@ class OpConservationTracking(Operator):
             if idx in resolvedMergersDict[time]:
                 fits = resolvedMergersDict[time][idx]["fits"]
                 newIds = resolvedMergersDict[time][idx]["newIds"]
-                self.mergerResolverPlugin.updateLabelImage(volume, idx, fits, newIds, offset=offset)
+                self.gmmMergerResolver.updateLabelImage(volume, idx, fits, newIds, offset=offset)
 
         return volume
 

--- a/ilastik/applets/tracking/conservation/opConservationTracking.py
+++ b/ilastik/applets/tracking/conservation/opConservationTracking.py
@@ -15,8 +15,6 @@ from lazyflow.stype import Opaque
 from ilastik.applets.base.applet import DatasetConstraintError
 from ilastik.applets.objectExtraction.opObjectExtraction import (
     default_features_key,
-    OpRegionFeatures,
-    OpAdaptTimeListRoi,
 )
 from lazyflow.operators import OpBlockedArrayCache
 from lazyflow.operators.valueProviders import OpZeroDefault
@@ -28,11 +26,6 @@ from lazyflow.request import Request, RequestPool
 
 from hytra.core.jsongraph import (
     getMappingsBetweenUUIDsAndTraxels,
-    getMergersDetectionsLinksDivisions,
-    getMergersPerTimestep,
-    getLinksPerTimestep,
-    getDetectionsPerTimestep,
-    getDivisionsPerTimestep,
 )
 from hytra.core.ilastikhypothesesgraph import IlastikHypothesesGraph
 from hytra.core.fieldofview import FieldOfView
@@ -129,10 +122,7 @@ class OpConservationTracking(Operator):
         self.RelabeledCleanBlocks.connect(self._relabeledOpCache.CleanBlocks)
         self.RelabeledCachedOutput.connect(self._relabeledOpCache.Output)
 
-        # Merger resolver plugin manager (contains GMM fit routine)
-        self.pluginPaths = [os.path.join(os.path.dirname(os.path.abspath(hytra.__file__)), "plugins")]
-        pluginManager = TrackingPluginManager(verbose=False, pluginPaths=self.pluginPaths)
-        self.mergerResolverPlugin = pluginManager.getMergerResolver()
+        self.gmmMergerResolver = GMMMergerResolver()
 
         self.result = None
 

--- a/ilastik/applets/tracking/structured/structuredTrackingApplet.py
+++ b/ilastik/applets/tracking/structured/structuredTrackingApplet.py
@@ -5,7 +5,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import hytra
 from ilastik.applets.tracking.structured.opStructuredTracking import OpStructuredTracking
 
 

--- a/ilastik/applets/tracking/structured/structuredTrackingGui.py
+++ b/ilastik/applets/tracking/structured/structuredTrackingGui.py
@@ -24,13 +24,9 @@ from ilastik.utility import bind
 from lazyflow.request.request import Request
 
 from ilastik.utility.gui.progress import GuiProgressVisitor
-from ilastik.utility.progress import DefaultProgressVisitor
 
 logger = logging.getLogger(__name__)
 
-import hytra
-
-# Import solvers for HyTra
 import dpct
 
 try:

--- a/ilastik/plugins_default/tracking_h5_event_export.py
+++ b/ilastik/plugins_default/tracking_h5_event_export.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 try:
     from hytra.core.jsongraph import (
-        getMappingsBetweenUUIDsAndTraxels,
         getMergersDetectionsLinksDivisions,
         getMergersPerTimestep,
         getLinksPerTimestep,
@@ -73,9 +72,9 @@ else:
 
                 if div is not None and len(div) > 0:
                     ds = tg.create_dataset("Splits", data=div, dtype=np.int32)
-                    ds.attrs[
-                        "Format"
-                    ] = "ancestor (previous file), descendant (current file), descendant (current file)"
+                    ds.attrs["Format"] = (
+                        "ancestor (previous file), descendant (current file), descendant (current file)"
+                    )
 
                 if mer is not None and len(mer) > 0:
                     ds = tg.create_dataset("Mergers", data=mer, dtype=np.int32)
@@ -95,7 +94,7 @@ else:
         exportsToFile = False
 
         def checkFilesExist(self, filename):
-            """ Check whether the files we want to export are already present """
+            """Check whether the files we want to export are already present"""
             return os.path.exists(filename)
 
         def export(self, filename, hypothesesGraph, pluginExportContext):

--- a/tests/test_ilastik/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraFluo-N2DH-SIM-01.py
+++ b/tests/test_ilastik/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraFluo-N2DH-SIM-01.py
@@ -136,12 +136,6 @@ class TestStructuredLearningTrackingHeadless(object):
 
     @timeLogged(logger)
     def testCSVExport(self):
-        # TODO: When Hytra is supported on Windows, we shouldn't skip the test and throw an assert instead
-        try:
-            import hytra
-        except ImportError as e:
-            pytest.xfail("Hytra tracking pipeline couldn't be imported: " + str(e))
-
         args = " --project=" + self.PROJECT_FILE
         args += " --headless"
 

--- a/tests/test_ilastik/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithMergers.py
+++ b/tests/test_ilastik/test_applets/structuredLearningTracking/testStructuredLearningTrackingHytraWithMergers.py
@@ -143,12 +143,6 @@ class TestStructuredLearningTrackingHeadless(object):
 
     @timeLogged(logger)
     def testCSVExport(self):
-        # TODO: When Hytra is supported on Windows, we shouldn't skip the test and throw an assert instead
-        try:
-            import hytra
-        except ImportError as e:
-            pytest.xfail("Hytra tracking pipeline couldn't be imported: " + str(e))
-
         args = " --project=" + self.PROJECT_FILE
         args += " --headless"
 


### PR DESCRIPTION
This PR mostly tests the new hytra package. I removed all yapsy plugins there and made them modules. Let's see if CI still likes it (it does so locally, with solvers, too).

removed a bunch of hytra imports that mostly checked whether hytra was in the env - unecessary.

direct instantiation of the relevant class for the gmm merger resolver

```
# where one ditches anything related to plugins...
self.mergerResolverPlugin = pluginManager.getMergerResolver()

# and instantiate it directly, explicitly
self.gmmMergerResolver = GMMMergerResolver()
```

there are some indirect plugin invocations via `IlastikMergerResolver` which are made explicit on the hytra side.

xref: #3194 

- [x] Format code and imports.
- [na] Add docstrings and comments.
- [na] Add tests.
- [x] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [na] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [na] Add screenshots / screen recordings.
- [x] move hytra package to main
- [x] remove last commit with `noyapsy` channel references
