### PR TITLE
Add folder picker to multiscale dataset browser

### DIFF
--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -59,6 +59,8 @@ class DefaultWidthComboBox(QComboBox):
         return size
 
     def minimumSizeHint(self):
+        """Prevent the dropdown from being as wide as the history.
+        OME-Zarr URLs have a habit of being very long, making the dialog huge by default"""
         size = super().minimumSizeHint()
         size.setWidth(0)
         return size
@@ -129,10 +131,11 @@ class MultiscaleDatasetBrowser(QDialog):
     def setup_ui(self):
         self.setMinimumSize(30 * line_height(), 16 * line_height())
         self.setWindowTitle("Select Multiscale Source")
+        self.setAcceptDrops(True)
         main_layout = QVBoxLayout()
 
         description = QLabel(self)
-        description.setText('Enter path or URL and click "Check".')
+        description.setText('Enter path or URL and click "Check". Or drag-and-drop a folder.')
         main_layout.addWidget(description)
 
         self.combo = DefaultWidthComboBox(self)
@@ -160,8 +163,8 @@ class MultiscaleDatasetBrowser(QDialog):
         self.browse_button.clicked.connect(self._browse_for_directory)
         self.check_button = QPushButton(self)
         self.check_button.setText("Check")
-        self.check_button.clicked.connect(self._validate_text_input)
-        self.combo.lineEdit().returnPressed.connect(self.check_button.click)
+        self.check_button.clicked.connect(lambda _: self._validate_text_input())
+        self.combo.lineEdit().returnPressed.connect(self._validate_text_input)
         combo_layout.addWidget(combo_label, 0, 0)
         combo_layout.addWidget(self.combo, 0, 1)
         combo_layout.addWidget(self.browse_button, 0, 2)
@@ -196,6 +199,26 @@ class MultiscaleDatasetBrowser(QDialog):
         main_layout.addWidget(self.qbuttons)
         self.setLayout(main_layout)
 
+    def dropEvent(self, dropEvent):
+        urls = dropEvent.mimeData().urls()
+        self.combo.clear()
+        self.combo.lineEdit().setText(urls[0].toLocalFile())
+        self._validate_text_input()
+
+    def dragEnterEvent(self, event):
+        # Only accept drag-and-drop events that consist of a single url to a local folder
+        if not event.mimeData().hasUrls():
+            return
+        urls = event.mimeData().urls()
+        if len(urls) != 1:
+            return
+        url = urls[0]
+        if not url.isLocalFile():
+            return
+        path = pathlib.Path(url.toLocalFile())
+        if path.is_dir():
+            event.acceptProposedAction()
+
     def _starting_directory_for_folder_picker(self) -> str:
         text = self.combo.currentText().strip()
         pref_path = pathlib.Path(preferences.get(self.PREFERENCES_GROUP, self.PREFERENCES_SETTING, pathlib.Path.home()))
@@ -205,7 +228,7 @@ class MultiscaleDatasetBrowser(QDialog):
             return str(default_dir)
 
         try:
-            return str(uri_to_Path(text))  # Valid file URI?
+            return str(uri_to_Path(text))  # Valid `file:` URI?
         except ValueError:
             pass
 
@@ -221,21 +244,19 @@ class MultiscaleDatasetBrowser(QDialog):
         return str(default_dir)
 
     def _browse_for_directory(self):
-        options = QFileDialog.Options(QFileDialog.ShowDirsOnly)
         directory = QFileDialog.getExistingDirectory(
             self,
-            "Select OME-Zarr Dataset Folder",
+            "Select OME-Zarr Multiscale Folder",
             self._starting_directory_for_folder_picker(),
-            options=options,
         )
         if not directory:
             return
 
         preferences.set(self.PREFERENCES_GROUP, self.PREFERENCES_SETTING, pathlib.Path(directory).as_posix())
         self.combo.lineEdit().setText(directory)
-        self.check_button.click()
+        self._validate_text_input()
 
-    def _validate_text_input(self, _event):
+    def _validate_text_input(self):
         self._set_inputs_enabled(False)
         self.selected_uri = None
         text = self.combo.currentText().strip()

