### PR TITLE
Add {export_source_hyphenated} placeholder to avoid spaces in export filenames

### DIFF
--- a/ilastik/applets/dataExport/opDataExport.py
+++ b/ilastik/applets/dataExport/opDataExport.py
@@ -51,6 +51,7 @@ class DataExportPathFormatter:
 
         if self._result_type:
             known_keys["result_type"] = self._result_type
+            known_keys["export_source_hyphenated"] = self._result_type.replace(" ", "-")
 
         return format_known_keys(path_template, known_keys)
 

--- a/ilastik/config.py
+++ b/ilastik/config.py
@@ -47,7 +47,7 @@ logging_config: ~/custom_ilastik_logging_config.json
 default_config = """
 [ilastik]
 debug: false
-output_filename_format: {dataset_dir}/{nickname}_{result_type}
+output_filename_format: {dataset_dir}/{nickname}_{export_source_hyphenated}
 output_format: compressed hdf5
 
 [lazyflow]

--- a/tests/test_ilastik/test_applets/dataExport/testOpDataExport.py
+++ b/tests/test_ilastik/test_applets/dataExport/testOpDataExport.py
@@ -114,14 +114,16 @@ class TestDataExportPathFormatter:
         ds_info = self.DummyDSInfo(
             filePath="/tmp/a/b/test_ds.h5", nickname="test_nickname", default_output_dir="/tmp/a"
         )
-        return DataExportPathFormatter(dataset_info=ds_info, working_dir="/tmp/a", result_type="mytype")
+        return DataExportPathFormatter(dataset_info=ds_info, working_dir="/tmp/a", result_type="my type")
 
     @pytest.mark.parametrize(
         "template_str,expected_path",
         [
             ("{nickname}", "test_nickname"),
             ("{dataset_dir}/{nickname}", "/tmp/a/test_nickname"),
-            ("{dataset_dir}/{nickname}+{result_type}", "/tmp/a/test_nickname+mytype"),
+            ("{dataset_dir}/{nickname}+{result_type}", "/tmp/a/test_nickname+my type"),
+            ("{export_source_hyphenated}", "my-type"),
+            ("{dataset_dir}/{nickname}_{export_source_hyphenated}", "/tmp/a/test_nickname_my-type"),
             ("{var}", "{var}"),
             ("", ""),
             ("mypath", "mypath"),


### PR DESCRIPTION
Fixes #2929

Workflow export names containing spaces are propagated into the default export filename template via `{result_type}`. This can result in default export filenames containing spaces.

Examples of export names containing spaces include:

* `Multicut Segmentation`
* `Thresholded Output`
* `Inverted Thresholded Output`

These values flow through:

`EXPORT_NAMES` → `SelectionNames` → `result_type` in `DataExportPathFormatter` → default template `{dataset_dir}/{nickname}_{result_type}` in `config.py`.

This change introduces a new `{export_source_hyphenated}` placeholder that replaces spaces with hyphens (for example, `Multicut-Segmentation`) and updates the default filename template to use it. The existing `{result_type}` placeholder is preserved unchanged for backward compatibility with existing projects.

## Checklist

* [x] Format code and imports.
* [ ] Add docstrings and comments. (Not needed for this small formatter change.)
* [x] Add tests.
* [x] Reference relevant issues and other pull requests.
* [x] Rebase commits into a logical sequence.
* [ ] Update user documentation. (Not applicable.)
* [ ] Add screenshots / screen recordings. (Not applicable.)

## Testing

Ran:

```bash
python -m pytest tests/test_ilastik/test_applets/dataExport/testOpDataExport.py -k PathFormatter -v
```

Result:

* 10 tests passed
* Added coverage for:

  * `{export_source_hyphenated}` → `my-type`
  * `{dataset_dir}/{nickname}_{export_source_hyphenated}` → `/tmp/a/test_nickname_my-type`

