### PR TITLE
Show error dialog when project file creation fails due to OSError (#3098)

### DIFF
--- a/ilastik/shell/gui/ilastikShell.py
+++ b/ilastik/shell/gui/ilastikShell.py
@@ -1560,9 +1560,23 @@ class IlastikShell(QMainWindow):
         :param h5_file_kwargs: Passed directly to h5py.File.__init__() of the project file; all standard params except 'mode' are allowed.
         """
 
-        newProjectFile = ProjectManager.createBlankProjectFile(
-            newProjectFilePath, workflow_class, self._workflow_cmdline_args, h5_file_kwargs
-        )
+        try:
+            newProjectFile = ProjectManager.createBlankProjectFile(
+                newProjectFilePath, workflow_class, self._workflow_cmdline_args, h5_file_kwargs
+            )
+        except OSError as e:
+            # OSError is the correct exception to catch here.
+            # BlockingIOError (raised on Linux/macOS when the file is locked)
+            # is a subclass of OSError, so it is caught here too.
+            # On Windows, h5py raises OSError directly.
+            QMessageBox.critical(
+                self,
+                "Failed to create project file",
+                f"Could not create project file at:\n{newProjectFilePath}\n\n"
+                f"The file may be locked by another process (e.g. open in another ilastik instance).\n\n"
+                f"Error: {e}",
+            )
+            return
         self._loadProject(newProjectFile, newProjectFilePath, workflow_class, readOnly=False)
 
         # If load failed, projectManager is None

--- a/tests/test_ilastik/test_shell/test_shell.py
+++ b/tests/test_ilastik/test_shell/test_shell.py
@@ -34,3 +34,35 @@ def test_valid_screen_geometry(loaded_geometry: QRect, screen_geometry: QRect, e
         ps_mock.return_value.availableGeometry.return_value = screen_geometry
         resulting_geometry = IlastikShell._valid_screen_geometry(loaded_geometry)
         assert resulting_geometry == expected_geometry
+
+
+def test_createAndLoadNewProject_shows_dialog_on_oserror():
+    """
+    When createBlankProjectFile raises an OSError (e.g. file locked by another
+    process), createAndLoadNewProject should show a QMessageBox.critical dialog
+    and return early without attempting to load the project.
+
+    Fixes #3098: Trying to overwrite locked project file fails silently.
+    """
+    from unittest.mock import MagicMock, patch
+
+    shell = MagicMock(spec=IlastikShell)
+    shell._workflow_cmdline_args = []
+
+    with (
+        patch(
+            "ilastik.shell.gui.ilastikShell.ProjectManager.createBlankProjectFile",
+            side_effect=OSError("Unable to lock file"),
+        ),
+        patch("ilastik.shell.gui.ilastikShell.QMessageBox.critical") as mock_critical,
+    ):
+        IlastikShell.createAndLoadNewProject(shell, "/fake/path/project.ilp", MagicMock())
+
+    # Error dialog must have been shown
+    mock_critical.assert_called_once()
+    args = mock_critical.call_args[0]
+    assert "Failed to create project file" in args[1]
+    assert "/fake/path/project.ilp" in args[2]
+
+    # Project must NOT have been loaded
+    shell._loadProject.assert_not_called()


### PR DESCRIPTION
## Summary
Fixes the silent failure when trying to create a new project file that
is already locked by another process (e.g. open in another ilastik
instance).

Fixes #3098

## Problem
When a user tries to overwrite an existing project file that is currently
open in another ilastik instance, `h5py.File` raises an `OSError`:
OSError: Unable to synchronously create file (unable to lock file, errno = 0)
Previously this exception propagated unhandled through
`createAndLoadNewProject` → `onNewProjectActionTriggered`, resulting in:
- No error dialog shown to the user
- The existing project file being corrupted (bad object header version)
- The error only visible in logs

## Fix
Wrap `ProjectManager.createBlankProjectFile` in a try/except in
`createAndLoadNewProject`. On `OSError`, show a `QMessageBox.critical`
dialog explaining the failure and return early without attempting to
load the project.

```python
try:
    newProjectFile = ProjectManager.createBlankProjectFile(...)
except OSError as e:
    QMessageBox.critical(
        self,
        "Failed to create project file",
        f"Could not create project file at:\n{newProjectFilePath}\n\n"
        f"The file may be locked by another process.\n\nError: {e}",
    )
    return
```

## Changes
- `ilastik/shell/gui/ilastikShell.py` — error handling in `createAndLoadNewProject`
- `tests/test_ilastik/test_shell/test_shell.py` — new test verifying dialog is shown and project is not loaded


## Checklist
- [x] Format code and imports.
- [x] Add docstrings and comments.
- [x] Add tests.
- [x] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
- [ ] Update user documentation. (Not required - error handling improvement)
- [ ] Add screenshots / screen recordings. (Cannot reproduce on Mac - Windows-specific file locking)


## Testing
tests/test_ilastik/test_shell/test_shell.py::test_createAndLoadNewProject_shows_dialog_on_oserror PASSED

The test mocks `createBlankProjectFile` to raise `OSError`, verifies
`QMessageBox.critical` is called with the correct title and file path,
and confirms `_loadProject` is never called.