--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -29,6 +29,7 @@ from qtpy.QtWidgets import (
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QFileDialog,
     QGridLayout,
     QLabel,
     QPushButton,
@@ -43,6 +44,7 @@ from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore
 from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore
 from lazyflow.utility.pathHelpers import uri_to_Path
+from volumina.utility import preferences
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +100,8 @@ class CheckRemoteStoreWorker(QThread):
 class MultiscaleDatasetBrowser(QDialog):
 
     EXAMPLE_URI = "https://data.ilastik.org/2d_cells_apoptotic_1channel.zarr"
+    PREFERENCES_GROUP = "DataSelection"
+    PREFERENCES_SETTING = "recent multiscale dir"
 
     def __init__(self, history=None, parent=None):
         super().__init__(parent)
@@ -135,13 +139,18 @@ class MultiscaleDatasetBrowser(QDialog):
         self.example_button.pressed.connect(lambda: self.combo.lineEdit().setText(self.EXAMPLE_URI))
 
         combo_layout = QGridLayout()
+        self.browse_button = QPushButton(self)
+        self.browse_button.setText("Browse...")
+        self.browse_button.setToolTip("Choose an OME-Zarr dataset folder from disk.")
+        self.browse_button.clicked.connect(self._browse_for_directory)
         self.check_button = QPushButton(self)
         self.check_button.setText("Check")
         self.check_button.clicked.connect(self._validate_text_input)
         self.combo.lineEdit().returnPressed.connect(self.check_button.click)
         combo_layout.addWidget(combo_label, 0, 0)
         combo_layout.addWidget(self.combo, 0, 1)
-        combo_layout.addWidget(self.check_button, 0, 2)
+        combo_layout.addWidget(self.browse_button, 0, 2)
+        combo_layout.addWidget(self.check_button, 0, 3)
         combo_layout.addWidget(self.example_button, 1, 0)
 
         main_layout.addLayout(combo_layout)
@@ -170,6 +179,45 @@ class MultiscaleDatasetBrowser(QDialog):
         self.combo.lineEdit().textChanged.connect(update_ok_button)
         main_layout.addWidget(self.qbuttons)
         self.setLayout(main_layout)
+
+    def _starting_directory_for_folder_picker(self) -> str:
+        text = self.combo.currentText().strip()
+        pref_path = pathlib.Path(preferences.get(self.PREFERENCES_GROUP, self.PREFERENCES_SETTING, pathlib.Path.home()))
+        default_dir = pref_path if pref_path.is_dir() else pref_path.parent
+
+        if not text:
+            return str(default_dir)
+
+        try:
+            return str(uri_to_Path(text))  # Valid file URI?
+        except ValueError:
+            pass
+
+        if isUrl(text):
+            return str(default_dir)
+
+        path = pathlib.Path(text).expanduser()
+        if path.exists():
+            return str(path if path.is_dir() else path.parent)
+        if path.parent.exists():
+            return str(path.parent)
+
+        return str(default_dir)
+
+    def _browse_for_directory(self):
+        options = QFileDialog.Options(QFileDialog.ShowDirsOnly)
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select OME-Zarr Dataset Folder",
+            self._starting_directory_for_folder_picker(),
+            options=options,
+        )
+        if not directory:
+            return
+
+        preferences.set(self.PREFERENCES_GROUP, self.PREFERENCES_SETTING, pathlib.Path(directory).as_posix())
+        self.combo.lineEdit().setText(directory)
+        self.check_button.click()
 
     def _validate_text_input(self, _event):
         self._set_inputs_enabled(False)
@@ -211,6 +259,7 @@ class MultiscaleDatasetBrowser(QDialog):
 
     def _set_inputs_enabled(self, enabled):
         self.example_button.setEnabled(enabled)
+        self.browse_button.setEnabled(enabled)
         self.check_button.setEnabled(enabled)
         self.combo.setEnabled(enabled)
 

--- a/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
+++ b/ilastik/applets/dataSelection/multiscaleDatasetBrowser.py
@@ -39,6 +39,7 @@ from qtpy.QtWidgets import (
 )
 from requests.exceptions import SSLError, ConnectionError as RequestsConnectionError
 
+from ilastik.utility.gui import line_height
 from lazyflow.utility import isUrl
 from lazyflow.utility.io_util.OMEZarrStore import OMEZarrStore
 from lazyflow.utility.io_util.RESTfulPrecomputedChunkedVolume import RESTfulPrecomputedChunkedVolume
@@ -47,6 +48,20 @@ from lazyflow.utility.pathHelpers import uri_to_Path
 from volumina.utility import preferences
 
 logger = logging.getLogger(__name__)
+
+
+class DefaultWidthComboBox(QComboBox):
+    DEFAULT_WIDTH = 24
+
+    def sizeHint(self):
+        size = super().sizeHint()
+        size.setWidth(self.DEFAULT_WIDTH * line_height())
+        return size
+
+    def minimumSizeHint(self):
+        size = super().minimumSizeHint()
+        size.setWidth(0)
+        return size
 
 
 def _validate_uri(text: str) -> str:
@@ -112,7 +127,7 @@ class MultiscaleDatasetBrowser(QDialog):
         self.setup_ui()
 
     def setup_ui(self):
-        self.setMinimumSize(800, 200)
+        self.setMinimumSize(30 * line_height(), 16 * line_height())
         self.setWindowTitle("Select Multiscale Source")
         main_layout = QVBoxLayout()
 
@@ -120,9 +135,9 @@ class MultiscaleDatasetBrowser(QDialog):
         description.setText('Enter path or URL and click "Check".')
         main_layout.addWidget(description)
 
-        self.combo = QComboBox(self)
+        self.combo = DefaultWidthComboBox(self)
         self.combo.setEditable(True)
-        self.combo.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Minimum)
+        self.combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         for item in self._history:
             self.combo.addItem(item, item)
@@ -152,6 +167,7 @@ class MultiscaleDatasetBrowser(QDialog):
         combo_layout.addWidget(self.browse_button, 0, 2)
         combo_layout.addWidget(self.check_button, 0, 3)
         combo_layout.addWidget(self.example_button, 1, 0)
+        combo_layout.setColumnStretch(1, 1)
 
         main_layout.addLayout(combo_layout)
 

--- a/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
+++ b/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
@@ -142,11 +142,11 @@ def test_browse_button_selects_directory_and_checks(qtbot, tmp_path):
                 multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=str(selected_directory)
             ) as select_directory:
                 dialog = get_dlg(qtbot)
-                with mock.patch.object(dialog.check_button, "click") as check_button_click:
+                with mock.patch.object(dialog, "_validate_text_input") as validate:
                     qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
 
     select_directory.assert_called_once()
-    check_button_click.assert_called_once_with()
+    validate.assert_called_once_with()
     assert dialog.combo.lineEdit().text() == str(selected_directory)
 
 
@@ -234,7 +234,7 @@ def test_browse_button_cancel_does_not_check(qtbot, tmp_path):
     with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
         with mock.patch.object(multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""):
             dialog = get_dlg(qtbot)
-            with mock.patch.object(dialog.check_button, "click") as check_button_click:
+            with mock.patch.object(dialog, "_validate_text_input") as validate:
                 qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
 
-    check_button_click.assert_not_called()
+    validate.assert_not_called()

--- a/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
+++ b/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
@@ -1,10 +1,21 @@
 import os
 import platform
+from unittest import mock
+
 import pytest
+from qtpy.QtCore import Qt
 
 from ilastik.applets.dataSelection import multiscaleDatasetBrowser
 
 WIN = platform.system() == "Windows"
+
+
+def get_dlg(qtbot):
+    dlg = multiscaleDatasetBrowser.MultiscaleDatasetBrowser()
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    return dlg
 
 
 @pytest.mark.parametrize(
@@ -104,3 +115,111 @@ def test_validate_uri_from_existing_Windows_path_with_special_characters(tmp_pat
 def test_validate_uri_from_Windows_path_raises(invalid_input):
     with pytest.raises(ValueError):
         multiscaleDatasetBrowser._validate_uri(invalid_input)
+
+
+def test_browse_button_selects_directory_and_checks(qtbot, tmp_path):
+    selected_directory = tmp_path / "dataset.ome.zarr"
+    selected_directory.mkdir()
+
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
+        with mock.patch.object(multiscaleDatasetBrowser.preferences, "set"):
+            with mock.patch.object(
+                multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=str(selected_directory)
+            ) as select_directory:
+                dialog = get_dlg(qtbot)
+                with mock.patch.object(dialog.check_button, "click") as check_button_click:
+                    qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    select_directory.assert_called_once()
+    check_button_click.assert_called_once_with()
+    assert dialog.combo.lineEdit().text() == str(selected_directory)
+
+
+def test_browse_button_cancel_keeps_current_text(qtbot, tmp_path):
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
+        with mock.patch.object(multiscaleDatasetBrowser.preferences, "set"):
+            with mock.patch.object(multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""):
+                dialog = get_dlg(qtbot)
+                dialog.combo.lineEdit().setText("https://example.com/data.zarr")
+
+                with mock.patch.object(dialog.check_button, "click") as check_button_click:
+                    qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    check_button_click.assert_not_called()
+    assert dialog.combo.lineEdit().text() == "https://example.com/data.zarr"
+
+
+def test_browse_button_reads_recent_starting_path_from_preferences(qtbot, tmp_path):
+    recent_directory = tmp_path / "recent.ome.zarr"
+    recent_directory.mkdir()
+
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=recent_directory) as pref_get:
+        with mock.patch.object(
+            multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""
+        ) as select_directory:
+            dialog = get_dlg(qtbot)
+            qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    pref_get.assert_called_once_with(dialog.PREFERENCES_GROUP, dialog.PREFERENCES_SETTING, mock.ANY)
+    select_directory.assert_called_once()
+    args, _kwargs = select_directory.call_args
+    assert args[2] == str(recent_directory)
+
+
+def test_browse_button_writes_accepted_path_to_preferences(qtbot, tmp_path):
+    selected_directory = tmp_path / "selected.ome.zarr"
+    selected_directory.mkdir()
+
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
+        with mock.patch.object(
+            multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=str(selected_directory)
+        ):
+            dialog = get_dlg(qtbot)
+            with mock.patch.object(multiscaleDatasetBrowser.preferences, "set") as pref_set:
+                with mock.patch.object(dialog.check_button, "click"):
+                    qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    pref_set.assert_called_once_with(
+        dialog.PREFERENCES_GROUP,
+        dialog.PREFERENCES_SETTING,
+        selected_directory.as_posix(),
+    )
+
+
+def test_browse_button_does_not_write_path_to_preferences_on_cancel(qtbot, tmp_path):
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
+        with mock.patch.object(multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""):
+            dialog = get_dlg(qtbot)
+            with mock.patch.object(multiscaleDatasetBrowser.preferences, "set") as pref_set:
+                qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    pref_set.assert_not_called()
+
+
+def test_browse_button_uses_existing_input_as_starting_path(qtbot, tmp_path):
+    recent_directory = tmp_path / "recent.ome.zarr"
+    recent_directory.mkdir()
+    input_directory = tmp_path / "input.ome.zarr"
+    input_directory.mkdir()
+
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=recent_directory):
+        with mock.patch.object(
+            multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""
+        ) as select_directory:
+            dialog = get_dlg(qtbot)
+            dialog.combo.lineEdit().setText(str(input_directory))
+            qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    select_directory.assert_called_once()
+    args, _kwargs = select_directory.call_args
+    assert args[2] == str(input_directory)
+
+
+def test_browse_button_cancel_does_not_check(qtbot, tmp_path):
+    with mock.patch.object(multiscaleDatasetBrowser.preferences, "get", return_value=tmp_path):
+        with mock.patch.object(multiscaleDatasetBrowser.QFileDialog, "getExistingDirectory", return_value=""):
+            dialog = get_dlg(qtbot)
+            with mock.patch.object(dialog.check_button, "click") as check_button_click:
+                qtbot.mouseClick(dialog.browse_button, Qt.MouseButton.LeftButton)
+
+    check_button_click.assert_not_called()

--- a/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
+++ b/tests/test_ilastik/test_applets/dataSelection/test_multiscale_dataset_browser.py
@@ -18,6 +18,21 @@ def get_dlg(qtbot):
     return dlg
 
 
+def test_combo_default_width_does_not_follow_long_history(qtbot, monkeypatch):
+    monkeypatch.setattr(multiscaleDatasetBrowser, "line_height", lambda: 11)
+    long_uri = "https://example.com/" + "long/" * 200 + "data.zarr"
+
+    dlg = multiscaleDatasetBrowser.MultiscaleDatasetBrowser(history=[long_uri])
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+
+    assert dlg.combo.sizeHint().width() == 24 * 11
+    assert dlg.combo.sizePolicy().horizontalPolicy() == multiscaleDatasetBrowser.QSizePolicy.Expanding
+    assert dlg.sizeHint().width() < 1000
+    assert dlg.width() < 1000
+
+
 @pytest.mark.parametrize(
     "text_input,expected",
     [


### PR DESCRIPTION
... and reduce the dialog's minimum and default size.

I guess I got tired of copy-and-pasting folder paths from Windows Explorer eventually :)

<img width="606" height="383" alt="image" src="https://github.com/user-attachments/assets/bbc7a5ea-eacc-4a2b-ad25-23acaac53492" />


- [X] Format code and imports.
- ~~Add docstrings and comments.~~
- [X] Add tests.
- ~~Reference relevant issues and other pull requests.~~
- [X] Rebase commits into a logical sequence.
- ~~Update [user documentation](https://github.com/ilastik/ilastik.github.io).~~
- [X] Add screenshots / screen recordings.
