### PR TITLE
Extract clearscale

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ outputs:
       script_env:
         - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
       script:
+        - {{PYTHON}} -m pip install git+https://github.com/ilastik/clearscale@ilastik-review
         - {{PYTHON}} -m pip install . --no-deps -vv
     requirements:
       host:
@@ -28,6 +29,7 @@ outputs:
         - pip
         - setuptools >=64.0
         - setuptools_scm >=6.2
+        - hatchling
       run:
         - python >=3.10
         - numpy >=1.25

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -48,6 +48,9 @@ dependencies:
   - aiohttp
   - fsspec
   - s3fs >=2022.8.2
+  - pip
+  - pip:
+    - git+https://github.com/ilastik/clearscale@ilastik-review
 
   # Deep learning dependencies (neural net workflow, trainable domain adaptation)
   # can be changed to request gpu versions by uncommenting the following line:

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -19,17 +19,15 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 
-import json
 from collections import OrderedDict
 from functools import reduce
-from typing import Dict, List
-
+from typing import List, Set
 
 from qtpy.QtCore import Qt, QAbstractItemModel, QModelIndex
 from ilastik.utility import bind
 from ilastik.utility.gui import ThreadRouter, threadRouted
 from lazyflow.utility.helpers import bigintprod, eq_shapes
-from lazyflow.utility.io_util.multiscaleStore import Multiscale
+from lazyflow.utility.io_util.clearscale import Scale, Multiscale, Shape as ClearscaleShape
 from .opDataSelection import DatasetInfo
 from .dataLaneSummaryTableModel import rowOfButtonsProxy
 
@@ -45,12 +43,12 @@ class DatasetColumn:
     NumColumns = 7
 
 
-def _dims_to_display_string(dimensions: Dict[str, int], axiskeys: str, dtype: type) -> str:
+def _dims_to_display_string(scale: Scale, dtype: type) -> str:
     """Generate labels to put into the scale combobox / to display in the table.
-    XYZ dimensions will be reordered to match axiskeys."""
-    reordered_dimensions = [dimensions[axis] for axis in axiskeys if axis in "xyz"]
-    shape_string = " / ".join(str(size) for size in reordered_dimensions)
-    scale_file_size = bigintprod(reordered_dimensions) * dtype().nbytes
+    Aim: XYZ dimensions + data size, but in original axis order"""
+    xyz_shape = scale.shape.without_axes_except("xyz").to_list()
+    shape_string = " / ".join(str(size) for size in xyz_shape)
+    scale_file_size = bigintprod(xyz_shape) * dtype().nbytes
     size_labels = {1e15: "PB", 1e12: "TB", 1e9: "GB", 1e6: "MB", 1e3: "KB", 1: "B"}
     size_factor = [f for f in size_labels.keys() if scale_file_size >= f][0]
     size_string = f"{scale_file_size / size_factor:.1f} {size_labels[size_factor]}"
@@ -223,9 +221,7 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
             return str(datasetInfo.drange or "")
         if index.column() == DatasetColumn.Scale:
             if datasetInfo.scales:
-                return _dims_to_display_string(
-                    datasetInfo.scales[datasetInfo.working_scale], datasetInfo.axiskeys, datasetInfo.laneDtype
-                )
+                return _dims_to_display_string(datasetInfo.scales[datasetInfo.working_scale], datasetInfo.laneDtype)
             return UninitializedDisplayData[index.column()]
 
         if index.column() == DatasetColumn.PixelSize:
@@ -275,8 +271,8 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         # is the first option in the drop-down box
         return OrderedDict(
             {
-                key: _dims_to_display_string(tagged_shape, datasetInfo.axiskeys, datasetInfo.laneDtype)
-                for key, tagged_shape in reversed(datasetInfo.scales.items())
+                key: _dims_to_display_string(scale, datasetInfo.laneDtype)
+                for key, scale in reversed(datasetInfo.scales.items())
             }
         )
 
@@ -286,16 +282,16 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         Return indices of the options from `get_scale_options` that have matching scales in all other roles.
         """
 
-        def shapes_intersection(shapes1: List[Dict[str, int]], shapes2: List[Dict[str, int]]):
-            return [s1 for s1 in shapes1 if any(eq_shapes(s1, s2) for s2 in shapes2)]
+        def shapes_intersection(shapes1: Set[ClearscaleShape], shapes2: Set[ClearscaleShape]):
+            return {s1 for s1 in shapes1 if any(eq_shapes(s1, s2) for s2 in shapes2)}
 
         # Checking if ready etc. shouldn't be necessary here because this should only be called
         # while building the scale dropdown (by which point everything should be ready).
-        scale_shapes_per_role: List[List[OrderedDict[str, int]]] = [
+        scale_shapes_per_role: List[Set[ClearscaleShape]] = [
             (
-                list(role_slot.value.scales.values())
+                set(role_slot.value.scales.keys_by_shape)
                 if role_slot.value.scales
-                else [dict(zip(role_slot.value.axistags.keys(), role_slot.value.laneShape))]
+                else {ClearscaleShape(zip(role_slot.value.axistags.keys(), role_slot.value.laneShape))}
             )
             for role_slot in self._op.DatasetGroupOut[laneIndex]
             if role_slot.ready()
@@ -304,8 +300,8 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
 
         scale_options: Multiscale = self._op.DatasetGroupOut[laneIndex][self._roleIndex].value.scales
         indices_of_common_scales = []
-        for i, shape in enumerate(reversed(scale_options.values())):
-            if any(eq_shapes(shape, common_shape) for common_shape in common_scale_shapes):
+        for i, scale in enumerate(reversed(scale_options.values())):
+            if any(eq_shapes(scale.shape, common_shape) for common_shape in common_scale_shapes):
                 indices_of_common_scales.append(i)
         return indices_of_common_scales
 

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -23,11 +23,11 @@ from collections import OrderedDict
 from functools import reduce
 from typing import List, Set
 
+from clearscale import Scale, Multiscale, Shape as ClearscaleShape
 from qtpy.QtCore import Qt, QAbstractItemModel, QModelIndex
 from ilastik.utility import bind
 from ilastik.utility.gui import ThreadRouter, threadRouted
 from lazyflow.utility.helpers import bigintprod, eq_shapes
-from lazyflow.utility.io_util.clearscale import Scale, Multiscale, Shape as ClearscaleShape
 from .opDataSelection import DatasetInfo
 from .dataLaneSummaryTableModel import rowOfButtonsProxy
 

--- a/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
+++ b/ilastik/applets/dataSelection/datasetDetailedInfoTableModel.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from functools import reduce
 from typing import List, Set
 
-from clearscale import Scale, Multiscale, Shape as ClearscaleShape
+import clearscale
 from qtpy.QtCore import Qt, QAbstractItemModel, QModelIndex
 from ilastik.utility import bind
 from ilastik.utility.gui import ThreadRouter, threadRouted
@@ -43,7 +43,7 @@ class DatasetColumn:
     NumColumns = 7
 
 
-def _dims_to_display_string(scale: Scale, dtype: type) -> str:
+def _dims_to_display_string(scale: clearscale.Scale, dtype: type) -> str:
     """Generate labels to put into the scale combobox / to display in the table.
     Aim: XYZ dimensions + data size, but in original axis order"""
     xyz_shape = scale.shape.without_axes_except("xyz").to_list()
@@ -282,23 +282,23 @@ class DatasetDetailedInfoTableModel(QAbstractItemModel):
         Return indices of the options from `get_scale_options` that have matching scales in all other roles.
         """
 
-        def shapes_intersection(shapes1: Set[ClearscaleShape], shapes2: Set[ClearscaleShape]):
+        def shapes_intersection(shapes1: Set[clearscale.Shape], shapes2: Set[clearscale.Shape]):
             return {s1 for s1 in shapes1 if any(eq_shapes(s1, s2) for s2 in shapes2)}
 
         # Checking if ready etc. shouldn't be necessary here because this should only be called
         # while building the scale dropdown (by which point everything should be ready).
-        scale_shapes_per_role: List[Set[ClearscaleShape]] = [
+        scale_shapes_per_role: List[Set[clearscale.Shape]] = [
             (
                 set(role_slot.value.scales.keys_by_shape)
                 if role_slot.value.scales
-                else {ClearscaleShape(zip(role_slot.value.axistags.keys(), role_slot.value.laneShape))}
+                else {clearscale.Shape(zip(role_slot.value.axistags.keys(), role_slot.value.laneShape))}
             )
             for role_slot in self._op.DatasetGroupOut[laneIndex]
             if role_slot.ready()
         ]
         common_scale_shapes = reduce(shapes_intersection, scale_shapes_per_role)
 
-        scale_options: Multiscale = self._op.DatasetGroupOut[laneIndex][self._roleIndex].value.scales
+        scale_options: clearscale.Multiscale = self._op.DatasetGroupOut[laneIndex][self._roleIndex].value.scales
         indices_of_common_scales = []
         for i, scale in enumerate(reversed(scale_options.values())):
             if any(eq_shapes(scale.shape, common_shape) for common_shape in common_scale_shapes):

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -618,19 +618,19 @@ class MultiscaleUrlDatasetInfo(DatasetInfo):
         return super().from_h5_group(group, params)
 
     def get_scale_matching_shape(self, target_shape: Dict[str, int]) -> str:
-        for scale, shape in self.scales.items():
-            if eq_shapes(shape, target_shape):
-                return scale
+        for scale_key, scale in self.scales.items():
+            if eq_shapes(scale.shape, target_shape):
+                return scale_key
         raise DatasetConstraintError("DataSelection", f"No scale matches shape {target_shape}")
 
     def has_scale_matching_shape(self, target_shape: Dict[str, int]) -> bool:
-        return any(eq_shapes(shape, target_shape) for shape in self.scales.values())
+        return any(eq_shapes(scale.shape, target_shape) for scale in self.scales.values())
 
     def switch_to_scale_with_shape(self, target_shape: Dict[str, int]):
-        for scale, shape in self.scales.items():
-            if eq_shapes(shape, target_shape):
-                self.working_scale = scale
-                self.laneShape = tuple(self.scales[scale].values())
+        for scale_key, scale in self.scales.items():
+            if eq_shapes(scale.shape, target_shape):
+                self.working_scale = scale_key
+                self.laneShape = scale.shape.to_tuple()
                 return
         raise DatasetConstraintError("DataSelection", f"No scale matches shape {target_shape}")
 

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -31,6 +31,7 @@ from numbers import Number
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional, Union, Callable, Set
 
+import clearscale
 import h5py
 import numpy
 import vigra
@@ -52,7 +53,7 @@ from lazyflow.operators.ioOperators import OpStreamingH5N5Reader
 from lazyflow.operators.opArrayPiper import OpArrayPiper
 from lazyflow.operators.opReorderAxes import OpReorderAxes
 from lazyflow.utility.helpers import get_default_axisordering, eq_shapes
-from lazyflow.utility.io_util.multiscaleStore import DEFAULT_SCALE_KEY, Multiscale
+from lazyflow.utility.io_util.multiscaleStore import DEFAULT_SCALE_KEY
 from lazyflow.utility.pathHelpers import splitPath, globH5N5, globNpz, PathComponents, uri_to_Path
 
 
@@ -104,7 +105,7 @@ class DatasetInfo(ABC):
         laneDtype: type,
         default_tags: AxisTags,  # inferred from dataset or another data lane
         axistags: AxisTags = None,  # given through datasetInfoEditorWidget or cmdline
-        scales: Multiscale = None,
+        scales: clearscale.Multiscale = None,
         allowLabels: bool = True,
         subvolume_roi: Tuple = None,
         display_mode: str = "default",

--- a/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
+++ b/lazyflow/operators/ioOperators/opOMEZarrMultiscaleReader.py
@@ -69,8 +69,6 @@ class OpOMEZarrMultiscaleReader(Operator):
         # Many public OME-Zarr datasets are chunked as full xy slices,
         # so orthoviews lead to downloading the entire dataset.
         self.Output.meta.prefer_2d = True
-        # Add OME-Zarr metadata to slot so that it can be ported over to an export
-        self.Output.meta.ome_zarr_translations = self._store.ome_zarr_translations
 
     def execute(self, slot, subindex, roi, result):
         result[...] = self._store.request(roi, self.Output.meta.active_scale)

--- a/lazyflow/utility/helpers.py
+++ b/lazyflow/utility/helpers.py
@@ -22,7 +22,7 @@
 
 from functools import reduce
 from operator import mul
-from typing import Iterable, Tuple, Type, Union, Dict
+from typing import Iterable, Tuple, Type, Union, Mapping
 import sys
 import numbers
 import numpy
@@ -165,8 +165,10 @@ def get_ram_per_element(dtype: Union[Type[object], numpy.dtype]) -> int:
         return sys.getsizeof(None)
 
 
-def eq_shapes(test: Dict[str, int], ref: Dict[str, int]) -> bool:
+def eq_shapes(test: Mapping[str, int], ref: Mapping[str, int]) -> bool:
     """Check if two tagged shapes are equal. Ignore channel. Additional singleton axes are ok."""
+    if hasattr(test, "without_axes") and hasattr(ref, "without_axes"):
+        return test.without_axes("c").without_singletons() == ref.without_axes("c").without_singletons()
     common_axes = set(test.keys()) & set(ref.keys())
     extra_axes = set(test.keys()) ^ set(ref.keys())
     common_match = all(test[a] == ref[a] for a in common_axes if a != "c")

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -233,10 +233,10 @@ class OMEZarrTranslations:
         if dataset is None and self.multiscale_translation is None:
             return Translation.identity(axiskeys)
         if dataset is None:
-            return Translation(self.multiscale_translation).reorder(axiskeys)
+            return Translation(self.multiscale_translation).with_axes(axiskeys)
         if self.multiscale_translation is None:
-            return Translation(dataset).reorder(axiskeys)
-        return (Translation(self.multiscale_translation) + Translation(dataset)).reorder(axiskeys)
+            return Translation(dataset).with_axes(axiskeys)
+        return (Translation(self.multiscale_translation) + Translation(dataset)).with_axes(axiskeys)
 
 
 def _axistags_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> vigra.AxisTags:

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -25,6 +25,8 @@ import os
 from typing import Dict, List, Optional, Literal, Tuple, Any
 from urllib.parse import unquote_to_bytes
 
+from clearscale import Multiscale
+from clearscale.ome_zarr import make_fake_shapes
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -35,8 +37,6 @@ from zarr.storage import FSStore, LRUStoreCache
 
 from lazyflow import rtype
 from lazyflow.utility import Timer, Memory
-from lazyflow.utility.io_util.clearscale import Multiscale
-from lazyflow.utility.io_util.clearscale.ome_zarr import make_fake_shapes
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional, Literal, Tuple, Any
 from urllib.parse import unquote_to_bytes
 
 from clearscale import Multiscale
-from clearscale.ome_zarr import make_fake_shapes
+from clearscale.ome_zarr import make_proportional_shapes
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -281,7 +281,7 @@ def _fetch_and_validate_ome_zarr_spec(uri: str, sort_uri: Optional[str] = None) 
     valid_ms = []
     for ms_dict in spec["multiscales"]:
         try:
-            valid_ms.append(Multiscale.from_ome_zarr(ms_dict, get_shape=make_fake_shapes(ms_dict)))
+            valid_ms.append(Multiscale.from_ome_zarr(ms_dict, shape_source=make_proportional_shapes(ms_dict)))
         except ValueError:
             continue
     if not valid_ms:
@@ -389,7 +389,7 @@ class OMEZarrStore(MultiscaleStore):
                 }
             return zarray.shape
 
-        multiscale = Multiscale.from_ome_zarr(self._multiscale_spec, get_shape=get_shape_keep_zarray)
+        multiscale = Multiscale.from_ome_zarr(self._multiscale_spec, shape_source=get_shape_keep_zarray)
         dtype = next(iter(self._scale_data.values()))["zarray"].dtype.type
         axistags = vigra.defaultAxistags("".join(multiscale.axes()))
         super().__init__(

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -39,7 +39,8 @@ from zarr.storage import FSStore, LRUStoreCache
 
 from lazyflow import rtype
 from lazyflow.utility import Timer, Memory
-from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit
+from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit, Translation
+from lazyflow.utility.io_util.clearscale._axis_values import Axes
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)
@@ -226,6 +227,16 @@ class OMEZarrTranslations:
             multiscale_translation=multiscale_translation,
             dataset_translations=dataset_translations,
         )
+
+    def resolve_at_scale(self, scale: str, axiskeys: Axes) -> Translation:
+        dataset = self.dataset_translations.get(scale)
+        if dataset is None and self.multiscale_translation is None:
+            return Translation.identity(axiskeys)
+        if dataset is None:
+            return Translation(self.multiscale_translation).reorder(axiskeys)
+        if self.multiscale_translation is None:
+            return Translation(dataset).reorder(axiskeys)
+        return (Translation(self.multiscale_translation) + Translation(dataset)).reorder(axiskeys)
 
 
 def _axistags_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> vigra.AxisTags:

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -38,9 +38,9 @@ from zarr.errors import ArrayNotFoundError
 from zarr.storage import FSStore, LRUStoreCache
 
 from lazyflow import rtype
-from lazyflow.base import Axiskey
 from lazyflow.utility import Timer, Memory
-from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY, Scale
+from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit
+from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +248,7 @@ def _axistags_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> vigra.AxisTags
     return vigra.defaultAxistags("".join(axis_keys))
 
 
-def _units_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> OrderedDict[Axiskey, str]:
+def _units_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> Unit:
     axis_keys = _axistags_from_multiscale(multiscale).keys()
     if "axes" in multiscale and "name" in multiscale["axes"][0]:
         # v0.4: Each axis entry may contain a unit key
@@ -256,10 +256,10 @@ def _units_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> OrderedDict[Axisk
     else:
         # v0.1 to v0.3 did not provide a standard for keeping unit metadata
         units = ["" for _ in axis_keys]
-    return OrderedDict(zip(axis_keys, units))
+    return Unit(zip(axis_keys, units))
 
 
-def _resolution_from_multiscale(multiscale: OME_ZARR_MULTISCALE, dataset: str) -> OrderedDict[Axiskey, float]:
+def _spacing_from_multiscale(multiscale: OME_ZARR_MULTISCALE, dataset: str) -> Spacing:
     def has_valid_resolution(transforms: Union[None, ValidTransformations, InvalidTransformationError]):
         return isinstance(transforms, tuple) and transforms[0].values and len(transforms[0].values) == len(axis_keys)
 
@@ -271,8 +271,7 @@ def _resolution_from_multiscale(multiscale: OME_ZARR_MULTISCALE, dataset: str) -
     dataset_transforms = _validate_transforms(dataset_spec.get("coordinateTransformations"))
     if not has_valid_resolution(dataset_transforms):
         logger.warning(f"Missing or invalid pixel resolution metadata for dataset={dataset_spec['path']}.")
-        default_resolution = [0.0 for _ in axis_keys]
-        return OrderedDict(zip(axis_keys, default_resolution))
+        return Spacing.fromkeys(axis_keys)
 
     dataset_resolution = dataset_transforms[0].values
 
@@ -280,11 +279,11 @@ def _resolution_from_multiscale(multiscale: OME_ZARR_MULTISCALE, dataset: str) -
     if not has_valid_resolution(multiscale_transforms):
         if multiscale_transforms is not None:
             logger.warning("Pixel resolution metadata at pyramid level was invalid.")
-        return OrderedDict(zip(axis_keys, dataset_resolution))
+        return Spacing(zip(axis_keys, dataset_resolution))
     else:
         multiscale_resolution = multiscale_transforms[0].values
         combined_resolution = numpy.array(multiscale_resolution) * numpy.array(dataset_resolution)
-        return OrderedDict(zip(axis_keys, combined_resolution))
+        return Spacing(zip(axis_keys, combined_resolution))
 
 
 def _get_multiscale_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> OME_ZARR_MULTISCALE:
@@ -612,9 +611,9 @@ class OMEZarrStore(MultiscaleStore):
                     ) from e
                 dtype = zarray.dtype.type
                 scale_metadata[scale_key] = Scale(
-                    shape=OrderedDict(zip([tag.key for tag in axistags], zarray.shape)),
-                    resolution=_resolution_from_multiscale(self._multiscale_spec, scale_key),
-                    units=_units_from_multiscale(self._multiscale_spec),
+                    shape=Shape(zip([tag.key for tag in axistags], zarray.shape)),
+                    spacing=_spacing_from_multiscale(self._multiscale_spec, scale_key),
+                    unit=_units_from_multiscale(self._multiscale_spec),
                 )
                 self._scale_data[scale_key] = {
                     "zarray": zarray,

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -18,13 +18,11 @@
 # on the ilastik web site at:
 # 		   http://ilastik.org/license.html
 ###############################################################################
-from dataclasses import dataclass
 import json
 import logging
 import math
 import os
-from collections import OrderedDict
-from typing import Dict, List, Optional, Union, Literal, Tuple, Any, Sequence
+from typing import Dict, List, Optional, Union, Literal, Tuple, Any
 from urllib.parse import unquote_to_bytes
 
 import jsonschema
@@ -37,9 +35,8 @@ from zarr.errors import ArrayNotFoundError
 from zarr.storage import FSStore, LRUStoreCache
 
 from lazyflow import rtype
-from lazyflow.base import Axiskey
 from lazyflow.utility import Timer, Memory
-from lazyflow.utility.io_util.clearscale import Translation, Multiscale
+from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)
@@ -108,59 +105,6 @@ class NotAnOMEZarrMultiscale(ValueError):
 
 class ScaleNotFoundError(KeyError):
     pass
-
-
-@dataclass(frozen=True)
-class OMEZarrTranslations:
-    """
-    Used for porting translation metadata from an OME-Zarr input to export.
-    Consider renaming/generalising this if using slot.meta.ome_zarr_translations for other purposes.
-    """
-
-    multiscale_translation: Optional[OrderedDict[Literal["t", "c", "z", "y", "x"], float]]  # {axis: translation}
-    dataset_translations: OrderedDict[
-        str, Optional[OrderedDict[Literal["t", "c", "z", "y", "x"], float]]
-    ]  # { scale_key: {axis: translation} }
-
-    @classmethod
-    def from_multiscale_spec(
-        cls, multiscale_spec: OME_ZARR_MULTISCALE, axes: Sequence[Axiskey]
-    ) -> "OMEZarrTranslations":
-        def get_translation(
-            transforms: Union[None, List[Dict[str, Any]]],
-        ) -> Union[OrderedDict[Literal["t", "c", "z", "y", "x"], float], None]:
-            if not transforms or not isinstance(transforms, list) or len(transforms) != 2:
-                # Translation transform must be second transform if it exists, otherwise nonsense
-                return None
-            tl = transforms[1]
-            if "type" not in tl or tl["type"] != "translation" or "translation" not in tl or not tl["translation"]:
-                return None
-            tl_values = tl["translation"]
-            if any(not isinstance(value, float) for value in tl_values):
-                return None
-            return OrderedDict(zip(axes, tl_values))
-
-        multiscale_translation = get_translation(multiscale_spec.get("coordinateTransformations"))
-        dataset_translations = OrderedDict(
-            [
-                (scale["path"], get_translation(scale.get("coordinateTransformations", [])))
-                for scale in multiscale_spec["datasets"]
-            ]
-        )
-        return cls(
-            multiscale_translation=multiscale_translation,
-            dataset_translations=dataset_translations,
-        )
-
-    def resolve_at_scale(self, scale: str, axiskeys: Sequence[Axiskey]) -> Translation:
-        dataset = self.dataset_translations.get(scale)
-        if dataset is None and self.multiscale_translation is None:
-            return Translation.identity(axiskeys)
-        if dataset is None:
-            return Translation(self.multiscale_translation).with_axes(axiskeys)
-        if self.multiscale_translation is None:
-            return Translation(dataset).with_axes(axiskeys)
-        return (Translation(self.multiscale_translation) + Translation(dataset)).with_axes(axiskeys)
 
 
 def _get_multiscale_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> OME_ZARR_MULTISCALE:
@@ -496,7 +440,6 @@ class OMEZarrStore(MultiscaleStore):
         multiscale = Multiscale.from_ome_zarr(self._multiscale_spec, get_shape=get_shape_keep_zarray)
         dtype = next(iter(self._scale_data.values()))["zarray"].dtype.type
         axistags = vigra.defaultAxistags("".join(multiscale.axes()))
-        self.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(self._multiscale_spec, multiscale.axes())
         super().__init__(
             uri=uri,
             dtype=dtype,

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -22,10 +22,9 @@ import json
 import logging
 import math
 import os
-from typing import Dict, List, Optional, Union, Literal, Tuple, Any
+from typing import Dict, List, Optional, Literal, Tuple, Any
 from urllib.parse import unquote_to_bytes
 
-import jsonschema
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -37,62 +36,17 @@ from zarr.storage import FSStore, LRUStoreCache
 from lazyflow import rtype
 from lazyflow.utility import Timer, Memory
 from lazyflow.utility.io_util.clearscale import Multiscale
+from lazyflow.utility.io_util.clearscale.ome_zarr import make_fake_shapes
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)
 
 ZARR_EXT = ".zarr"
 
-OME_ZARR_DATASET = Dict[Literal["path", "coordinateTransformations"], Any]  # single dataset (= scale)
-OME_ZARR_MULTISCALE = Dict[  # single multiscales entry of a json-validated OME-Zarr zattrs (any version)
-    # The spec allows for multiple multiscales, but in practice we only ever see one.
-    Literal["axes", "datasets", "version", "coordinateTransformations", "name"],
-    Union[List[Dict], List[OME_ZARR_DATASET], str],
-]
-OME_ZARR_SPEC = Dict[Literal["multiscales"], List[OME_ZARR_MULTISCALE]]  # json-validated OME-Zarr zattrs (any version)
-MULTISCALE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "multiscales": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "axes": {
-                        "type": "array",
-                        "minItems": 2,
-                        "maxItems": 5,
-                        "items": {
-                            "oneOf": [
-                                {"type": "string"},
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {"type": "string"},
-                                    },
-                                    "required": ["name"],
-                                },
-                            ]
-                        },
-                    },
-                    "datasets": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                            "type": "object",
-                            "properties": {"path": {"type": "string"}},
-                            "required": ["path"],
-                        },
-                    },
-                    "version": {"type": "string"},
-                },
-                "required": ["datasets", "version"],
-            },
-        },
-    },
-    "required": ["multiscales"],
-}
+OME_ZARR_MULTISCALE = Dict[Literal["axes", "datasets", "version", "coordinateTransformations"], Any]
+"""Single entry in OME-Zarr attrs['multiscales'] list.
+The spec allowed multiple entries, but in practice there is only ever one."""
+OME_ZARR_SPEC = Dict[Literal["multiscales"], List[OME_ZARR_MULTISCALE]]
 
 
 class NoOMEZarrMetaFound(ValueError):
@@ -321,19 +275,17 @@ def _fetch_and_validate_ome_zarr_spec(uri: str, sort_uri: Optional[str] = None) 
     # Found .zattrs, but what kind of .zattrs?
     _check_non_multiscale_specs(spec, uri, sort_uri)
 
-    try:
-        jsonschema.validate(spec, MULTISCALE_SCHEMA)
-    except jsonschema.ValidationError as e:
-        err_msg = (
-            "Metadata for this store did not match OME-Zarr spec, "
-            "or reports no multiscale datasets. Details below."
-            f"\nMetadata read from {uri}/.zattrs."
-            f"\n\nProblematic metadata entry: {e.json_path}"
-            f"\nProblem: {e.message}"
-            f"\nRequired properties: {e.schema}"
-            f"\nFull metadata received:\n{spec}"
-        )
-        raise NoOMEZarrMetaFound(err_msg)
+    if "multiscales" not in spec or not spec["multiscales"]:
+        raise NoOMEZarrMetaFound(f"No 'multiscales' metadata found in: {spec!r}")
+
+    valid_ms = []
+    for ms_dict in spec["multiscales"]:
+        try:
+            valid_ms.append(Multiscale.from_ome_zarr(ms_dict, get_shape=make_fake_shapes(ms_dict)))
+        except ValueError:
+            continue
+    if not valid_ms:
+        raise NoOMEZarrMetaFound(f"No valid multiscale entry found in: {spec['multiscales']!r}")
     return spec
 
 

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -28,7 +28,6 @@ from typing import Dict, List, Optional, Union, Literal, Tuple, Any, Sequence
 from urllib.parse import unquote_to_bytes
 
 import jsonschema
-import numpy
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -38,9 +37,9 @@ from zarr.errors import ArrayNotFoundError
 from zarr.storage import FSStore, LRUStoreCache
 
 from lazyflow import rtype
+from lazyflow.base import Axiskey
 from lazyflow.utility import Timer, Memory
-from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit, Translation
-from lazyflow.utility.io_util.clearscale._axis_values import Axes
+from lazyflow.utility.io_util.clearscale import Translation, Multiscale
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__name__)
@@ -107,87 +106,8 @@ class NotAnOMEZarrMultiscale(ValueError):
     pass
 
 
-class InvalidTransformationError(ValueError):
-    pass
-
-
 class ScaleNotFoundError(KeyError):
     pass
-
-
-@dataclass(frozen=True)
-class OMEZarrCoordinateTransformation:
-    """Used by OME-Zarr export to adjust export metadata according to input."""
-
-    type: Literal["scale", "translation"]
-    values: Optional[List[float]]
-
-    @classmethod
-    def from_json(cls, json_data: Dict) -> "OMEZarrCoordinateTransformation":
-        """Expected dicts look like
-        {
-          "type": Literal["scale", "translation"]
-          and EITHER "scale": List[number] OR "translation": List[number]
-        }
-        Unfortunately, the spec is internally inconsistent, so there is a chance that we may encounter
-        a coordinateTransformation with a "path" key instead of "scale" or "translation"; and possibly
-        coordinateTransformations with "type": "identity".
-        Afaik, none of the more popular converters/writers do this.
-        """
-        if (
-            json_data["type"] not in ("scale", "translation")
-            or ("scale" not in json_data and "translation" not in json_data)
-            or "path" in json_data
-        ):
-            raise InvalidTransformationError()
-        # Could raise KeyError for real nonsense like {"type": "scale", "translation": [0, 0]}
-        return cls(type=json_data["type"], values=json_data[json_data["type"]])
-
-
-# tuple(scale_transform, Optional[translation_transform])
-ValidTransformations = Tuple[OMEZarrCoordinateTransformation, Optional[OMEZarrCoordinateTransformation]]
-TransformationsOrError = Union[ValidTransformations, InvalidTransformationError]
-
-
-def _validate_transforms(
-    coordinate_transformations: Optional[List[Dict[str, Union[str, List[float]]]]],
-) -> Union[None, ValidTransformations, InvalidTransformationError]:
-    """
-    Resolves the OME-Zarr spec's inconsistency in the coordinateTransformations field.
-    Avoids raising errors because valid metadata are not required to load and work with the data.
-    Distinguishes between None and invalid transformations so that caller can warn on the latter.
-    Returns:
-    - None if input was None (allowed for multiscale_transformations)
-    - Tuple of scale transform and optionally translation transform if valid
-    - InvalidTransformationError if invalid (e.g. not None but also no scale transform present)
-    Inattentive writers might produce invalid transforms, depending on what part of the spec they read.
-    The Transformations spec [1] allows for "identity" transforms and arbitrary numbers of transforms,
-    but the Multiscales spec [2] only allows exactly one "scale", optionally followed by one "translation"
-    transform.
-    The "official" validator's schema [3] implements neither of these rules exactly :) It instead allows
-    for exactly one "scale" transform, plus an arbitrary number of "translation" transforms, in any order.
-    But this, plus the example at the start of the OME-Zarr spec, make a clear enough indicator that
-    "one scale + one optional translation" is the convention, and all public datasets conform to this.
-    To be graceful, we'll accept the first scale and translation.
-    [1] https://ngff.openmicroscopy.org/latest/index.html#trafo-md
-    [2] https://ngff.openmicroscopy.org/latest/index.html#multiscale-md
-    [3] https://github.com/ome/ngff/blob/1383ce6218539baf9fe4350c46d992f2dbfe7af1/0.4/schemas/image.schema#L167
-    """
-    if coordinate_transformations is None:
-        return None
-    if not isinstance(coordinate_transformations, list) or not coordinate_transformations:
-        return InvalidTransformationError()
-    scale_transform = translation_transform = None
-    for t in coordinate_transformations:
-        try:
-            transform = OMEZarrCoordinateTransformation.from_json(t)
-        except (InvalidTransformationError, KeyError):
-            continue
-        if scale_transform is None and transform.type == "scale":
-            scale_transform = transform
-        if translation_transform is None and transform.type == "translation":
-            translation_transform = transform
-    return (scale_transform, translation_transform) if scale_transform else InvalidTransformationError()
 
 
 @dataclass(frozen=True)
@@ -203,23 +123,27 @@ class OMEZarrTranslations:
     ]  # { scale_key: {axis: translation} }
 
     @classmethod
-    def from_multiscale_spec(cls, multiscale_spec: OME_ZARR_MULTISCALE) -> "OMEZarrTranslations":
+    def from_multiscale_spec(
+        cls, multiscale_spec: OME_ZARR_MULTISCALE, axes: Sequence[Axiskey]
+    ) -> "OMEZarrTranslations":
         def get_translation(
-            transforms: Union[None, ValidTransformations, InvalidTransformationError],
+            transforms: Union[None, List[Dict[str, Any]]],
         ) -> Union[OrderedDict[Literal["t", "c", "z", "y", "x"], float], None]:
-            axes = [tag.key for tag in _axistags_from_multiscale(multiscale_spec)]
-            translation = None
-            if transforms and isinstance(transforms, tuple) and transforms[1]:
-                translation = OrderedDict(zip(axes, transforms[1].values))
-            return translation
+            if not transforms or not isinstance(transforms, list) or len(transforms) != 2:
+                # Translation transform must be second transform if it exists, otherwise nonsense
+                return None
+            tl = transforms[1]
+            if "type" not in tl or tl["type"] != "translation" or "translation" not in tl or not tl["translation"]:
+                return None
+            tl_values = tl["translation"]
+            if any(not isinstance(value, float) for value in tl_values):
+                return None
+            return OrderedDict(zip(axes, tl_values))
 
-        multiscale_translation = get_translation(_validate_transforms(multiscale_spec.get("coordinateTransformations")))
+        multiscale_translation = get_translation(multiscale_spec.get("coordinateTransformations"))
         dataset_translations = OrderedDict(
             [
-                (
-                    scale["path"],
-                    get_translation(_validate_transforms(scale.get("coordinateTransformations", []))),
-                )
+                (scale["path"], get_translation(scale.get("coordinateTransformations", [])))
                 for scale in multiscale_spec["datasets"]
             ]
         )
@@ -228,7 +152,7 @@ class OMEZarrTranslations:
             dataset_translations=dataset_translations,
         )
 
-    def resolve_at_scale(self, scale: str, axiskeys: Axes) -> Translation:
+    def resolve_at_scale(self, scale: str, axiskeys: Sequence[Axiskey]) -> Translation:
         dataset = self.dataset_translations.get(scale)
         if dataset is None and self.multiscale_translation is None:
             return Translation.identity(axiskeys)
@@ -237,64 +161,6 @@ class OMEZarrTranslations:
         if self.multiscale_translation is None:
             return Translation(dataset).with_axes(axiskeys)
         return (Translation(self.multiscale_translation) + Translation(dataset)).with_axes(axiskeys)
-
-
-def _axistags_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> vigra.AxisTags:
-    if "axes" in multiscale:
-        ome_axes = multiscale["axes"]
-        if "name" in ome_axes[0]:
-            # v0.4: spec["axes"] requires name, recommends type and unit; like:
-            # [
-            #   {'name': 'c', 'type': 'channel'},
-            #   {'name': 'y', 'type': 'space', 'unit': 'nanometer'},
-            #   {'name': 'x', 'type': 'space', 'unit': 'nanometer'}
-            # ]
-            axis_keys = [d["name"] for d in ome_axes]
-        else:
-            # v0.3: ['t', 'c', 'y', 'x']
-            axis_keys = ome_axes
-    else:
-        # v0.1 and v0.2 did not allow variable axes
-        axis_keys = ["t", "c", "z", "y", "x"]
-    return vigra.defaultAxistags("".join(axis_keys))
-
-
-def _units_from_multiscale(multiscale: OME_ZARR_MULTISCALE) -> Unit:
-    axis_keys = _axistags_from_multiscale(multiscale).keys()
-    if "axes" in multiscale and "name" in multiscale["axes"][0]:
-        # v0.4: Each axis entry may contain a unit key
-        units = [a["unit"] if "unit" in a else "" for a in multiscale["axes"]]
-    else:
-        # v0.1 to v0.3 did not provide a standard for keeping unit metadata
-        units = ["" for _ in axis_keys]
-    return Unit(zip(axis_keys, units))
-
-
-def _spacing_from_multiscale(multiscale: OME_ZARR_MULTISCALE, dataset: str) -> Spacing:
-    def has_valid_resolution(transforms: Union[None, ValidTransformations, InvalidTransformationError]):
-        return isinstance(transforms, tuple) and transforms[0].values and len(transforms[0].values) == len(axis_keys)
-
-    axis_keys = _axistags_from_multiscale(multiscale).keys()
-    try:
-        dataset_spec = next(d for d in multiscale["datasets"] if d["path"] == dataset)
-    except StopIteration:
-        raise ValueError(f'Dataset "{dataset}" not defined in OME-Zarr "datasets" metadata:\n{multiscale["datasets"]}')
-    dataset_transforms = _validate_transforms(dataset_spec.get("coordinateTransformations"))
-    if not has_valid_resolution(dataset_transforms):
-        logger.warning(f"Missing or invalid pixel resolution metadata for dataset={dataset_spec['path']}.")
-        return Spacing.fromkeys(axis_keys)
-
-    dataset_resolution = dataset_transforms[0].values
-
-    multiscale_transforms = _validate_transforms(multiscale.get("coordinateTransformations"))
-    if not has_valid_resolution(multiscale_transforms):
-        if multiscale_transforms is not None:
-            logger.warning("Pixel resolution metadata at pyramid level was invalid.")
-        return Spacing(zip(axis_keys, dataset_resolution))
-    else:
-        multiscale_resolution = multiscale_transforms[0].values
-        combined_resolution = numpy.array(multiscale_resolution) * numpy.array(dataset_resolution)
-        return Spacing(zip(axis_keys, combined_resolution))
 
 
 def _get_multiscale_for_dataset(ome_spec: OME_ZARR_SPEC, dataset_subpath: str) -> OME_ZARR_MULTISCALE:
@@ -597,49 +463,47 @@ class OMEZarrStore(MultiscaleStore):
                 f"\n\nMultiscale store found at: {self.base_uri}"
                 f"\n\nFull metadata: {self._ome_spec}"
             )
-        axistags = _axistags_from_multiscale(self._multiscale_spec)
-        datasets = self._multiscale_spec["datasets"]
         uncached_store = _ensure_connection_and_get_store(self.base_uri)
         # There is an additional block cache in front of OpOMEZarrMultiscaleReader, so e.g. when
         # the user scrolls across z back and forth, this does not trigger requests to the store.
         # But blocks can be misaligned with file size in the store. This cache can prevent downloading
         # the same file repeatedly for multiple blocks.
         self._store = LRUStoreCache(uncached_store, max_size=_get_zarr_cache_max_size())
-        dtype = None
-        scale_metadata = OrderedDict()  # Becomes slot metadata -> must be serializable (no ZarrArray allowed)
+
         self._scale_data = {}
-        for scale in datasets:  # OME-Zarr spec requires datasets ordered from high to low resolution
+
+        def get_shape_keep_zarray(path):
+            """Provide shape for the metadata collection (not contained in _multiscale_spec).
+            This requires loading a ZarrArray at the path.
+            Build internal cache of data objects along the way to avoid duplicate requests."""
             with Timer() as timer:
-                scale_key = scale["path"]
-                # Loading a ZarrArray at this path is necessary to obtain the scale dimensions for the GUI
                 try:
-                    zarray = ZarrArray(store=self._store, path=scale_key)
+                    zarray = ZarrArray(store=self._store, path=path)
                 except ArrayNotFoundError as e:
                     raise ValueError(
                         f"Malformed OME-Zarr store at {self.base_uri}: "
-                        f'Metadata points to a nonexistent array at sub-path "{scale_key}".'
+                        f'Metadata points to a nonexistent array at sub-path "{path}".'
                         f"\nTrying to load multiscale:\n{self._multiscale_spec}"
                     ) from e
-                dtype = zarray.dtype.type
-                scale_metadata[scale_key] = Scale(
-                    shape=Shape(zip([tag.key for tag in axistags], zarray.shape)),
-                    spacing=_spacing_from_multiscale(self._multiscale_spec, scale_key),
-                    unit=_units_from_multiscale(self._multiscale_spec),
-                )
-                self._scale_data[scale_key] = {
+                logger.info(f"Initializing scale {path} took {timer.seconds()*1000} ms.")
+                self._scale_data[path] = {
                     "zarray": zarray,
                     "chunks": zarray.chunks,
                     "shape": zarray.shape,
                 }
-                logger.info(f"Initializing scale {scale_key} took {timer.seconds()*1000} ms.")
-        self.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(self._multiscale_spec)
+            return zarray.shape
+
+        multiscale = Multiscale.from_ome_zarr(self._multiscale_spec, get_shape=get_shape_keep_zarray)
+        dtype = next(iter(self._scale_data.values()))["zarray"].dtype.type
+        axistags = vigra.defaultAxistags("".join(multiscale.axes()))
+        self.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(self._multiscale_spec, multiscale.axes())
         super().__init__(
             uri=uri,
             dtype=dtype,
             axistags=axistags,
-            multiscale=scale_metadata,
-            lowest_resolution_key=list(scale_metadata.keys())[-1],
-            highest_resolution_key=list(scale_metadata.keys())[0],
+            multiscale=multiscale,
+            lowest_resolution_key=list(multiscale.keys())[-1],
+            highest_resolution_key=list(multiscale.keys())[0],
         )
 
     @staticmethod

--- a/lazyflow/utility/io_util/OMEZarrStore.py
+++ b/lazyflow/utility/io_util/OMEZarrStore.py
@@ -25,8 +25,7 @@ import os
 from typing import Dict, List, Optional, Literal, Tuple, Any
 from urllib.parse import unquote_to_bytes
 
-from clearscale import Multiscale
-from clearscale.ome_zarr import make_proportional_shapes
+import clearscale
 import s3fs
 import vigra
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -281,7 +280,11 @@ def _fetch_and_validate_ome_zarr_spec(uri: str, sort_uri: Optional[str] = None) 
     valid_ms = []
     for ms_dict in spec["multiscales"]:
         try:
-            valid_ms.append(Multiscale.from_ome_zarr(ms_dict, shape_source=make_proportional_shapes(ms_dict)))
+            valid_ms.append(
+                clearscale.Multiscale.from_ome_zarr(
+                    ms_dict, shape_source=clearscale.ome_zarr.make_proportional_shapes(ms_dict)
+                )
+            )
         except ValueError:
             continue
     if not valid_ms:
@@ -389,7 +392,7 @@ class OMEZarrStore(MultiscaleStore):
                 }
             return zarray.shape
 
-        multiscale = Multiscale.from_ome_zarr(self._multiscale_spec, shape_source=get_shape_keep_zarray)
+        multiscale = clearscale.Multiscale.from_ome_zarr(self._multiscale_spec, shape_source=get_shape_keep_zarray)
         dtype = next(iter(self._scale_data.values()))["zarray"].dtype.type
         axistags = vigra.defaultAxistags("".join(multiscale.axes()))
         super().__init__(

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -28,7 +28,8 @@ import numpy
 import requests
 import vigra
 
-from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY, Scale
+from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit
+from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__file__)
 
@@ -103,9 +104,9 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
         self.n_channels = self._json_info["num_channels"]
         internal_scales = [
             Scale(
-                shape=OrderedDict(zip("czyx", [self.n_channels] + scale["size"][::-1])),
-                resolution=OrderedDict(zip("czyx", [0.0] + scale["resolution"][::-1])),
-                units=OrderedDict(zip("czyx", ["", "nm", "nm", "nm"])),
+                shape=Shape(zip("czyx", [self.n_channels] + scale["size"][::-1])),
+                spacing=Spacing(zip("czyx", [0.0] + scale["resolution"][::-1])),
+                unit=Unit(zip("czyx", ["", "nm", "nm", "nm"])),
             )
             for scale in self._json_info["scales"]
         ]

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -22,12 +22,12 @@
 import json
 import logging
 
+from clearscale import Multiscale
 import jsonschema
 import numpy
 import requests
 import vigra
 
-from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__file__)

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -21,14 +21,13 @@
 ###############################################################################
 import json
 import logging
-from collections import OrderedDict
 
 import jsonschema
 import numpy
 import requests
 import vigra
 
-from lazyflow.utility.io_util.clearscale import Scale, Shape, Spacing, Unit
+from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.multiscaleStore import MultiscaleStore, DEFAULT_SCALE_KEY
 
 logger = logging.getLogger(__file__)
@@ -102,21 +101,12 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
         highest_resolution_key = self._json_info["scales"][0]["key"]
         self._scales = {scale["key"]: scale for scale in self._json_info["scales"]}
         self.n_channels = self._json_info["num_channels"]
-        internal_scales = [
-            Scale(
-                shape=Shape(zip("czyx", [self.n_channels] + scale["size"][::-1])),
-                spacing=Spacing(zip("czyx", [0.0] + scale["resolution"][::-1])),
-                unit=Unit(zip("czyx", ["", "nm", "nm", "nm"])),
-            )
-            for scale in self._json_info["scales"]
-        ]
-        scale_metadata = OrderedDict(zip(self._scales.keys(), internal_scales))
 
         super().__init__(
             uri=volume_url,
             dtype=dtype,
             axistags=axistags,
-            multiscale=scale_metadata,
+            multiscale=Multiscale.from_precomputed(self._json_info),
             lowest_resolution_key=lowest_resolution_key,
             highest_resolution_key=highest_resolution_key,
         )

--- a/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
+++ b/lazyflow/utility/io_util/RESTfulPrecomputedChunkedVolume.py
@@ -22,7 +22,7 @@
 import json
 import logging
 
-from clearscale import Multiscale
+import clearscale
 import jsonschema
 import numpy
 import requests
@@ -106,7 +106,7 @@ class RESTfulPrecomputedChunkedVolume(MultiscaleStore):
             uri=volume_url,
             dtype=dtype,
             axistags=axistags,
-            multiscale=Multiscale.from_precomputed(self._json_info),
+            multiscale=clearscale.Multiscale.from_precomputed(self._json_info),
             lowest_resolution_key=lowest_resolution_key,
             highest_resolution_key=highest_resolution_key,
         )

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -20,75 +20,29 @@
 ###############################################################################
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import Tuple, Optional
+from typing import Tuple
 
 import numpy
 import vigra
 
-from lazyflow.base import Axiskey, TaggedShape
 from lazyflow.slot import OutputSlot
+from lazyflow.utility.io_util.clearscale import Scale
 
 # See MultiscaleStore docstring for details
-Multiscale = OrderedDict[str, "Scale"]
+Multiscale = OrderedDict[str, Scale]
 DEFAULT_SCALE_KEY = ""
-DEFAULT_DISPLAY_RESOLUTION = 1.0
-DEFAULT_VIGRA_RESOLUTION = 0.0
 
 
-def set_multiscale_meta(slot: OutputSlot, multiscale: Multiscale, active_scale_key: str):
+def set_multiscale_meta(slot: OutputSlot, multiscale: "Multiscale", active_scale_key: str):
     """Updates slot.meta with multiscale, and pixel size for active scale."""
     assert active_scale_key in multiscale, f"Tried to set slot meta for non-existent scale {active_scale_key}"
     assert slot.meta.axistags is not None, "multiscale can not be used to update slot metadata missing axistags."
     active_scale = multiscale[active_scale_key]
     if active_scale.has_pixel_size():
-        for axis, res in active_scale.resolution.items():
-            slot.meta.axistags.setResolution(axis, res)
-        slot.meta.axis_units = active_scale.units
+        active_scale.spacing.to_vigra(slot.meta.axistags)
+        slot.meta.axis_units = dict(active_scale.unit)
     slot.meta.scales = OrderedDict([(key, scale.shape) for key, scale in multiscale.items()])
     slot.meta.active_scale = active_scale_key  # Used by export to correlate export with input scale
-
-
-@dataclass(frozen=True, slots=True)
-class Scale:
-    shape: TaggedShape
-    resolution: Optional[OrderedDict[Axiskey, float]] = None
-    units: Optional[OrderedDict[Axiskey, str]] = None
-
-    def __post_init__(self):
-        if self.resolution is None:
-            object.__setattr__(self, "resolution", OrderedDict([(k, DEFAULT_VIGRA_RESOLUTION) for k in self.shape]))
-        if self.units is None:
-            object.__setattr__(self, "units", OrderedDict([(k, "") for k in self.shape]))
-        if self.shape.keys() != self.resolution.keys() or self.shape.keys() != self.units.keys():
-            raise ValueError(
-                f"Tried to set up invalid scale: Axiskeys differ "
-                f"(shape={self.shape.keys()}, resolution={self.resolution.keys()}, units={self.units.keys()})"
-            )
-
-    def has_pixel_size(self):
-        return any(self.units.values()) or any(res != DEFAULT_VIGRA_RESOLUTION for res in self.resolution.values())
-
-    def to_display_string(self, name=""):
-        shape = ", ".join(f"{axis}: {size}" for axis, size in self.shape.items())
-        name_and_shape = f'"{name}" ({shape})' if name else f"{shape}"
-        pixel_size = ""
-        if self.has_pixel_size():
-            axis_strings = []
-            for axis in self.shape.keys():
-                if axis == "c":
-                    continue
-                res = self.resolution[axis]
-                if res == DEFAULT_VIGRA_RESOLUTION:
-                    res = DEFAULT_DISPLAY_RESOLUTION
-                unit = ""
-                if self.units[axis]:
-                    unit = f" {self.units[axis]}"
-                elif axis != "t":
-                    unit = " px"
-                axis_strings.append(f"{axis}: {res:g}{unit}")
-            pixel_size = " at pixel size: " + ", ".join(axis_strings)
-        return f"{name_and_shape}{pixel_size}"
 
 
 class MultiscaleStore(metaclass=ABCMeta):

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -35,8 +35,8 @@ def set_multiscale_meta(slot: OutputSlot, multiscale: Multiscale, active_scale_k
     assert active_scale_key in multiscale, f"Tried to set slot meta for non-existent scale {active_scale_key}"
     assert slot.meta.axistags is not None, "multiscale can not be used to update slot metadata missing axistags."
     active_scale = multiscale[active_scale_key]
-    if active_scale.has_pixel_size():
-        active_scale.spacing.to_vigra(slot.meta.axistags)
+    if active_scale.has_physical_meta():
+        active_scale.pixel_size.to_vigra(slot.meta.axistags)
         slot.meta.axis_units = dict(active_scale.unit)
     slot.meta.scales = multiscale
     slot.meta.active_scale = active_scale_key  # Used by export to correlate export with input scale

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -21,11 +21,11 @@
 from abc import ABCMeta, abstractmethod
 from typing import Tuple
 
+from clearscale import Multiscale
 import numpy
 import vigra
 
 from lazyflow.slot import OutputSlot
-from lazyflow.utility.io_util.clearscale import Multiscale
 
 DEFAULT_SCALE_KEY = ""
 

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -19,21 +19,18 @@
 # 		   http://ilastik.org/license.html
 ###############################################################################
 from abc import ABCMeta, abstractmethod
-from collections import OrderedDict
 from typing import Tuple
 
 import numpy
 import vigra
 
 from lazyflow.slot import OutputSlot
-from lazyflow.utility.io_util.clearscale import Scale
+from lazyflow.utility.io_util.clearscale import Multiscale
 
-# See MultiscaleStore docstring for details
-Multiscale = OrderedDict[str, Scale]
 DEFAULT_SCALE_KEY = ""
 
 
-def set_multiscale_meta(slot: OutputSlot, multiscale: "Multiscale", active_scale_key: str):
+def set_multiscale_meta(slot: OutputSlot, multiscale: Multiscale, active_scale_key: str):
     """Updates slot.meta with multiscale, and pixel size for active scale."""
     assert active_scale_key in multiscale, f"Tried to set slot meta for non-existent scale {active_scale_key}"
     assert slot.meta.axistags is not None, "multiscale can not be used to update slot metadata missing axistags."
@@ -41,7 +38,7 @@ def set_multiscale_meta(slot: OutputSlot, multiscale: "Multiscale", active_scale
     if active_scale.has_pixel_size():
         active_scale.spacing.to_vigra(slot.meta.axistags)
         slot.meta.axis_units = dict(active_scale.unit)
-    slot.meta.scales = OrderedDict([(key, scale.shape) for key, scale in multiscale.items()])
+    slot.meta.scales = multiscale
     slot.meta.active_scale = active_scale_key  # Used by export to correlate export with input scale
 
 
@@ -69,10 +66,7 @@ class MultiscaleStore(metaclass=ABCMeta):
         :param uri: Location where this store was initialized (as passed to __init__).
         :param dtype: The dataset's numpy dtype.
         :param axistags: vigra.AxisTags describing the dataset's axes.
-        :param multiscale: Dict of scales for GUI and OME-Zarr export, {key: tagged shape}
-            Order from highest to lowest resolution (i.e. largest to smallest shape).
-            Keys: absolute identifiers for each scale as found in the dataset.
-            Axis order of all scales must match axistags.
+        :param multiscale: clearscale.Multiscale holding scale metadata (keys, shapes, pixel sizes, translations)
         :param lowest_resolution_key: Key of the lowest-resolution scale within the multiscale dict.
             This acts as the default scale after load until the user selects a different one.
         :param highest_resolution_key: Used to infer the maximum dataset size, and for legacy HBP-mode projects.
@@ -83,13 +77,6 @@ class MultiscaleStore(metaclass=ABCMeta):
         self.multiscale = multiscale
         self.lowest_resolution_key = lowest_resolution_key
         self.highest_resolution_key = highest_resolution_key
-        scale_keys = list(self.multiscale.keys())
-        assert (
-            self.highest_resolution_key == scale_keys[0] and self.lowest_resolution_key == scale_keys[-1]
-        ), "Multiscale dict must be ordered from highest to lowest resolution (i.e. largest to smallest shape)"
-        assert all(
-            list(scale.shape.keys()) == axistags.keys() for scale in self.multiscale.values()
-        ), "Multiscale values must match given axistags"
 
     @abstractmethod
     def get_shape(self, scale_key: str) -> Tuple[int]:

--- a/lazyflow/utility/io_util/multiscaleStore.py
+++ b/lazyflow/utility/io_util/multiscaleStore.py
@@ -21,7 +21,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import Tuple
 
-from clearscale import Multiscale
+import clearscale
 import numpy
 import vigra
 
@@ -30,7 +30,7 @@ from lazyflow.slot import OutputSlot
 DEFAULT_SCALE_KEY = ""
 
 
-def set_multiscale_meta(slot: OutputSlot, multiscale: Multiscale, active_scale_key: str):
+def set_multiscale_meta(slot: OutputSlot, multiscale: clearscale.Multiscale, active_scale_key: str):
     """Updates slot.meta with multiscale, and pixel size for active scale."""
     assert active_scale_key in multiscale, f"Tried to set slot meta for non-existent scale {active_scale_key}"
     assert slot.meta.axistags is not None, "multiscale can not be used to update slot metadata missing axistags."
@@ -58,7 +58,7 @@ class MultiscaleStore(metaclass=ABCMeta):
         uri: str,
         dtype: numpy.dtype,
         axistags: vigra.AxisTags,
-        multiscale: Multiscale,
+        multiscale: clearscale.Multiscale,
         lowest_resolution_key: str,
         highest_resolution_key: str,
     ):

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -22,7 +22,7 @@
 import logging
 from functools import partial
 from pathlib import Path
-from typing import List, Tuple, Dict, OrderedDict, Optional, Union, TypeVar, Sequence
+from typing import List, Tuple, Dict, OrderedDict, Optional, Union, TypeVar
 
 import numpy
 import zarr
@@ -39,12 +39,18 @@ from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
-from lazyflow.utility.io_util.clearscale import Spacing, Shape as MShape, Translation, Factor, Offset, BlueprintShapes
+from lazyflow.utility.io_util.clearscale import (
+    Spacing,
+    Shape as MShape,
+    Translation,
+    Factor,
+    Offset,
+    BlueprintShapes,
+    BlueprintFactors,
+)
 
 logger = logging.getLogger(__name__)
 
-OrderedScaling = OrderedTranslation = OrderedDict[Axiskey, float]  # { axis: scaling }
-ScalingsByScaleKey = OrderedDict[str, OrderedScaling]  # { scale_key: { axis: scaling } }
 ShapesByScaleKey = OrderedDict[str, TaggedShape]  # { scale_key: { axis: size } }
 AxisKey = TypeVar("AxisKey", bound=Axiskey)
 
@@ -60,45 +66,31 @@ def match_target_scales_to_input_excluding_upscales(
     # Since input_scales is ordered largest-to-smallest, simply drop matching scales before input_key.
     all_matching_scales = _match_target_scales_to_input(export_shape, input_scales, input_key)
     assert input_key in all_matching_scales, "generated scales don't include source scale"
-    start = list(all_matching_scales.keys()).index(input_key)
-    keep_scales = list(all_matching_scales.keys())[start:]
-    return ODict((k, all_matching_scales[k]) for k in keep_scales)
+    return all_matching_scales.drop_before(input_key)
 
 
 def _match_target_scales_to_input(
     export_shape: TaggedShape, input_scales: ShapesByScaleKey, input_key: str
-) -> ShapesByScaleKey:
-    def _eq_shape_permissive(test: TaggedShape, ref: TaggedShape) -> bool:
-        """
-        Check if two shapes are equal. Ignore channel and allow `test` to have additional axes (but no dropped axes).
-        """
-        return all(a not in ref or a == "c" or test[a] == ref[a] for a in test.keys())
-
+) -> BlueprintShapes:
     source_scale_shape = input_scales[input_key]
-    if _eq_shape_permissive(export_shape, source_scale_shape):
-        # Export shape is unmodified from its source scale - then all other scales shapes should be identical.
-        target_scales = input_scales
+    export_shape = MShape(export_shape)
+    if export_shape.matches(source_scale_shape, only=SPATIAL_AXES):
+        # Export shape is unmodified from its source scale -> output shapes = input shapes
+        export_shapes = BlueprintShapes(input_scales).reorder(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
     else:
-        # Export shape is modified (cropped).
-        # Get source multiscale's scaling factors relative to the (uncropped) input shape and compute cropped scale
-        # shapes from that.
-        input_scalings = _multiscale_to_scalings(input_scales, source_scale_shape, list(export_shape.keys()))
-        target_scales_items = []
-        for scale_key, scale_factors in input_scalings.items():
-            scaled_shape = MShape(export_shape).scale_by(scale_factors, rounding=int)
-            remaining_spatial = len(scaled_shape.singleton_axes(SPATIAL_AXES))
-            if remaining_spatial < 2 and scale_key != input_key:
-                # Avoid nonsense scales that aren't at least a 2d image,
-                # but make sure the source scale stays so we don't return only upscales
-                break
-            target_scales_items.append((scale_key, scaled_shape))
-        target_scales = ODict(target_scales_items)
+        # Export shape is modified (cropped) -> apply input scaling factors to export shape
+        def two_spatials_or_is_input(scale: str, shape: MShape):
+            remaining_spatial = len(shape.non_singleton_axes(SPATIAL_AXES))
+            return remaining_spatial > 1 or scale == input_key
 
-    scales_items = []
-    for scale_key, target_shape in target_scales.items():
-        export_scale_shape = MShape(target_shape).reorder(OME_ZARR_AXES).overwrite_with(export_shape, axes="c")
-        scales_items.append((scale_key, export_scale_shape))
-    return ODict(scales_items)
+        input_scalings = BlueprintFactors.from_shapes(input_scales, reference=source_scale_shape).with_identity("tc")
+        export_shapes = (
+            input_scalings.to_shapes(reference=export_shape, rounding="floor")
+            .reorder(OME_ZARR_AXES)
+            .filter_items(two_spatials_or_is_input)
+        )
+
+    return export_shapes
 
 
 def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> ShapesByScaleKey:
@@ -125,21 +117,6 @@ def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
     tagged_maxshape = MShape(tagged_image_shape).with_ones("tc")
     chunk_shape = determineBlockShape(list(tagged_maxshape.values()), target_max_size / dtype_bytes)
     return chunk_shape
-
-
-def _multiscale_to_scalings(
-    multiscale: ShapesByScaleKey,
-    base_shape: TaggedShape,
-    output_axiskeys: Sequence[Axiskey],
-) -> ScalingsByScaleKey:
-    """Multiscale and base_shape may have arbitrary axes.
-    Output are scaling factors relative to base_shape, with axes output_axiskeys.
-    Scale factor 1.0 for axes not present in scale or base shape, and for channel."""
-    factors = [
-        MShape(base_shape).scaling_to(scale_shape, fixed="c").reorder(output_axiskeys)
-        for scale_shape in multiscale.values()
-    ]
-    return ODict(zip(multiscale.keys(), factors))
 
 
 def _create_empty_zarray(
@@ -184,8 +161,8 @@ def _get_axes_meta(export_axiskeys, ilastik_meta):
 
 
 def _get_datasets_meta(
-    export_scalings: ScalingsByScaleKey,
-    export_resolution: OrderedScaling,
+    export_scalings: BlueprintFactors,
+    export_resolution: Spacing,
 ):
     """
     Dataset metadata consists of (1) path, (2) coordinate transformations (scale and translation).
@@ -209,7 +186,7 @@ def _get_datasets_meta(
 
 
 def _get_multiscale_transformations(
-    export_resolution_along_unscaled: OrderedScaling,
+    export_resolution_along_unscaled: Spacing,
     export_offset: Optional[TaggedShape],
     export_axiskeys: List[Axiskey],
     ilastik_meta: Dict,
@@ -266,9 +243,9 @@ def _get_multiscale_transformations(
 
 def _get_resolution_as_split_scaling(
     ilastik_meta: Dict,
-    export_scalings: ScalingsByScaleKey,
+    export_scalings: BlueprintFactors,
     input_scales: Optional[ShapesByScaleKey],
-) -> Tuple[OrderedScaling, OrderedScaling]:
+) -> Tuple[Spacing, Spacing]:
     """
     Extract resolution from axistags and split it to return
     - axes that are scaled in either the export (if it's multiscale) or the input (if it's multiscale)
@@ -296,7 +273,7 @@ def _get_resolution_as_split_scaling(
     return resolution.partition(is_scaling_axis)
 
 
-def _get_scaling_method_metadata(export_scalings: ScalingsByScaleKey, interpolation_order: int) -> Optional[Dict]:
+def _get_scaling_method_metadata(export_scalings: BlueprintFactors, interpolation_order: int) -> Optional[Dict]:
     combined_scaling_mag = [numpy.prod(list(scale.values())) for scale in export_scalings.values()]
     if all(numpy.isclose(m, 1.0) for m in combined_scaling_mag):
         return None
@@ -311,7 +288,7 @@ def _get_scaling_method_metadata(export_scalings: ScalingsByScaleKey, interpolat
 
 def _write_ome_zarr_and_ilastik_metadata(
     abs_export_path: str,
-    export_scalings: ScalingsByScaleKey,
+    export_scalings: BlueprintFactors,
     interpolation_order: int,
     export_offset: Optional[TaggedShape],
     input_scales: Optional[ShapesByScaleKey],
@@ -395,7 +372,7 @@ def write_ome_zarr(
 
         chunk_shape = _get_chunk_shape(export_shape, export_dtype)
 
-        export_scalings = _multiscale_to_scalings(target_scales, export_shape, list(export_shape.keys()))
+        export_scalings = BlueprintShapes(target_scales).reorder(export_shape).to_factors(export_shape)
         combined_scaling_mag = {key: numpy.prod(list(scale.values())) for key, scale in export_scalings.items()}
 
         # Upscales/raw - uncached (maybe this helps keep unscaled computation cache warm)

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -39,7 +39,7 @@ from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.clearscale import (
-    Spacing,
+    PixelSize,
     Shape,
     Translation,
     PixelOffset,
@@ -163,8 +163,8 @@ def _write_ome_zarr_and_ilastik_metadata(
     ilastik_meta: Dict,
 ):
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
-    export_spacing = Spacing.from_vigra(ilastik_meta["axistags"])
-    axes = list(export_spacing.keys())
+    export_pixel_size = PixelSize.from_vigra(ilastik_meta["axistags"])
+    axes = list(export_pixel_size.keys())
     if ilastik_meta["axis_units"]:
         export_unit = Unit(ilastik_meta["axis_units"]).with_axes(axes)
     else:
@@ -173,9 +173,9 @@ def _write_ome_zarr_and_ilastik_metadata(
     input_translation = input_scale.translation if input_scale else Translation.identity(axes)
     export_translation = input_translation.with_axes(axes)
     if export_offset:
-        export_translation += export_offset.with_axes(axes).to_physical(export_spacing)
+        export_translation += export_offset.with_axes(axes).to_physical(export_pixel_size)
 
-    export_scale = Scale(export_shape, export_spacing, export_unit, export_translation)
+    export_scale = Scale(export_shape, export_pixel_size, export_unit, export_translation)
     multiscale = export_blueprint.apply_to_scale(export_scale)
     ome_zarr_multiscale_meta = multiscale.to_ome_zarr(version="0.4", axis_types="infer")
 

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -24,6 +24,16 @@ from functools import partial
 from pathlib import Path
 from typing import List, Dict, Optional, Union, Mapping
 
+from clearscale import (
+    PixelSize,
+    Shape,
+    Translation,
+    PixelOffset,
+    BlueprintShapes,
+    Scale,
+    Unit,
+    Multiscale,
+)
 import numpy
 import zarr
 from zarr.storage import FSStore
@@ -38,16 +48,6 @@ from lazyflow.roi import determineBlockShape, roiFromShape, roiToSlice
 from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
-from lazyflow.utility.io_util.clearscale import (
-    PixelSize,
-    Shape,
-    Translation,
-    PixelOffset,
-    BlueprintShapes,
-    Scale,
-    Unit,
-    Multiscale,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -30,7 +30,7 @@ from zarr.storage import FSStore
 
 from ilastik import __version__ as ilastik_version
 from lazyflow import USER_LOGLEVEL
-from lazyflow.base import SPATIAL_AXES, Axiskey, Shape, TaggedShape
+from lazyflow.base import SPATIAL_AXES, Axiskey, Shape as ShapeTuple, TaggedShape
 from lazyflow.operators import OpReorderAxes
 from lazyflow.operators.opBlockedArrayCache import OpBlockedArrayCache
 from lazyflow.operators.opResize import OpResize
@@ -41,7 +41,7 @@ from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
 from lazyflow.utility.io_util.clearscale import (
     Spacing,
-    Shape as MShape,
+    Shape,
     Translation,
     PixelOffset,
     BlueprintShapes,
@@ -72,14 +72,14 @@ def match_target_scales_to_input_excluding_upscales(
 def _match_target_scales_to_input(
     export_shape: TaggedShape, input_scales: ShapesByScaleKey, input_key: str
 ) -> BlueprintShapes:
-    source_scale_shape = input_scales[input_key]
-    export_shape = MShape(export_shape)
+    source_scale_shape = Shape(input_scales[input_key])
+    export_shape = Shape(export_shape)
     if export_shape.matches(source_scale_shape, only=SPATIAL_AXES):
         # Export shape is unmodified from its source scale -> output shapes = input shapes
         export_shapes = BlueprintShapes(input_scales).with_axes(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
     else:
         # Export shape is modified (cropped) -> apply input scaling factors to export shape
-        def two_spatials_or_is_input(scale: str, shape: MShape):
+        def two_spatials_or_is_input(scale: str, shape: Shape):
             remaining_spatial = len(shape.non_singleton_axes(SPATIAL_AXES))
             return remaining_spatial > 1 or scale == input_key
 
@@ -98,15 +98,13 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Shapes
     Default target scales are isotropic 2x downscaling along x, y and z if present.
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
     """
-    unscaled = MShape(unscaled_shape).with_axes(OME_ZARR_AXES)
-    chunk_shape_tagged = dict(zip(unscaled.keys(), _get_chunk_shape(unscaled, dtype)))
-    shapes = BlueprintShapes.downscale_powers_of_2_xyz(
-        base_shape=unscaled, shape_limit=chunk_shape_tagged, rounding="floor"
-    )
+    unscaled = Shape(unscaled_shape).with_axes(OME_ZARR_AXES)
+    chunk_shape = _get_chunk_shape(unscaled, dtype)
+    shapes = BlueprintShapes.downscale_powers_of_2_xyz(base_shape=unscaled, shape_limit=chunk_shape, rounding="floor")
     return shapes.to_dict()
 
 
-def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
+def _get_chunk_shape(tagged_image_shape: Shape, dtype) -> Shape:
     """Determine chunk shape for OME-Zarr storage. 1 for t and c,
     ilastik default rules for zyx, with a max of 1MB uncompressed per chunk.
     This results in (y: 506 x: 505) for 32-bit 2D and (z: 63 y: 64 x: 63) for 32-bit 3D."""
@@ -114,9 +112,9 @@ def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
     if isinstance(dtype, numpy.dtype):  # Extract raw type class
         dtype = dtype.type
     dtype_bytes = dtype().nbytes
-    tagged_maxshape = MShape(tagged_image_shape).with_ones("tc")
-    chunk_shape = determineBlockShape(tagged_maxshape.to_list(), target_max_size / dtype_bytes)
-    return chunk_shape
+    tagged_maxshape = tagged_image_shape.with_ones("tc")
+    chunk_shape: ShapeTuple = determineBlockShape(tagged_maxshape.to_list(), target_max_size / dtype_bytes)
+    return Shape(zip(tagged_maxshape.keys(), chunk_shape))
 
 
 def _create_empty_zarray(
@@ -127,9 +125,11 @@ def _create_empty_zarray(
     export_dtype,
 ) -> zarr.Array:
     """Creates folders and zarr-internal (not OME) metadata files."""
-    assert len(chunk_shape) == len(scale_shape), "chunk and image shape must have same dimensions"
+    assert list(chunk_shape.keys()) == list(scale_shape.keys()), "chunk and image shape must have same axes"
     store = FSStore(abs_export_path, mode="w", **OME_ZARR_V_0_4_KWARGS)
-    zarray = zarr.creation.zeros(scale_shape, store=store, path=scale_key, chunks=chunk_shape, dtype=export_dtype)
+    zarray = zarr.creation.zeros(
+        scale_shape.to_tuple(), store=store, path=scale_key, chunks=chunk_shape.to_tuple(), dtype=export_dtype
+    )
     return zarray
 
 
@@ -174,7 +174,7 @@ def _get_scaling_method_metadata(export_blueprint: BlueprintShapes, interpolatio
 
 def _write_ome_zarr_and_ilastik_metadata(
     abs_export_path: str,
-    export_shape: TaggedShape,
+    export_shape: Shape,
     export_blueprint: BlueprintShapes,
     interpolation_order: int,
     export_offset: Optional[PixelOffset],
@@ -213,7 +213,7 @@ def write_ome_zarr(
     export_path: str,
     image_source_slot: Slot,
     progress_signal: OrderedSignal,
-    export_offset: Union[Shape, None],
+    export_offset: Union[ShapeTuple, None],
     target_scales: Optional[ShapesByScaleKey] = None,
 ):
     pc = PathComponents(export_path)
@@ -236,7 +236,7 @@ def write_ome_zarr(
         op_reorder.Input.connect(image_source_slot)
         reordered_source = op_reorder.Output
         progress_signal(25)
-        export_shape = MShape(reordered_source.meta.getTaggedShape())
+        export_shape = Shape(reordered_source.meta.getTaggedShape())
         export_dtype = reordered_source.meta.dtype
         input_scale_key = reordered_source.meta.get("active_scale")
         input_translations = reordered_source.meta.get("ome_zarr_translations")
@@ -260,13 +260,13 @@ def write_ome_zarr(
         for upscale_key, v in reversed(sorted(upscale_mags.items(), key=lambda x: x[1])):
             scale_type = "upscaled data" if v < 1.0 else "unscaled data"
             logger.log(USER_LOGLEVEL, f"Exporting {scale_type} to scale path '{upscale_key}'")
-            target_shape = export_blueprint[upscale_key].to_tuple()
+            target_shape = export_blueprint[upscale_key]
             op_scale = None
             try:
                 op_scale = OpResize(
                     parent=image_source_slot.operator,
                     RawImage=reordered_source,
-                    TargetShape=target_shape,
+                    TargetShape=target_shape.to_tuple(),
                     InterpolationOrder=interpolation_order,
                 )
                 requester = BigRequestStreamer(op_scale.ResizedImage, roiFromShape(op_scale.ResizedImage.meta.shape))
@@ -282,21 +282,21 @@ def write_ome_zarr(
         downscale_mags = {k: v for k, v in combined_scaling_mag.items() if v > 1.0}
         prev_slot = reordered_source
         for downscale_key, _ in sorted(downscale_mags.items(), key=lambda x: x[1]):
-            target_shape = export_blueprint[downscale_key].to_tuple()
+            target_shape = export_blueprint[downscale_key]
             logger.log(USER_LOGLEVEL, f"Exporting downscale to scale path '{downscale_key}'")
             op_scale = OpResize(
                 parent=image_source_slot.operator,
                 RawImage=prev_slot,
-                TargetShape=target_shape,
+                TargetShape=target_shape.to_tuple(),
                 InterpolationOrder=interpolation_order,
             )
             ops_to_clean.append(op_scale)
             op_cache = OpBlockedArrayCache(parent=image_source_slot.operator)
             ops_to_clean.append(op_cache)
             op_cache.Input.connect(op_scale.ResizedImage)
-            op_cache.BlockShape.setValue(chunk_shape)
+            op_cache.BlockShape.setValue(chunk_shape.to_tuple())
             requester = BigRequestStreamer(
-                op_cache.Output, roiFromShape(op_cache.Output.meta.shape), blockshape=chunk_shape
+                op_cache.Output, roiFromShape(op_cache.Output.meta.shape), blockshape=chunk_shape.to_tuple()
             )
             zarray = _create_empty_zarray(abs_export_path, downscale_key, target_shape, chunk_shape, export_dtype)
             requester.resultSignal.subscribe(partial(_write_block, zarray))

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -20,7 +20,6 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 import logging
-from collections import OrderedDict as ODict
 from functools import partial
 from pathlib import Path
 from typing import List, Tuple, Dict, OrderedDict, Optional, Union, TypeVar, Sequence
@@ -40,7 +39,7 @@ from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
-from lazyflow.utility.io_util.clearscale import Spacing, Shape as MShape, Translation, Factor, Offset
+from lazyflow.utility.io_util.clearscale import Spacing, Shape as MShape, Translation, Factor, Offset, BlueprintShapes
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +85,8 @@ def _match_target_scales_to_input(
         input_scalings = _multiscale_to_scalings(input_scales, source_scale_shape, list(export_shape.keys()))
         target_scales_items = []
         for scale_key, scale_factors in input_scalings.items():
-            scaled_shape = MShape(export_shape).scale_by(scale_factors, f_round=int)
-            remaining_spatial = len(scaled_shape.singletons(SPATIAL_AXES))
+            scaled_shape = MShape(export_shape).scale_by(scale_factors, rounding=int)
+            remaining_spatial = len(scaled_shape.singleton_axes(SPATIAL_AXES))
             if remaining_spatial < 2 and scale_key != input_key:
                 # Avoid nonsense scales that aren't at least a 2d image,
                 # but make sure the source scale stays so we don't return only upscales
@@ -108,18 +107,11 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Shapes
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
     """
     unscaled = MShape(unscaled_shape).reorder(OME_ZARR_AXES)
-    chunk_shape_tagged = ODict(zip(unscaled.keys(), _get_chunk_shape(unscaled, dtype)))
-    scales_items = []
-    sanity_limit = 42
-    for i in range(0, sanity_limit):
-        scale_key = f"s{i}"
-        scale_factor = 2**i
-        scaling = Factor.uniform(unscaled.keys(), scale_factor).with_ones_except(SPATIAL_AXES)
-        scaled_shape = unscaled.scale_by(scaling, f_round=int)
-        scales_items.append((scale_key, scaled_shape))
-        if all(scaled_shape[axis] <= chunk_shape_tagged[axis] for axis in SPATIAL_AXES):
-            break
-    return ODict(scales_items)
+    chunk_shape_tagged = dict(zip(unscaled.keys(), _get_chunk_shape(unscaled, dtype)))
+    shapes = BlueprintShapes.downscale_powers_of_2_xyz(
+        base_shape=unscaled, shape_limit=chunk_shape_tagged, rounding="floor"
+    )
+    return shapes.to_dict()
 
 
 def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
@@ -380,7 +372,7 @@ def write_ome_zarr(
             "Appending to an existing OME-Zarr store is not yet implemented."
             f"\nPath: {abs_export_path}."
         )
-    export_offset = MShape(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
+    export_offset = Offset(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
     op_reorder = OpReorderAxes(parent=image_source_slot.operator)
     op_reorder.AxisOrder.setValue("".join(OME_ZARR_AXES))
     ops_to_clean = [op_reorder]

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -43,7 +43,7 @@ from lazyflow.utility.io_util.clearscale import (
     Spacing,
     Shape as MShape,
     Translation,
-    Offset,
+    PixelOffset,
     BlueprintShapes,
     BlueprintFactors,
     Scale,
@@ -76,7 +76,7 @@ def _match_target_scales_to_input(
     export_shape = MShape(export_shape)
     if export_shape.matches(source_scale_shape, only=SPATIAL_AXES):
         # Export shape is unmodified from its source scale -> output shapes = input shapes
-        export_shapes = BlueprintShapes(input_scales).reorder(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
+        export_shapes = BlueprintShapes(input_scales).with_axes(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
     else:
         # Export shape is modified (cropped) -> apply input scaling factors to export shape
         def two_spatials_or_is_input(scale: str, shape: MShape):
@@ -86,7 +86,7 @@ def _match_target_scales_to_input(
         input_scalings = BlueprintFactors.from_shapes(input_scales, reference=source_scale_shape).with_identity("tc")
         export_shapes = (
             input_scalings.to_shapes(reference=export_shape, rounding="floor")
-            .reorder(OME_ZARR_AXES)
+            .with_axes(OME_ZARR_AXES)
             .filter_items(two_spatials_or_is_input)
         )
 
@@ -98,7 +98,7 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Shapes
     Default target scales are isotropic 2x downscaling along x, y and z if present.
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
     """
-    unscaled = MShape(unscaled_shape).reorder(OME_ZARR_AXES)
+    unscaled = MShape(unscaled_shape).with_axes(OME_ZARR_AXES)
     chunk_shape_tagged = dict(zip(unscaled.keys(), _get_chunk_shape(unscaled, dtype)))
     shapes = BlueprintShapes.downscale_powers_of_2_xyz(
         base_shape=unscaled, shape_limit=chunk_shape_tagged, rounding="floor"
@@ -153,7 +153,7 @@ def _resolve_translations(export_axiskeys, export_offset, export_spacing, input_
     export_translation = Translation.identity(export_axiskeys)
     input_translation = Translation.identity(export_axiskeys)
     if export_offset:
-        export_translation = export_offset.reorder(export_axiskeys).to_physical(export_spacing)
+        export_translation = export_offset.with_axes(export_axiskeys).to_physical(export_spacing)
     if input_translations:
         input_translation = input_translations.resolve_at_scale(input_scale_key, export_axiskeys)
     sum_translation = export_translation + input_translation
@@ -177,7 +177,7 @@ def _write_ome_zarr_and_ilastik_metadata(
     export_shape: TaggedShape,
     export_blueprint: BlueprintShapes,
     interpolation_order: int,
-    export_offset: Optional[Offset],
+    export_offset: Optional[PixelOffset],
     input_scale_key: Optional[str],
     input_translations: Optional[OMEZarrTranslations],
     ilastik_meta: Dict,
@@ -185,7 +185,7 @@ def _write_ome_zarr_and_ilastik_metadata(
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
     export_spacing = Spacing.from_vigra(ilastik_meta["axistags"])
     if ilastik_meta["axis_units"]:
-        export_unit = Unit(ilastik_meta["axis_units"]).reorder(export_spacing)
+        export_unit = Unit(ilastik_meta["axis_units"]).with_axes(export_spacing)
     else:
         export_unit = Unit.empty(export_spacing)
     export_translation = _resolve_translations(
@@ -228,7 +228,7 @@ def write_ome_zarr(
             "Appending to an existing OME-Zarr store is not yet implemented."
             f"\nPath: {abs_export_path}."
         )
-    export_offset = Offset(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
+    export_offset = PixelOffset(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
     op_reorder = OpReorderAxes(parent=image_source_slot.operator)
     op_reorder.AxisOrder.setValue("".join(OME_ZARR_AXES))
     ops_to_clean = [op_reorder]
@@ -250,7 +250,7 @@ def write_ome_zarr(
 
         chunk_shape = _get_chunk_shape(export_shape, export_dtype)
 
-        export_blueprint = BlueprintShapes(target_scales).reorder(export_shape)
+        export_blueprint = BlueprintShapes(target_scales).with_axes(export_shape)
         export_scalings = export_blueprint.to_factors(export_shape)
         combined_scaling_mag = {key: factor.magnitude() for key, factor in export_scalings.items()}
 

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -38,7 +38,6 @@ from lazyflow.roi import determineBlockShape, roiFromShape, roiToSlice
 from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
-from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
 from lazyflow.utility.io_util.clearscale import (
     Spacing,
     Shape,
@@ -149,17 +148,6 @@ def _write_to_dataset_attrs(ilastik_meta: Dict, za: zarr.Array):
         za.attrs["drange"] = ilastik_meta["drange"]
 
 
-def _resolve_translations(export_axiskeys, export_offset, export_spacing, input_translations, input_scale_key):
-    export_translation = Translation.identity(export_axiskeys)
-    input_translation = Translation.identity(export_axiskeys)
-    if export_offset:
-        export_translation = export_offset.with_axes(export_axiskeys).to_physical(export_spacing)
-    if input_translations:
-        input_translation = input_translations.resolve_at_scale(input_scale_key, export_axiskeys)
-    sum_translation = export_translation + input_translation
-    return sum_translation
-
-
 def _get_scaling_method_metadata(export_blueprint: BlueprintShapes, interpolation_order: int) -> Optional[Dict]:
     if not export_blueprint.scaled_axes():
         return None
@@ -178,19 +166,21 @@ def _write_ome_zarr_and_ilastik_metadata(
     export_blueprint: BlueprintShapes,
     interpolation_order: int,
     export_offset: Optional[PixelOffset],
-    input_scale_key: Optional[str],
-    input_translations: Optional[OMEZarrTranslations],
+    input_scale: Optional[Scale],
     ilastik_meta: Dict,
 ):
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
     export_spacing = Spacing.from_vigra(ilastik_meta["axistags"])
+    axes = list(export_spacing.keys())
     if ilastik_meta["axis_units"]:
-        export_unit = Unit(ilastik_meta["axis_units"]).with_axes(export_spacing)
+        export_unit = Unit(ilastik_meta["axis_units"]).with_axes(axes)
     else:
-        export_unit = Unit.empty(export_spacing)
-    export_translation = _resolve_translations(
-        export_shape.keys(), export_offset, export_spacing, input_translations, input_scale_key
-    )
+        export_unit = Unit.empty(axes)
+
+    input_translation = input_scale.translation if input_scale else Translation.identity(axes)
+    export_translation = input_translation.with_axes(axes)
+    if export_offset:
+        export_translation += export_offset.with_axes(axes).to_physical(export_spacing)
 
     export_scale = Scale(export_shape, export_spacing, export_unit, export_translation)
     multiscale = export_blueprint.apply_to_scale(export_scale)
@@ -239,7 +229,8 @@ def write_ome_zarr(
         export_shape = Shape(reordered_source.meta.getTaggedShape())
         export_dtype = reordered_source.meta.dtype
         input_scale_key = reordered_source.meta.get("active_scale")
-        input_translations = reordered_source.meta.get("ome_zarr_translations")
+        input_multiscale = reordered_source.meta.get("scales")
+        input_scale = input_multiscale[input_scale_key] if input_multiscale and input_scale_key else None
         interpolation_order = OpResize.semantics_to_interpolation[
             reordered_source.meta.get("data_semantics", ImageTypes.Intensities)
         ]
@@ -311,8 +302,7 @@ def write_ome_zarr(
             export_blueprint,
             interpolation_order,
             export_offset,
-            input_scale_key,
-            input_translations,
+            input_scale,
             {
                 "axistags": reordered_source.meta.axistags,
                 "axis_units": reordered_source.meta.get("axis_units"),

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -22,7 +22,7 @@
 import logging
 from functools import partial
 from pathlib import Path
-from typing import List, Dict, OrderedDict, Optional, Union
+from typing import List, Dict, Optional, Union, Mapping
 
 import numpy
 import zarr
@@ -44,14 +44,12 @@ from lazyflow.utility.io_util.clearscale import (
     Translation,
     PixelOffset,
     BlueprintShapes,
-    BlueprintFactors,
     Scale,
     Unit,
+    Multiscale,
 )
 
 logger = logging.getLogger(__name__)
-
-ShapesByScaleKey = OrderedDict[str, TaggedShape]  # { scale_key: { axis: size } }
 
 OME_ZARR_V_0_4_KWARGS = dict(dimension_separator="/")
 OME_ZARR_AXES: List[Axiskey] = ["t", "c", "z", "y", "x"]
@@ -59,40 +57,35 @@ SINGE_SCALE_DEFAULT_KEY = "s0"
 
 
 def match_target_scales_to_input_excluding_upscales(
-    export_shape: TaggedShape, input_scales: ShapesByScaleKey, input_key: str
-) -> ShapesByScaleKey:
+    export_shape: TaggedShape, input_scales: Multiscale, input_key: str
+) -> BlueprintShapes:
     """We assume people don't generally want to upscale lower-resolution segmentations to raw scale."""
     # Since input_scales is ordered largest-to-smallest, simply drop matching scales before input_key.
     all_matching_scales = _match_target_scales_to_input(export_shape, input_scales, input_key)
-    assert input_key in all_matching_scales, "generated scales don't include source scale"
     return all_matching_scales.drop_before(input_key)
 
 
 def _match_target_scales_to_input(
-    export_shape: TaggedShape, input_scales: ShapesByScaleKey, input_key: str
+    export_shape: TaggedShape, input_scales: Multiscale, input_key: str
 ) -> BlueprintShapes:
-    source_scale_shape = Shape(input_scales[input_key])
-    export_shape = Shape(export_shape)
-    if export_shape.matches(source_scale_shape, only=SPATIAL_AXES):
-        # Export shape is unmodified from its source scale -> output shapes = input shapes
-        export_shapes = BlueprintShapes(input_scales).with_axes(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
+    source_scale_shape = input_scales[input_key].shape
+    if source_scale_shape.matches(export_shape, only=SPATIAL_AXES):
+        # Unmodified source shape - reproduce exact multiscale shapes
+        shapes = BlueprintShapes.from_multiscale(input_scales)
     else:
-        # Export shape is modified (cropped) -> apply input scaling factors to export shape
+
         def two_spatials_or_is_input(scale: str, shape: Shape):
             remaining_spatial = len(shape.non_singleton_axes(SPATIAL_AXES))
             return remaining_spatial > 1 or scale == input_key
 
-        input_scalings = BlueprintFactors.from_shapes(input_scales, reference=source_scale_shape).with_identity("tc")
-        export_shapes = (
-            input_scalings.to_shapes(reference=export_shape, rounding="floor")
-            .with_axes(OME_ZARR_AXES)
-            .filter_items(two_spatials_or_is_input)
-        )
+        shapes = BlueprintShapes.from_multiscale_rescaled(
+            input_scales, target_shape=export_shape, source_key=input_key, scaled_axes=SPATIAL_AXES, rounding="floor"
+        ).filter_items(two_spatials_or_is_input)
 
-    return export_shapes
+    return shapes.with_axes(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
 
 
-def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> ShapesByScaleKey:
+def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> BlueprintShapes:
     """
     Default target scales are isotropic 2x downscaling along x, y and z if present.
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
@@ -100,7 +93,7 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Shapes
     unscaled = Shape(unscaled_shape).with_axes(OME_ZARR_AXES)
     chunk_shape = _get_chunk_shape(unscaled, dtype)
     shapes = BlueprintShapes.downscale_powers_of_2_xyz(base_shape=unscaled, shape_limit=chunk_shape, rounding="floor")
-    return shapes.to_dict()
+    return shapes
 
 
 def _get_chunk_shape(tagged_image_shape: Shape, dtype) -> Shape:
@@ -204,7 +197,7 @@ def write_ome_zarr(
     image_source_slot: Slot,
     progress_signal: OrderedSignal,
     export_offset: Union[ShapeTuple, None],
-    target_scales: Optional[ShapesByScaleKey] = None,
+    target_scales: Optional[Mapping[str, Mapping[str, int]]] = None,
 ):
     pc = PathComponents(export_path)
     if pc.internalPath:

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -22,7 +22,7 @@
 import logging
 from functools import partial
 from pathlib import Path
-from typing import List, Tuple, Dict, OrderedDict, Optional, Union, TypeVar
+from typing import List, Dict, OrderedDict, Optional, Union
 
 import numpy
 import zarr
@@ -43,16 +43,16 @@ from lazyflow.utility.io_util.clearscale import (
     Spacing,
     Shape as MShape,
     Translation,
-    Factor,
     Offset,
     BlueprintShapes,
     BlueprintFactors,
+    Scale,
+    Unit,
 )
 
 logger = logging.getLogger(__name__)
 
 ShapesByScaleKey = OrderedDict[str, TaggedShape]  # { scale_key: { axis: size } }
-AxisKey = TypeVar("AxisKey", bound=Axiskey)
 
 OME_ZARR_V_0_4_KWARGS = dict(dimension_separator="/")
 OME_ZARR_AXES: List[Axiskey] = ["t", "c", "z", "y", "x"]
@@ -115,7 +115,7 @@ def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
         dtype = dtype.type
     dtype_bytes = dtype().nbytes
     tagged_maxshape = MShape(tagged_image_shape).with_ones("tc")
-    chunk_shape = determineBlockShape(list(tagged_maxshape.values()), target_max_size / dtype_bytes)
+    chunk_shape = determineBlockShape(tagged_maxshape.to_list(), target_max_size / dtype_bytes)
     return chunk_shape
 
 
@@ -149,133 +149,19 @@ def _write_to_dataset_attrs(ilastik_meta: Dict, za: zarr.Array):
         za.attrs["drange"] = ilastik_meta["drange"]
 
 
-def _get_axes_meta(export_axiskeys, ilastik_meta):
-    axis_types = {"t": "time", "c": "channel", "z": "space", "y": "space", "x": "space"}
-    axes = [{"name": a, "type": axis_types[a]} for a in export_axiskeys]
-    # Don't write empty unit entries
-    if ilastik_meta["axis_units"]:
-        for a in axes:
-            if a["name"] in ilastik_meta["axis_units"] and ilastik_meta["axis_units"][a["name"]]:
-                a["unit"] = ilastik_meta["axis_units"][a["name"]]
-    return axes
-
-
-def _get_datasets_meta(
-    export_scalings: BlueprintFactors,
-    export_resolution: Spacing,
-):
-    """
-    Dataset metadata consists of (1) path, (2) coordinate transformations (scale and translation).
-    Transformations should be in physical / absolute units if available.
-    Hence, the scale transformation is simply the pixel size.
-    Translation is not applicable for our export on individual datasets. This is intended for reporting offsets
-    introduced by the scaling method (e.g. half-pixel shift), which OpResize doesn't.
-
-    :param export_scalings: relative scaling factors for each scale-level
-    :param export_resolution: pixel size
-    """
-    datasets = []
-    for scale_key, scaling in export_scalings.items():
-        absolute_scaling = Factor(scaling).to_physical(export_resolution)
-        dataset = {
-            "path": scale_key,
-            "coordinateTransformations": [{"type": "scale", "scale": list(absolute_scaling.values())}],
-        }
-        datasets.append(dataset)
-    return datasets
-
-
-def _get_multiscale_transformations(
-    export_resolution_along_unscaled: Spacing,
-    export_offset: Optional[TaggedShape],
-    export_axiskeys: List[Axiskey],
-    ilastik_meta: Dict,
-    input_translations: Optional[OMEZarrTranslations],
-    input_scale_key: Optional[str],
-) -> Optional[List[Dict]]:
-    """
-    Multiscale-level scale transform = pixel size along unscaled axes (usually t).
-    Multiscale-level translation transform = export offset + input translation.
-    Whereby "input translation" is the sum of input dataset translation and input multiscale translation.
-
-    In OME-Zarr 0.4, since transformations are in absolute units, it makes no difference
-    whether we put them at multiscale-level or dataset-level. We try to match convention:
-    - scale transform: Convention is to put scale for unscaled axes in multiscale transforms.
-    - translation transform: There is no convention. We interpret export_offset as a global translation
-      of the multiscale export, so multiscale transforms seems appropriate.
-
-    :param export_resolution_along_unscaled: For the multiscale "scale" metadata (pixel size along unscaled axes like t)
-    :param export_offset: From export subregion settings, in export source slot's axis order (not export target axes)
-    :param export_axiskeys: Export target axes
-    :param ilastik_meta: To get resolution from axistags (to convert offset to translation)
-    :param input_translations: To extract existing dataset and multiscale translations
-    :param input_scale_key: To extract existing dataset translations from input_ome_meta
-
-    Returns None or the transformations adjusted to export axes as OME-Zarr conforming dicts.
-    """
-
-    axes = export_axiskeys
-    resolution = Spacing.from_vigra(ilastik_meta["axistags"])
-    sum_translation = Translation.identity(axes)
+def _resolve_translations(export_axiskeys, export_offset, export_spacing, input_translations, input_scale_key):
+    export_translation = Translation.identity(export_axiskeys)
+    input_translation = Translation.identity(export_axiskeys)
     if export_offset:
-        # Convert offset pixels to absolute units
-        sum_translation = Offset(export_offset).reorder(axes).to_physical(resolution)
+        export_translation = export_offset.reorder(export_axiskeys).to_physical(export_spacing)
     if input_translations:
-        input_dataset_translation = input_translations.dataset_translations.get(input_scale_key)
-        input_multiscale_translation = input_translations.multiscale_translation
-        if input_dataset_translation:
-            reordered_dataset = Translation(input_dataset_translation).reorder(axes)
-            sum_translation = sum_translation + reordered_dataset
-        if input_multiscale_translation:
-            reordered_multiscale = Translation(input_multiscale_translation).reorder(axes)
-            sum_translation = sum_translation + reordered_multiscale
-
-    multiscale_transforms = []
-    if not Factor(export_resolution_along_unscaled).is_identity():
-        multiscale_transforms.append({"type": "scale", "scale": list(export_resolution_along_unscaled.values())})
-    if not sum_translation.is_identity():
-        if not multiscale_transforms:
-            # Must have a scale transform before translation transform
-            multiscale_transforms.append({"type": "scale", "scale": list(Factor.identity(export_axiskeys).values())})
-        multiscale_transforms.append({"type": "translation", "translation": list(sum_translation.values())})
-    return multiscale_transforms or None
+        input_translation = input_translations.resolve_at_scale(input_scale_key, export_axiskeys)
+    sum_translation = export_translation + input_translation
+    return sum_translation
 
 
-def _get_resolution_as_split_scaling(
-    ilastik_meta: Dict,
-    export_scalings: BlueprintFactors,
-    input_scales: Optional[ShapesByScaleKey],
-) -> Tuple[Spacing, Spacing]:
-    """
-    Extract resolution from axistags and split it to return
-    - axes that are scaled in either the export (if it's multiscale) or the input (if it's multiscale)
-    - axes that are not scaled in either.
-    With resolution = 1.0 for the respective other axes.
-
-    We want to report physical pixel size (absolute scale) on the dataset-level in OME-Zarr for axes
-    along which the pyramid is scaled, and the pixel size for unscaled axes on multiscale-level.
-    Scaling from input OME meta not required, the reader already factors it into the axistags.
-    """
-
-    def is_scaling_axis(axis):
-        if len(export_scalings) > 1 and any(scale[axis] != 1 for scale in export_scalings.values()):
-            return True
-        # In case of single-scale export, we still consider this a scaling axis if it's scaled in the input
-        if not input_scales:
-            return False
-        tagged_shapes = list(input_scales.values())
-        base_size = tagged_shapes[0].get(axis)
-        if not base_size:
-            return False
-        return any(scale_shape[axis] != base_size for scale_shape in tagged_shapes)
-
-    resolution = Spacing.from_vigra(ilastik_meta["axistags"])
-    return resolution.partition(is_scaling_axis)
-
-
-def _get_scaling_method_metadata(export_scalings: BlueprintFactors, interpolation_order: int) -> Optional[Dict]:
-    combined_scaling_mag = [numpy.prod(list(scale.values())) for scale in export_scalings.values()]
-    if all(numpy.isclose(m, 1.0) for m in combined_scaling_mag):
+def _get_scaling_method_metadata(export_blueprint: BlueprintShapes, interpolation_order: int) -> Optional[Dict]:
+    if not export_blueprint.scaled_axes():
         return None
     metadata = {
         "description": "ilastik's lazyflow.operators.opResize.OpResize is a lazy implementation of skimage.transform.resize.",
@@ -288,36 +174,29 @@ def _get_scaling_method_metadata(export_scalings: BlueprintFactors, interpolatio
 
 def _write_ome_zarr_and_ilastik_metadata(
     abs_export_path: str,
-    export_scalings: BlueprintFactors,
+    export_shape: TaggedShape,
+    export_blueprint: BlueprintShapes,
     interpolation_order: int,
-    export_offset: Optional[TaggedShape],
-    input_scales: Optional[ShapesByScaleKey],
+    export_offset: Optional[Offset],
     input_scale_key: Optional[str],
     input_translations: Optional[OMEZarrTranslations],
     ilastik_meta: Dict,
 ):
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
-    export_axiskeys = list(next(iter(export_scalings.values())).keys())
-    export_resolution_along_scaled, export_resolution_along_unscaled = _get_resolution_as_split_scaling(
-        ilastik_meta, export_scalings, input_scales
+    export_spacing = Spacing.from_vigra(ilastik_meta["axistags"])
+    if ilastik_meta["axis_units"]:
+        export_unit = Unit(ilastik_meta["axis_units"]).reorder(export_spacing)
+    else:
+        export_unit = Unit.empty(export_spacing)
+    export_translation = _resolve_translations(
+        export_shape.keys(), export_offset, export_spacing, input_translations, input_scale_key
     )
 
-    axes = _get_axes_meta(export_axiskeys, ilastik_meta)
-    datasets = _get_datasets_meta(export_scalings, export_resolution_along_scaled)
-    ome_zarr_multiscale_meta = {"axes": axes, "datasets": datasets, "version": "0.4"}
+    export_scale = Scale(export_shape, export_spacing, export_unit, export_translation)
+    multiscale = export_blueprint.apply_to_scale(export_scale)
+    ome_zarr_multiscale_meta = multiscale.to_ome_zarr(version="0.4", axis_types="infer")
 
-    multiscale_transformations = _get_multiscale_transformations(
-        export_resolution_along_unscaled,
-        export_offset,
-        export_axiskeys,
-        ilastik_meta,
-        input_translations,
-        input_scale_key,
-    )
-    if multiscale_transformations:
-        ome_zarr_multiscale_meta["coordinateTransformations"] = multiscale_transformations
-
-    scaling_meta = _get_scaling_method_metadata(export_scalings, interpolation_order)
+    scaling_meta = _get_scaling_method_metadata(export_blueprint, interpolation_order)
     if scaling_meta:
         ome_zarr_multiscale_meta["metadata"] = scaling_meta
 
@@ -325,7 +204,7 @@ def _write_ome_zarr_and_ilastik_metadata(
     root = zarr.group(store, overwrite=False)
     root.attrs["_creator"] = ilastik_signature
     root.attrs["multiscales"] = [ome_zarr_multiscale_meta]
-    for path in export_scalings.keys():
+    for path in export_blueprint.keys():
         za = zarr.Array(store, path=path)
         _write_to_dataset_attrs(ilastik_meta, za)
 
@@ -357,9 +236,8 @@ def write_ome_zarr(
         op_reorder.Input.connect(image_source_slot)
         reordered_source = op_reorder.Output
         progress_signal(25)
-        export_shape = reordered_source.meta.getTaggedShape()
+        export_shape = MShape(reordered_source.meta.getTaggedShape())
         export_dtype = reordered_source.meta.dtype
-        input_scales = reordered_source.meta.get("scales")
         input_scale_key = reordered_source.meta.get("active_scale")
         input_translations = reordered_source.meta.get("ome_zarr_translations")
         interpolation_order = OpResize.semantics_to_interpolation[
@@ -368,12 +246,13 @@ def write_ome_zarr(
 
         if target_scales is None:  # single-scale export
             single_target_key = input_scale_key if input_scale_key else SINGE_SCALE_DEFAULT_KEY
-            target_scales = ShapesByScaleKey({single_target_key: export_shape})
+            target_scales = BlueprintShapes({single_target_key: export_shape})
 
         chunk_shape = _get_chunk_shape(export_shape, export_dtype)
 
-        export_scalings = BlueprintShapes(target_scales).reorder(export_shape).to_factors(export_shape)
-        combined_scaling_mag = {key: numpy.prod(list(scale.values())) for key, scale in export_scalings.items()}
+        export_blueprint = BlueprintShapes(target_scales).reorder(export_shape)
+        export_scalings = export_blueprint.to_factors(export_shape)
+        combined_scaling_mag = {key: factor.magnitude() for key, factor in export_scalings.items()}
 
         # Upscales/raw - uncached (maybe this helps keep unscaled computation cache warm)
         # Also covers single-scale export
@@ -381,7 +260,7 @@ def write_ome_zarr(
         for upscale_key, v in reversed(sorted(upscale_mags.items(), key=lambda x: x[1])):
             scale_type = "upscaled data" if v < 1.0 else "unscaled data"
             logger.log(USER_LOGLEVEL, f"Exporting {scale_type} to scale path '{upscale_key}'")
-            target_shape = tuple(target_scales[upscale_key].values())
+            target_shape = export_blueprint[upscale_key].to_tuple()
             op_scale = None
             try:
                 op_scale = OpResize(
@@ -403,7 +282,7 @@ def write_ome_zarr(
         downscale_mags = {k: v for k, v in combined_scaling_mag.items() if v > 1.0}
         prev_slot = reordered_source
         for downscale_key, _ in sorted(downscale_mags.items(), key=lambda x: x[1]):
-            target_shape = tuple(target_scales[downscale_key].values())
+            target_shape = export_blueprint[downscale_key].to_tuple()
             logger.log(USER_LOGLEVEL, f"Exporting downscale to scale path '{downscale_key}'")
             op_scale = OpResize(
                 parent=image_source_slot.operator,
@@ -428,10 +307,10 @@ def write_ome_zarr(
         progress_signal(95)
         _write_ome_zarr_and_ilastik_metadata(
             abs_export_path,
-            export_scalings,
+            export_shape,
+            export_blueprint,
             interpolation_order,
             export_offset,
-            input_scales,
             input_scale_key,
             input_translations,
             {

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -23,10 +23,9 @@ import logging
 from collections import OrderedDict as ODict
 from functools import partial
 from pathlib import Path
-from typing import List, Tuple, Dict, OrderedDict, Optional, Iterable, Union
+from typing import List, Tuple, Dict, OrderedDict, Optional, Union, TypeVar, Sequence
 
 import numpy
-import vigra
 import zarr
 from zarr.storage import FSStore
 
@@ -41,25 +40,18 @@ from lazyflow.slot import Slot
 from lazyflow.utility import OrderedSignal, PathComponents, BigRequestStreamer
 from lazyflow.utility.data_semantics import ImageTypes
 from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
-from lazyflow.utility.io_util.multiscaleStore import DEFAULT_VIGRA_RESOLUTION
+from lazyflow.utility.io_util.clearscale import Spacing, Shape as MShape, Translation, Factor, Offset
 
 logger = logging.getLogger(__name__)
 
 OrderedScaling = OrderedTranslation = OrderedDict[Axiskey, float]  # { axis: scaling }
 ScalingsByScaleKey = OrderedDict[str, OrderedScaling]  # { scale_key: { axis: scaling } }
 ShapesByScaleKey = OrderedDict[str, TaggedShape]  # { scale_key: { axis: size } }
+AxisKey = TypeVar("AxisKey", bound=Axiskey)
 
 OME_ZARR_V_0_4_KWARGS = dict(dimension_separator="/")
 OME_ZARR_AXES: List[Axiskey] = ["t", "c", "z", "y", "x"]
 SINGE_SCALE_DEFAULT_KEY = "s0"
-
-
-def _rescale_size(size: int, factor: float) -> int:
-    """
-    Rescale a single dimension of a shape.
-    Floor-round to match behavior of OpResize, and ensure minimum size is 1.
-    """
-    return max(int(size / factor), 1)
 
 
 def match_target_scales_to_input_excluding_upscales(
@@ -91,12 +83,12 @@ def _match_target_scales_to_input(
         # Export shape is modified (cropped).
         # Get source multiscale's scaling factors relative to the (uncropped) input shape and compute cropped scale
         # shapes from that.
-        input_scalings = _multiscale_to_scalings(input_scales, source_scale_shape, export_shape.keys())
+        input_scalings = _multiscale_to_scalings(input_scales, source_scale_shape, list(export_shape.keys()))
         target_scales_items = []
         for scale_key, scale_factors in input_scalings.items():
-            scaled_shape = ODict([(a, _rescale_size(size, scale_factors[a])) for a, size in export_shape.items()])
-            is_less_than_2d = len([a for a in SPATIAL_AXES if a in scaled_shape and scaled_shape[a] > 1]) < 2
-            if is_less_than_2d and scale_key != input_key:
+            scaled_shape = MShape(export_shape).scale_by(scale_factors, f_round=int)
+            remaining_spatial = len(scaled_shape.singletons(SPATIAL_AXES))
+            if remaining_spatial < 2 and scale_key != input_key:
                 # Avoid nonsense scales that aren't at least a 2d image,
                 # but make sure the source scale stays so we don't return only upscales
                 break
@@ -105,11 +97,8 @@ def _match_target_scales_to_input(
 
     scales_items = []
     for scale_key, target_shape in target_scales.items():
-        reordered_shape = _reorder(target_shape, OME_ZARR_AXES, 1)
-        if "c" in export_shape:
-            reordered_shape["c"] = export_shape["c"]
-        reordered_item = (scale_key, reordered_shape)
-        scales_items.append(reordered_item)
+        export_scale_shape = MShape(target_shape).reorder(OME_ZARR_AXES).overwrite_with(export_shape, axes="c")
+        scales_items.append((scale_key, export_scale_shape))
     return ODict(scales_items)
 
 
@@ -118,32 +107,19 @@ def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> Shapes
     Default target scales are isotropic 2x downscaling along x, y and z if present.
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
     """
-    unscaled = _reorder(unscaled_shape, OME_ZARR_AXES, 1)
-    chunk_shape_tagged = ODict(zip(OME_ZARR_AXES, _get_chunk_shape(unscaled, dtype)))
+    unscaled = MShape(unscaled_shape).reorder(OME_ZARR_AXES)
+    chunk_shape_tagged = ODict(zip(unscaled.keys(), _get_chunk_shape(unscaled, dtype)))
     scales_items = []
     sanity_limit = 42
     for i in range(0, sanity_limit):
         scale_key = f"s{i}"
         scale_factor = 2**i
-        scaled_shape = []
-        for axis, size in unscaled.items():
-            if axis in SPATIAL_AXES:
-                scaled_shape.append(_rescale_size(size, scale_factor))
-            else:
-                scaled_shape.append(size)
-        scaled_shape_tagged = ODict(zip(OME_ZARR_AXES, scaled_shape))
-        item = (scale_key, scaled_shape_tagged)
-        scales_items.append(item)
-        if all(scaled_shape_tagged[axis] <= chunk_shape_tagged[axis] for axis in SPATIAL_AXES):
+        scaling = Factor.uniform(unscaled.keys(), scale_factor).with_ones_except(SPATIAL_AXES)
+        scaled_shape = unscaled.scale_by(scaling, f_round=int)
+        scales_items.append((scale_key, scaled_shape))
+        if all(scaled_shape[axis] <= chunk_shape_tagged[axis] for axis in SPATIAL_AXES):
             break
     return ODict(scales_items)
-
-
-def _reorder(
-    shape: Dict[Axiskey, Union[int, float]], axes: Iterable[Axiskey], default_value: Union[int, float]
-) -> TaggedShape:
-    """Reorder a tagged shape to `axes`, using `default_value` for axes missing in `shape`."""
-    return ODict([(a, shape[a] if a in shape else default_value) for a in axes])
 
 
 def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
@@ -154,9 +130,7 @@ def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
     if isinstance(dtype, numpy.dtype):  # Extract raw type class
         dtype = dtype.type
     dtype_bytes = dtype().nbytes
-    tagged_maxshape = tagged_image_shape.copy()
-    tagged_maxshape["t"] = 1
-    tagged_maxshape["c"] = 1
+    tagged_maxshape = MShape(tagged_image_shape).with_ones("tc")
     chunk_shape = determineBlockShape(list(tagged_maxshape.values()), target_max_size / dtype_bytes)
     return chunk_shape
 
@@ -164,24 +138,15 @@ def _get_chunk_shape(tagged_image_shape: TaggedShape, dtype) -> Shape:
 def _multiscale_to_scalings(
     multiscale: ShapesByScaleKey,
     base_shape: TaggedShape,
-    output_axiskeys: Iterable[Axiskey],
+    output_axiskeys: Sequence[Axiskey],
 ) -> ScalingsByScaleKey:
     """Multiscale and base_shape may have arbitrary axes.
     Output are scaling factors relative to base_shape, with axes output_axiskeys.
     Scale factor 1.0 for axes not present in scale or base shape, and for channel."""
-    factors = []
-    for scale_shape in multiscale.values():
-        common_axes = [a for a in scale_shape if a in base_shape]
-        scale_values = [scale_shape[a] for a in common_axes]
-        base_values = [base_shape[a] for a in common_axes]
-        # This scale's scaling relative to base_shape.
-        # Scaling "factors" are technically divisors for the shape (factor 2.0 means half the shape).
-        relative_factors = {a: base / s for a, s, base in zip(common_axes, scale_values, base_values)}
-        # Pad with 1.0 for requested axes not present in scale/base, and c
-        axes_matched_factors = ODict(
-            [(a, relative_factors[a] if a in relative_factors and a != "c" else 1.0) for a in output_axiskeys]
-        )
-        factors.append(axes_matched_factors)
+    factors = [
+        MShape(base_shape).scaling_to(scale_shape, fixed="c").reorder(output_axiskeys)
+        for scale_shape in multiscale.values()
+    ]
     return ODict(zip(multiscale.keys(), factors))
 
 
@@ -241,19 +206,14 @@ def _get_datasets_meta(
     :param export_resolution: pixel size
     """
     datasets = []
-    export_axiskeys = list(next(iter(export_scalings.values())).keys())
     for scale_key, scaling in export_scalings.items():
-        absolute_scaling = ODict([(a, scaling[a] * export_resolution[a]) for a in export_axiskeys])
+        absolute_scaling = Factor(scaling).to_physical(export_resolution)
         dataset = {
             "path": scale_key,
             "coordinateTransformations": [{"type": "scale", "scale": list(absolute_scaling.values())}],
         }
         datasets.append(dataset)
     return datasets
-
-
-def _get_tagged_resolution(axistags: vigra.AxisTags) -> OrderedScaling:
-    return ODict([(tag.key, tag.resolution if tag.resolution != DEFAULT_VIGRA_RESOLUTION else 1.0) for tag in axistags])
 
 
 def _get_multiscale_transformations(
@@ -286,35 +246,33 @@ def _get_multiscale_transformations(
     """
 
     axes = export_axiskeys
-    resolution = _get_tagged_resolution(ilastik_meta["axistags"])
-    sum_translation: OrderedTranslation = ODict(zip(axes, [0.0] * len(axes)))
+    resolution = Spacing.from_vigra(ilastik_meta["axistags"])
+    sum_translation = Translation.identity(axes)
     if export_offset:
         # Convert offset pixels to absolute units
-        reordered_offset = _reorder(export_offset, axes, 0)
-        sum_translation = ODict([(a, reordered_offset[a] * resolution[a]) for a in axes])
+        sum_translation = Offset(export_offset).reorder(axes).to_physical(resolution)
     if input_translations:
         input_dataset_translation = input_translations.dataset_translations.get(input_scale_key)
         input_multiscale_translation = input_translations.multiscale_translation
         if input_dataset_translation:
-            reordered_dataset = _reorder(input_dataset_translation, axes, 0.0)
-            sum_translation = ODict([(a, sum_translation[a] + reordered_dataset[a]) for a in axes])
+            reordered_dataset = Translation(input_dataset_translation).reorder(axes)
+            sum_translation = sum_translation + reordered_dataset
         if input_multiscale_translation:
-            reordered_multiscale = _reorder(input_multiscale_translation, axes, 0.0)
-            sum_translation = ODict([(a, sum_translation[a] + reordered_multiscale[a]) for a in axes])
+            reordered_multiscale = Translation(input_multiscale_translation).reorder(axes)
+            sum_translation = sum_translation + reordered_multiscale
 
     multiscale_transforms = []
-    if any(v != 1 for v in export_resolution_along_unscaled.values()):
+    if not Factor(export_resolution_along_unscaled).is_identity():
         multiscale_transforms.append({"type": "scale", "scale": list(export_resolution_along_unscaled.values())})
-    if any(v != 0 for v in sum_translation.values()):
+    if not sum_translation.is_identity():
         if not multiscale_transforms:
             # Must have a scale transform before translation transform
-            multiscale_transforms.append({"type": "scale", "scale": [1.0] * len(export_axiskeys)})
+            multiscale_transforms.append({"type": "scale", "scale": list(Factor.identity(export_axiskeys).values())})
         multiscale_transforms.append({"type": "translation", "translation": list(sum_translation.values())})
     return multiscale_transforms or None
 
 
 def _get_resolution_as_split_scaling(
-    export_axiskeys: List[Axiskey],
     ilastik_meta: Dict,
     export_scalings: ScalingsByScaleKey,
     input_scales: Optional[ShapesByScaleKey],
@@ -342,11 +300,8 @@ def _get_resolution_as_split_scaling(
             return False
         return any(scale_shape[axis] != base_size for scale_shape in tagged_shapes)
 
-    assert export_axiskeys == [tag.key for tag in ilastik_meta["axistags"]], "wat"
-    tagged_resolution = _get_tagged_resolution(ilastik_meta["axistags"])
-    resolution_scaled = ODict([(a, tagged_resolution[a] if is_scaling_axis(a) else 1.0) for a in export_axiskeys])
-    resolution_unscaled = ODict([(a, tagged_resolution[a] if not is_scaling_axis(a) else 1.0) for a in export_axiskeys])
-    return resolution_scaled, resolution_unscaled
+    resolution = Spacing.from_vigra(ilastik_meta["axistags"])
+    return resolution.partition(is_scaling_axis)
 
 
 def _get_scaling_method_metadata(export_scalings: ScalingsByScaleKey, interpolation_order: int) -> Optional[Dict]:
@@ -375,7 +330,7 @@ def _write_ome_zarr_and_ilastik_metadata(
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
     export_axiskeys = list(next(iter(export_scalings.values())).keys())
     export_resolution_along_scaled, export_resolution_along_unscaled = _get_resolution_as_split_scaling(
-        export_axiskeys, ilastik_meta, export_scalings, input_scales
+        ilastik_meta, export_scalings, input_scales
     )
 
     axes = _get_axes_meta(export_axiskeys, ilastik_meta)
@@ -425,9 +380,7 @@ def write_ome_zarr(
             "Appending to an existing OME-Zarr store is not yet implemented."
             f"\nPath: {abs_export_path}."
         )
-    export_offset: TaggedShape = (
-        ODict(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
-    )
+    export_offset = MShape(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
     op_reorder = OpReorderAxes(parent=image_source_slot.operator)
     op_reorder.AxisOrder.setValue("".join(OME_ZARR_AXES))
     ops_to_clean = [op_reorder]
@@ -450,7 +403,7 @@ def write_ome_zarr(
 
         chunk_shape = _get_chunk_shape(export_shape, export_dtype)
 
-        export_scalings = _multiscale_to_scalings(target_scales, export_shape, export_shape.keys())
+        export_scalings = _multiscale_to_scalings(target_scales, export_shape, list(export_shape.keys()))
         combined_scaling_mag = {key: numpy.prod(list(scale.values())) for key, scale in export_scalings.items()}
 
         # Upscales/raw - uncached (maybe this helps keep unscaled computation cache warm)

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -82,7 +82,7 @@ def _match_target_scales_to_input(
             input_scales, target_shape=export_shape, source_key=input_key, scaled_axes=SPATIAL_AXES, rounding="floor"
         ).filter_items(two_spatials_or_is_input)
 
-    return shapes.with_axes(OME_ZARR_AXES).with_sizes(export_shape, axes="tc")
+    return shapes.with_axes(OME_ZARR_AXES).with_sizes(export_shape, only_axes="tc")
 
 
 def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> BlueprintShapes:

--- a/lazyflow/utility/io_util/write_ome_zarr.py
+++ b/lazyflow/utility/io_util/write_ome_zarr.py
@@ -24,16 +24,7 @@ from functools import partial
 from pathlib import Path
 from typing import List, Dict, Optional, Union, Mapping
 
-from clearscale import (
-    PixelSize,
-    Shape,
-    Translation,
-    PixelOffset,
-    BlueprintShapes,
-    Scale,
-    Unit,
-    Multiscale,
-)
+import clearscale
 import numpy
 import zarr
 from zarr.storage import FSStore
@@ -57,8 +48,8 @@ SINGE_SCALE_DEFAULT_KEY = "s0"
 
 
 def match_target_scales_to_input_excluding_upscales(
-    export_shape: TaggedShape, input_scales: Multiscale, input_key: str
-) -> BlueprintShapes:
+    export_shape: TaggedShape, input_scales: clearscale.Multiscale, input_key: str
+) -> clearscale.BlueprintShapes:
     """We assume people don't generally want to upscale lower-resolution segmentations to raw scale."""
     # Since input_scales is ordered largest-to-smallest, simply drop matching scales before input_key.
     all_matching_scales = _match_target_scales_to_input(export_shape, input_scales, input_key)
@@ -66,37 +57,39 @@ def match_target_scales_to_input_excluding_upscales(
 
 
 def _match_target_scales_to_input(
-    export_shape: TaggedShape, input_scales: Multiscale, input_key: str
-) -> BlueprintShapes:
+    export_shape: TaggedShape, input_scales: clearscale.Multiscale, input_key: str
+) -> clearscale.BlueprintShapes:
     source_scale_shape = input_scales[input_key].shape
     if source_scale_shape.matches(export_shape, only=SPATIAL_AXES):
         # Unmodified source shape - reproduce exact multiscale shapes
-        shapes = BlueprintShapes.from_multiscale(input_scales)
+        shapes = clearscale.BlueprintShapes.from_multiscale(input_scales)
     else:
 
-        def two_spatials_or_is_input(scale: str, shape: Shape):
+        def two_spatials_or_is_input(scale: str, shape: clearscale.Shape):
             remaining_spatial = len(shape.non_singleton_axes(SPATIAL_AXES))
             return remaining_spatial > 1 or scale == input_key
 
-        shapes = BlueprintShapes.from_multiscale_rescaled(
+        shapes = clearscale.BlueprintShapes.from_multiscale_rescaled(
             input_scales, target_shape=export_shape, source_key=input_key, scaled_axes=SPATIAL_AXES, rounding="floor"
         ).filter_items(two_spatials_or_is_input)
 
     return shapes.with_axes(OME_ZARR_AXES).with_sizes(export_shape, only_axes="tc")
 
 
-def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> BlueprintShapes:
+def generate_default_target_scales(unscaled_shape: TaggedShape, dtype) -> clearscale.BlueprintShapes:
     """
     Default target scales are isotropic 2x downscaling along x, y and z if present.
     The smallest scale included is just small enough for the entire image to fit into one chunk (per t and c).
     """
-    unscaled = Shape(unscaled_shape).with_axes(OME_ZARR_AXES)
+    unscaled = clearscale.Shape(unscaled_shape).with_axes(OME_ZARR_AXES)
     chunk_shape = _get_chunk_shape(unscaled, dtype)
-    shapes = BlueprintShapes.downscale_powers_of_2_xyz(base_shape=unscaled, shape_limit=chunk_shape, rounding="floor")
+    shapes = clearscale.BlueprintShapes.downscale_powers_of_2_xyz(
+        base_shape=unscaled, shape_limit=chunk_shape, rounding="floor"
+    )
     return shapes
 
 
-def _get_chunk_shape(tagged_image_shape: Shape, dtype) -> Shape:
+def _get_chunk_shape(tagged_image_shape: clearscale.Shape, dtype) -> clearscale.Shape:
     """Determine chunk shape for OME-Zarr storage. 1 for t and c,
     ilastik default rules for zyx, with a max of 1MB uncompressed per chunk.
     This results in (y: 506 x: 505) for 32-bit 2D and (z: 63 y: 64 x: 63) for 32-bit 3D."""
@@ -106,14 +99,14 @@ def _get_chunk_shape(tagged_image_shape: Shape, dtype) -> Shape:
     dtype_bytes = dtype().nbytes
     tagged_maxshape = tagged_image_shape.with_ones("tc")
     chunk_shape: ShapeTuple = determineBlockShape(tagged_maxshape.to_list(), target_max_size / dtype_bytes)
-    return Shape(zip(tagged_maxshape.keys(), chunk_shape))
+    return clearscale.Shape(zip(tagged_maxshape.keys(), chunk_shape))
 
 
 def _create_empty_zarray(
     abs_export_path: str,
     scale_key: str,
-    scale_shape: Shape,
-    chunk_shape: Shape,
+    scale_shape: clearscale.Shape,
+    chunk_shape: clearscale.Shape,
     export_dtype,
 ) -> zarr.Array:
     """Creates folders and zarr-internal (not OME) metadata files."""
@@ -141,7 +134,9 @@ def _write_to_dataset_attrs(ilastik_meta: Dict, za: zarr.Array):
         za.attrs["drange"] = ilastik_meta["drange"]
 
 
-def _get_scaling_method_metadata(export_blueprint: BlueprintShapes, interpolation_order: int) -> Optional[Dict]:
+def _get_scaling_method_metadata(
+    export_blueprint: clearscale.BlueprintShapes, interpolation_order: int
+) -> Optional[Dict]:
     if not export_blueprint.scaled_axes():
         return None
     metadata = {
@@ -155,27 +150,27 @@ def _get_scaling_method_metadata(export_blueprint: BlueprintShapes, interpolatio
 
 def _write_ome_zarr_and_ilastik_metadata(
     abs_export_path: str,
-    export_shape: Shape,
-    export_blueprint: BlueprintShapes,
+    export_shape: clearscale.Shape,
+    export_blueprint: clearscale.BlueprintShapes,
     interpolation_order: int,
-    export_offset: Optional[PixelOffset],
-    input_scale: Optional[Scale],
+    export_offset: Optional[clearscale.PixelOffset],
+    input_scale: Optional[clearscale.Scale],
     ilastik_meta: Dict,
 ):
     ilastik_signature = {"name": "ilastik", "version": ilastik_version, "ome_zarr_exporter_version": 2}
-    export_pixel_size = PixelSize.from_vigra(ilastik_meta["axistags"])
+    export_pixel_size = clearscale.PixelSize.from_vigra(ilastik_meta["axistags"])
     axes = list(export_pixel_size.keys())
     if ilastik_meta["axis_units"]:
-        export_unit = Unit(ilastik_meta["axis_units"]).with_axes(axes)
+        export_unit = clearscale.Unit(ilastik_meta["axis_units"]).with_axes(axes)
     else:
-        export_unit = Unit.empty(axes)
+        export_unit = clearscale.Unit.empty(axes)
 
-    input_translation = input_scale.translation if input_scale else Translation.identity(axes)
+    input_translation = input_scale.translation if input_scale else clearscale.Translation.identity(axes)
     export_translation = input_translation.with_axes(axes)
     if export_offset:
         export_translation += export_offset.with_axes(axes).to_physical(export_pixel_size)
 
-    export_scale = Scale(export_shape, export_pixel_size, export_unit, export_translation)
+    export_scale = clearscale.Scale(export_shape, export_pixel_size, export_unit, export_translation)
     multiscale = export_blueprint.apply_to_scale(export_scale)
     ome_zarr_multiscale_meta = multiscale.to_ome_zarr(version="0.4", axis_types="infer")
 
@@ -211,7 +206,9 @@ def write_ome_zarr(
             "Appending to an existing OME-Zarr store is not yet implemented."
             f"\nPath: {abs_export_path}."
         )
-    export_offset = PixelOffset(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
+    export_offset = (
+        clearscale.PixelOffset(zip(image_source_slot.meta.getAxisKeys(), export_offset)) if export_offset else None
+    )
     op_reorder = OpReorderAxes(parent=image_source_slot.operator)
     op_reorder.AxisOrder.setValue("".join(OME_ZARR_AXES))
     ops_to_clean = [op_reorder]
@@ -219,7 +216,7 @@ def write_ome_zarr(
         op_reorder.Input.connect(image_source_slot)
         reordered_source = op_reorder.Output
         progress_signal(25)
-        export_shape = Shape(reordered_source.meta.getTaggedShape())
+        export_shape = clearscale.Shape(reordered_source.meta.getTaggedShape())
         export_dtype = reordered_source.meta.dtype
         input_scale_key = reordered_source.meta.get("active_scale")
         input_multiscale = reordered_source.meta.get("scales")
@@ -230,11 +227,11 @@ def write_ome_zarr(
 
         if target_scales is None:  # single-scale export
             single_target_key = input_scale_key if input_scale_key else SINGE_SCALE_DEFAULT_KEY
-            target_scales = BlueprintShapes({single_target_key: export_shape})
+            target_scales = clearscale.BlueprintShapes({single_target_key: export_shape})
 
         chunk_shape = _get_chunk_shape(export_shape, export_dtype)
 
-        export_blueprint = BlueprintShapes(target_scales).with_axes(export_shape)
+        export_blueprint = clearscale.BlueprintShapes(target_scales).with_axes(export_shape)
         export_scalings = export_blueprint.to_factors(export_shape)
         combined_scaling_mag = {key: factor.magnitude() for key, factor in export_scalings.items()}
 

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -26,6 +26,7 @@ from typing import Tuple
 from unittest import mock
 from unittest.mock import Mock
 
+from clearscale import Multiscale
 import numpy
 import requests
 import vigra
@@ -34,7 +35,6 @@ from pathlib import Path
 import zarr
 from PIL import Image
 
-from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 from lazyflow.utility.io_util.OMEZarrStore import ScaleNotFoundError
 from lazyflow.utility.io_util.multiscaleStore import DEFAULT_SCALE_KEY

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -21,7 +21,7 @@
 import json
 import os
 import shutil
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from typing import Tuple
 from unittest import mock
 from unittest.mock import Mock
@@ -1035,7 +1035,7 @@ class TestOpDataSelection_OMEZarr:
 
         assert op.Image.meta.scales == Multiscale.from_ome_zarr(
             self.ZATTRS["multiscales"][0],
-            get_shape=lambda path: {"s0": self.SHAPE_ORIGINAL_ZYX, "s1": self.SHAPE_SCALED_ZYX}[path],
+            shape_source=lambda path: {"s0": self.SHAPE_ORIGINAL_ZYX, "s1": self.SHAPE_SCALED_ZYX}[path],
         )
 
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscale)

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -34,6 +34,7 @@ from pathlib import Path
 import zarr
 from PIL import Image
 
+from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 from lazyflow.utility.io_util.OMEZarrStore import ScaleNotFoundError
 from lazyflow.utility.io_util.multiscaleStore import DEFAULT_SCALE_KEY
@@ -884,12 +885,7 @@ class TestOpDataSelection_PrecomputedChunks:
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
-        assert op.Image.meta.scales == OrderedDict(
-            [
-                ("800_800_70", OrderedDict([("c", 1), ("z", 1), ("y", 20), ("x", 24)])),
-                ("1600_1600_70", OrderedDict([("c", 1), ("z", 1), ("y", 10), ("x", 12)])),
-            ]
-        )
+        assert op.Image.meta.scales == Multiscale.from_precomputed(self.INFO_JSON)
 
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscale)
         scale_keys = list(op.Image.meta.scales.keys())
@@ -1037,11 +1033,9 @@ class TestOpDataSelection_OMEZarr:
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
-        assert op.Image.meta.scales == OrderedDict(
-            [
-                ("s0", OrderedDict([("z", 1), ("y", 20), ("x", 24)])),
-                ("s1", OrderedDict([("z", 1), ("y", 10), ("x", 12)])),
-            ]
+        assert op.Image.meta.scales == Multiscale.from_ome_zarr(
+            self.ZATTRS["multiscales"][0],
+            get_shape=lambda path: {"s0": self.SHAPE_ORIGINAL_ZYX, "s1": self.SHAPE_SCALED_ZYX}[path],
         )
 
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscale)
@@ -1264,7 +1258,13 @@ class TestOpDataSelection_DatasetInfo:
         responses = {
             ".zattrs": {
                 "multiscales": [
-                    {"axes": [{"name": "x"}, {"name": "y"}], "datasets": [{"path": "s0"}], "version": "0.4"}
+                    {
+                        "axes": [{"name": "x"}, {"name": "y"}],
+                        "datasets": [
+                            {"path": "s0", "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0]}]}
+                        ],
+                        "version": "0.4",
+                    }
                 ]
             },
             "s0/.zarray": {

--- a/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testOpDataSelection.py
@@ -26,7 +26,7 @@ from typing import Tuple
 from unittest import mock
 from unittest.mock import Mock
 
-from clearscale import Multiscale
+import clearscale
 import numpy
 import requests
 import vigra
@@ -885,7 +885,7 @@ class TestOpDataSelection_PrecomputedChunks:
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
-        assert op.Image.meta.scales == Multiscale.from_precomputed(self.INFO_JSON)
+        assert op.Image.meta.scales == clearscale.Multiscale.from_precomputed(self.INFO_JSON)
 
         # Switch to original unscaled resolution (first in the list, see multiscaleStore.multiscale)
         scale_keys = list(op.Image.meta.scales.keys())
@@ -1033,7 +1033,7 @@ class TestOpDataSelection_OMEZarr:
         loaded_scale0 = op.Image[:].wait()
         numpy.testing.assert_allclose(loaded_scale0, self.IMAGE_SCALED.reshape((1, 1, 1, 10, 12)))
 
-        assert op.Image.meta.scales == Multiscale.from_ome_zarr(
+        assert op.Image.meta.scales == clearscale.Multiscale.from_ome_zarr(
             self.ZATTRS["multiscales"][0],
             shape_source=lambda path: {"s0": self.SHAPE_ORIGINAL_ZYX, "s1": self.SHAPE_SCALED_ZYX}[path],
         )

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
@@ -299,6 +299,132 @@ class TestOpExportSlot(object):
             written_file = z5py.ZarrFile(export_path, "r")
             assert written_file.attrs["multiscales"] == expected_meta_s1
 
+    def test_ome_zarr_roundtrip_multiscale(self):
+        """Ensure that loading an OME-Zarr dataset and then re-exporting one of
+        its scales produces the same data and metadata."""
+        input_meta = [
+            {
+                "name": "input.zarr",
+                "type": "sample",
+                "version": "0.4",
+                "axes": [
+                    {"type": "space", "name": "z", "unit": "micrometer"},
+                    {"type": "space", "name": "y", "unit": "nanometer"},
+                    {"type": "space", "name": "x", "unit": "nanometer"},
+                ],
+                "datasets": [
+                    {
+                        "path": "s0",
+                        "coordinateTransformations": [
+                            {"scale": [1.0, 0.2, 0.2], "type": "scale"},
+                            {"translation": [0.0, 0.0, 0.0], "type": "translation"},
+                        ],
+                    },
+                    {
+                        "path": "s1",
+                        "coordinateTransformations": [
+                            {"scale": [1.0, 1.4, 1.4], "type": "scale"},
+                            {"translation": [0.0, 7.62, 8.49], "type": "translation"},
+                        ],
+                    },
+                ],
+                "coordinateTransformations": [
+                    {"scale": [0.3, 1.0, 1.0], "type": "scale"},
+                    {"translation": [2.0, 0.6, 0.0], "type": "translation"},
+                ],
+            }
+        ]
+        # Expected written meta is the same as input, but tczyx, and with no name
+        expected_ms = {
+            "axes": [
+                {"name": "t", "type": "time"},
+                {"name": "c", "type": "channel"},
+                {"name": "z", "type": "space", "unit": "micrometer"},
+                {"name": "y", "type": "space", "unit": "nanometer"},
+                {"name": "x", "type": "space", "unit": "nanometer"},
+            ],
+            "datasets": [
+                {
+                    "coordinateTransformations": [{"scale": [1.0, 1.0, 1.0, 0.2, 0.2], "type": "scale"}],
+                    "path": "s0",
+                },
+                {
+                    "coordinateTransformations": [
+                        {"scale": [1.0, 1.0, 1.0, 0.6, 0.6], "type": "scale"},
+                        {"translation": [0.0, 0.0, 0.0, 7.62, 8.49], "type": "translation"},
+                    ],
+                    "path": "s1",
+                },
+            ],
+            "coordinateTransformations": [
+                {"scale": [1.0, 1.0, 0.3, 1.0, 1.0], "type": "scale"},
+                {"translation": [0.0, 0.0, 2.0, 0.6, 0.0], "type": "translation"},
+            ],
+            "version": "0.4",
+            "metadata": {
+                "description": "ilastik's lazyflow.operators.opResize.OpResize "
+                "is a lazy implementation of "
+                "skimage.transform.resize.",
+                "kwargs": {"anti_aliasing": True, "order": 1, "preserve_range": True},
+                "method": "skimage.transform.resize",
+                "version": "0.24.0",
+            },
+        }
+
+        input_path = self._tmpdir + "/input.zarr"
+        file = z5py.ZarrFile(input_path, "w")
+        data = numpy.random.random((16, 15, 15)).astype(numpy.float32)
+        downscale = data[:, ::3, ::3]
+        file.create_dataset("s0", data=data)
+        file.create_dataset("s1", data=downscale)
+        file.attrs["multiscales"] = input_meta
+
+        noop = Operator(graph=Graph())  # parent so that OpInputDataReader doesn't drop into single-scale mode
+
+        # Raw scale first
+        export_path = self._tmpdir + "/test_export_multi.zarr"
+        with Pipeline(parent=noop) as pipeline:
+            pipeline.add(OpInputDataReader, FilePath=input_path + "/s0")
+            opExport = pipeline.add(OpExportSlot, OutputFormat="multi-scale OME-Zarr", OutputFilenameFormat=export_path)
+            opExport.run_export()
+
+            assert os.path.exists(export_path)
+            written_file = z5py.ZarrFile(export_path, "r")
+            assert len(written_file.attrs["multiscales"]) == 1
+            written_ms = written_file.attrs["multiscales"][0]
+            assert written_ms["axes"] == expected_ms["axes"]
+            assert written_ms["metadata"] == expected_ms["metadata"]
+            assert written_ms["version"] == expected_ms["version"]
+            written_ms_transforms = written_ms["coordinateTransformations"]
+            expected_ms_transforms = expected_ms["coordinateTransformations"]
+            self._assert_transforms_eq(written_ms_transforms, expected_ms_transforms)
+            assert len(written_ms["datasets"]) == len(expected_ms["datasets"])
+            for written_ds, expected_ds in zip(written_ms["datasets"], expected_ms["datasets"]):
+                assert written_ds["path"] == expected_ds["path"]
+                written_ds_transforms = written_ds["coordinateTransformations"]
+                expected_ds_transforms = expected_ds["coordinateTransformations"]
+                assert len(written_ds_transforms) == len(
+                    expected_ds_transforms
+                ), f"expected {len(expected_ds_transforms)}"
+                self._assert_transforms_eq(written_ds_transforms, expected_ds_transforms)
+
+    @staticmethod
+    def _assert_transforms_eq(written_transforms, expected_transforms):
+        if len(expected_transforms) == 0:
+            return
+        assert "scale" in written_transforms[0]
+        written_ms_scale = written_transforms[0]["scale"]
+        expected_scale = expected_transforms[0]["scale"]
+        for written, expected in zip(written_ms_scale, expected_scale):
+            assert numpy.isclose(written, expected, atol=1e-15)
+        if len(expected_transforms) == 1:
+            return
+        assert "translation" in written_transforms[1]
+        written_ms_transl = written_transforms[1]["translation"]
+        expected_transl = expected_transforms[1]["translation"]
+        for written, expected in zip(written_ms_transl, expected_transl):
+            assert numpy.isclose(written, expected, atol=1e-15)
+
     def testBasic_Npy(self):
         data = numpy.random.random((100, 100)).astype(numpy.float32)
         data = vigra.taggedView(data, vigra.defaultAxistags("xy"))

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
@@ -110,7 +110,10 @@ class TestOpExportSlot(object):
             read_data = opRead.Output[:].wait()
             numpy.testing.assert_array_equal(read_data, expected_data)
             written_file = z5py.ZarrFile(str(expected_export_path), "r")
-            assert written_file.attrs["multiscales"][0]["coordinateTransformations"] == expected_transformations
+            assert (
+                written_file.attrs["multiscales"][0]["datasets"][0]["coordinateTransformations"]
+                == expected_transformations
+            )
         finally:
             opRead.cleanUp()
 
@@ -234,13 +237,12 @@ class TestOpExportSlot(object):
                     {"name": "y", "type": "space", "unit": "nanometer"},
                     {"name": "x", "type": "space", "unit": "nanometer"},
                 ],
-                "coordinateTransformations": [
-                    {"scale": [1.0, 1.0, 1.0, 1.0, 1.0], "type": "scale"},
-                    {"translation": [0.0, 0.0, 0.0, 7.62, 8.49], "type": "translation"},
-                ],
                 "datasets": [
                     {
-                        "coordinateTransformations": [{"scale": [1.0, 1.0, 1.0, 1.4, 1.4], "type": "scale"}],
+                        "coordinateTransformations": [
+                            {"scale": [1.0, 1.0, 1.0, 1.4, 1.4], "type": "scale"},
+                            {"translation": [0.0, 0.0, 0.0, 7.62, 8.49], "type": "translation"},
+                        ],
                         "path": "s1",
                     }
                 ],

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpExportSlot.py
@@ -158,15 +158,11 @@ class TestOpExportSlot(object):
                 if scale == "s0":  # only assert written data at raw scale here (scaling covered in OpResize)
                     numpy.testing.assert_array_equal(read_data, expected_data)
                 written_file = z5py.ZarrFile(str(expected_export_path), "r")
-                expected_multiscale_transformations = [
-                    {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]},
+                assert "coordinateTransformations" not in written_file.attrs["multiscales"][0]
+                expected_dataset_transformations = [
+                    {"type": "scale", "scale": [1.0, 1.0, 1.0, 2.0**i, 2.0**i]},
                     {"type": "translation", "translation": [0.0, 0.0, 0.0, 10.0, 20.0]},
                 ]
-                assert (
-                    written_file.attrs["multiscales"][0]["coordinateTransformations"]
-                    == expected_multiscale_transformations
-                )
-                expected_dataset_transformations = [{"type": "scale", "scale": [1.0, 1.0, 1.0, 2.0**i, 2.0**i]}]
                 assert (
                     written_file.attrs["multiscales"][0]["datasets"][i]["coordinateTransformations"]
                     == expected_dataset_transformations
@@ -300,8 +296,15 @@ class TestOpExportSlot(object):
             assert written_file.attrs["multiscales"] == expected_meta_s1
 
     def test_ome_zarr_roundtrip_multiscale(self):
-        """Ensure that loading an OME-Zarr dataset and then re-exporting one of
-        its scales produces the same data and metadata."""
+        """
+        Ensure metadata roundtrips correctly when re-exporting a multiscale dataset as-is.
+        Output metadata won't/shouldn't be *identical* to input. Even when just re-exporting
+        the loaded data unprocessed, the export is actually a new multiscale. It's just
+        scaled to the same scaling levels as the source pyramid. ilastik's scaling implementation
+        (OpResize) will not reproduce the downscaled source data.
+        The exported metadata must correctly describe the export, not carry over metadata
+        from the source falsely. See detailed comment below.
+        """
         input_meta = [
             {
                 "name": "input.zarr",
@@ -323,7 +326,7 @@ class TestOpExportSlot(object):
                     {
                         "path": "s1",
                         "coordinateTransformations": [
-                            {"scale": [1.0, 1.4, 1.4], "type": "scale"},
+                            {"scale": [1.0, 0.6, 0.6], "type": "scale"},
                             {"translation": [0.0, 7.62, 8.49], "type": "translation"},
                         ],
                     },
@@ -334,7 +337,11 @@ class TestOpExportSlot(object):
                 ],
             }
         ]
-        # Expected written meta is the same as input, but tczyx, and with no name
+        # Expected written meta is the same as input, but:
+        # - tczyx
+        # - no name
+        # - multiscale-global transformations are folded into datasets (similar to ome-zarr 0.6 convention)
+        # - "s1" transformations are discarded. The exported "s1" is a newly generated downscale.
         expected_ms = {
             "axes": [
                 {"name": "t", "type": "time"},
@@ -345,20 +352,19 @@ class TestOpExportSlot(object):
             ],
             "datasets": [
                 {
-                    "coordinateTransformations": [{"scale": [1.0, 1.0, 1.0, 0.2, 0.2], "type": "scale"}],
+                    "coordinateTransformations": [
+                        {"scale": [1.0, 1.0, 0.3, 0.2, 0.2], "type": "scale"},
+                        {"translation": [0.0, 0.0, 2.0, 0.6, 0.0], "type": "translation"},
+                    ],
                     "path": "s0",
                 },
                 {
                     "coordinateTransformations": [
-                        {"scale": [1.0, 1.0, 1.0, 0.6, 0.6], "type": "scale"},
-                        {"translation": [0.0, 0.0, 0.0, 7.62, 8.49], "type": "translation"},
+                        {"scale": [1.0, 1.0, 0.3, 0.6, 0.6], "type": "scale"},
+                        {"translation": [0.0, 0.0, 2.0, 0.6, 0.0], "type": "translation"},
                     ],
                     "path": "s1",
                 },
-            ],
-            "coordinateTransformations": [
-                {"scale": [1.0, 1.0, 0.3, 1.0, 1.0], "type": "scale"},
-                {"translation": [0.0, 0.0, 2.0, 0.6, 0.0], "type": "translation"},
             ],
             "version": "0.4",
             "metadata": {
@@ -395,9 +401,7 @@ class TestOpExportSlot(object):
             assert written_ms["axes"] == expected_ms["axes"]
             assert written_ms["metadata"] == expected_ms["metadata"]
             assert written_ms["version"] == expected_ms["version"]
-            written_ms_transforms = written_ms["coordinateTransformations"]
-            expected_ms_transforms = expected_ms["coordinateTransformations"]
-            self._assert_transforms_eq(written_ms_transforms, expected_ms_transforms)
+            assert "coordinateTransformations" not in written_ms
             assert len(written_ms["datasets"]) == len(expected_ms["datasets"])
             for written_ds, expected_ds in zip(written_ms["datasets"], expected_ms["datasets"]):
                 assert written_ds["path"] == expected_ds["path"]

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -32,12 +32,11 @@ import h5py
 import pytest
 import zarr
 
-from collections import OrderedDict
 from typing import Tuple, List
 from PIL import Image
 
-from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations, NotAnOMEZarrMultiscale
-from lazyflow.utility.io_util.multiscaleStore import Multiscale
+from lazyflow.utility.io_util.clearscale import Multiscale
+from lazyflow.utility.io_util.OMEZarrStore import NotAnOMEZarrMultiscale
 from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 
 
@@ -310,9 +309,7 @@ class TestOpInputDataReaderWithOMEZarr:
             ("some.zarr/A/1/0", "s0", "s1"),  # well (./row/column/field-of-view/scales)
         ],
     )
-    def ome_zarr_store_on_disc(
-        self, tmp_path, request, monkeypatch
-    ) -> Tuple[PathTuple, List[numpy.array], Multiscale, OMEZarrTranslations]:
+    def ome_zarr_store_on_disc(self, tmp_path, request, monkeypatch) -> Tuple[PathTuple, List[numpy.array], Multiscale]:
         """Sets up a zarr store of a random image at raw scale and a downscale.
         Returns dataset paths, datasets, and the metadata expected on the
         reader's output slot."""
@@ -383,17 +380,11 @@ class TestOpInputDataReaderWithOMEZarr:
         )
 
         expected_images = [image_original, image_scaled]
-        # Scales metadata for GUI
-        expected_multiscale = OrderedDict(
-            [
-                (path0, OrderedDict(zip("cyx", dataset_shape))),
-                (path1, OrderedDict(zip("cyx", scaled_shape))),
-            ]
+        expected_multiscale = Multiscale.from_ome_zarr(
+            correct_multiscale_zattrs, get_shape=lambda path: tuple({path0: dataset_shape, path1: scaled_shape}[path])
         )
-        # OME-Zarr metadata for export
-        expected_additional_meta = OMEZarrTranslations.from_multiscale_spec(correct_multiscale_zattrs, "cyx")
 
-        return request.param, expected_images, expected_multiscale, expected_additional_meta
+        return request.param, expected_images, expected_multiscale
 
     @pytest.fixture
     def parent(self, graph):
@@ -401,7 +392,7 @@ class TestOpInputDataReaderWithOMEZarr:
         return Operator(graph=graph)
 
     def test_load_from_file_path(self, tmp_path, parent, ome_zarr_store_on_disc):
-        paths, expected_images, expected_multiscale, expected_additional_meta = ome_zarr_store_on_disc
+        paths, expected_images, expected_multiscale = ome_zarr_store_on_disc
         zarr_dir, path0, _ = paths
         # Request raw scale to test that the full path is used.
         # The loader implementation defaults to loading the lowest resolution (last scale).
@@ -411,14 +402,13 @@ class TestOpInputDataReaderWithOMEZarr:
         reader.WorkingDirectory.setValue(str(zarr_dir))
 
         assert reader.Output.meta.scales == expected_multiscale
-        assert reader.Output.meta.ome_zarr_translations == expected_additional_meta
 
         loaded_data = reader.Output[:].wait()
 
         numpy.testing.assert_array_equal(loaded_data, expected_images[0])
 
     def test_load_from_file_uri(self, tmp_path, parent, ome_zarr_store_on_disc):
-        paths, expected_images, expected_multiscale, expected_additional_meta = ome_zarr_store_on_disc
+        paths, expected_images, expected_multiscale = ome_zarr_store_on_disc
         zarr_dir, path0, _ = paths
         # Request raw scale to test that the full path is used.
         # The loader implementation defaults to loading the lowest resolution (last scale).
@@ -428,14 +418,13 @@ class TestOpInputDataReaderWithOMEZarr:
         reader.WorkingDirectory.setValue(str(zarr_dir))
 
         assert reader.Output.meta.scales == expected_multiscale
-        assert reader.Output.meta.ome_zarr_translations == expected_additional_meta
 
         loaded_data = reader.Output[:].wait()
 
         numpy.testing.assert_array_equal(loaded_data, expected_images[0])
 
     def test_load_from_file_path_via_slot(self, tmp_path, parent, ome_zarr_store_on_disc):
-        paths, expected_images, expected_multiscale, expected_additional_meta = ome_zarr_store_on_disc
+        paths, expected_images, expected_multiscale = ome_zarr_store_on_disc
         zarr_subdir, path0, _ = paths
         zarr_dir = tmp_path / zarr_subdir
         reader = OpInputDataReader(parent=parent, ActiveScale=path0)
@@ -443,14 +432,13 @@ class TestOpInputDataReaderWithOMEZarr:
         reader.WorkingDirectory.setValue(zarr_dir)
 
         assert reader.Output.meta.scales == expected_multiscale
-        assert reader.Output.meta.ome_zarr_translations == expected_additional_meta
 
         loaded_data = reader.Output[:].wait()
 
         numpy.testing.assert_array_equal(loaded_data, expected_images[0])
 
     def test_load_from_file_uri_via_slot(self, tmp_path, parent, ome_zarr_store_on_disc):
-        paths, expected_images, expected_multiscale, expected_additional_meta = ome_zarr_store_on_disc
+        paths, expected_images, expected_multiscale = ome_zarr_store_on_disc
         zarr_subdir, path0, _ = paths
         zarr_dir = tmp_path / zarr_subdir
         reader = OpInputDataReader(parent=parent, ActiveScale=path0)
@@ -458,7 +446,6 @@ class TestOpInputDataReaderWithOMEZarr:
         reader.WorkingDirectory.setValue(zarr_dir)
 
         assert reader.Output.meta.scales == expected_multiscale
-        assert reader.Output.meta.ome_zarr_translations == expected_additional_meta
 
         loaded_data = reader.Output[:].wait()
 

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -32,10 +32,10 @@ import h5py
 import pytest
 import zarr
 
+from clearscale import Multiscale
 from typing import Tuple, List
 from PIL import Image
 
-from lazyflow.utility.io_util.clearscale import Multiscale
 from lazyflow.utility.io_util.OMEZarrStore import NotAnOMEZarrMultiscale
 from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -36,11 +36,7 @@ from collections import OrderedDict
 from typing import Tuple, List
 from PIL import Image
 
-from lazyflow.utility.io_util.OMEZarrStore import (
-    OMEZarrTranslations,
-    InvalidTransformationError,
-    NotAnOMEZarrMultiscale,
-)
+from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations, NotAnOMEZarrMultiscale
 from lazyflow.utility.io_util.multiscaleStore import Multiscale
 from lazyflow.utility.io_util.write_ome_zarr import OME_ZARR_V_0_4_KWARGS
 
@@ -394,11 +390,8 @@ class TestOpInputDataReaderWithOMEZarr:
                 (path1, OrderedDict(zip("cyx", scaled_shape))),
             ]
         )
-        # Singleton the error so that OMEZarrMultiscaleMeta objects can be eq compared
-        err_placeholder = InvalidTransformationError()
-        monkeypatch.setattr(InvalidTransformationError, "__new__", lambda _: err_placeholder)
         # OME-Zarr metadata for export
-        expected_additional_meta = OMEZarrTranslations.from_multiscale_spec(correct_multiscale_zattrs)
+        expected_additional_meta = OMEZarrTranslations.from_multiscale_spec(correct_multiscale_zattrs, "cyx")
 
         return request.param, expected_images, expected_multiscale, expected_additional_meta
 

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -381,7 +381,8 @@ class TestOpInputDataReaderWithOMEZarr:
 
         expected_images = [image_original, image_scaled]
         expected_multiscale = Multiscale.from_ome_zarr(
-            correct_multiscale_zattrs, get_shape=lambda path: tuple({path0: dataset_shape, path1: scaled_shape}[path])
+            correct_multiscale_zattrs,
+            shape_source=lambda path: tuple({path0: dataset_shape, path1: scaled_shape}[path]),
         )
 
         return request.param, expected_images, expected_multiscale

--- a/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/testOpInputDataReader.py
@@ -32,7 +32,7 @@ import h5py
 import pytest
 import zarr
 
-from clearscale import Multiscale
+import clearscale
 from typing import Tuple, List
 from PIL import Image
 
@@ -309,7 +309,9 @@ class TestOpInputDataReaderWithOMEZarr:
             ("some.zarr/A/1/0", "s0", "s1"),  # well (./row/column/field-of-view/scales)
         ],
     )
-    def ome_zarr_store_on_disc(self, tmp_path, request, monkeypatch) -> Tuple[PathTuple, List[numpy.array], Multiscale]:
+    def ome_zarr_store_on_disc(
+        self, tmp_path, request, monkeypatch
+    ) -> Tuple[PathTuple, List[numpy.array], clearscale.Multiscale]:
         """Sets up a zarr store of a random image at raw scale and a downscale.
         Returns dataset paths, datasets, and the metadata expected on the
         reader's output slot."""
@@ -380,7 +382,7 @@ class TestOpInputDataReaderWithOMEZarr:
         )
 
         expected_images = [image_original, image_scaled]
-        expected_multiscale = Multiscale.from_ome_zarr(
+        expected_multiscale = clearscale.Multiscale.from_ome_zarr(
             correct_multiscale_zattrs,
             shape_source=lambda path: tuple({path0: dataset_shape, path1: scaled_shape}[path]),
         )

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -27,8 +27,8 @@ from lazyflow.operators.ioOperators import (
     OpStreamingH5N5Reader,
 )
 from lazyflow.slot import Slot
-from lazyflow.utility.io_util.clearscale import Multiscale, Scale, BlueprintShapes, Spacing, Unit
-from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, ShapesByScaleKey
+from lazyflow.utility.io_util.clearscale import Scale, BlueprintShapes, Spacing, Unit
+from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
 from ..test_ioOperators.testOpStreamingH5N5Reader import h5n5_file, data
 
 
@@ -837,7 +837,7 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     progress = mock.Mock()
     target_shape_up = OrderedDict(zip("tczyx", (6, 2, 16, 15, 13)))  # ome-zarr standard
     target_shape_down = OrderedDict(zip("tczyx", (6, 2, 3, 2, 3)))
-    target_scales: ShapesByScaleKey = OrderedDict([("upscale", target_shape_up), ("downscale", target_shape_down)])
+    target_scales = BlueprintShapes([("upscale", target_shape_up), ("downscale", target_shape_down)])
 
     write_ome_zarr(str(export_path), op_data.Output, progress, None, target_scales)
 
@@ -847,13 +847,12 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     assert "axis_units" in reader.Output.meta
     assert reader.Output.meta.axis_units == dict(zip(axes, units))
     assert reader.Output.meta.getAxisKeys() == list("tczyx")
-    assert reader.Output.meta.scales == Multiscale.from_shapes(
-        BlueprintShapes(target_scales),
+    assert reader.Output.meta.scales == BlueprintShapes(target_scales).apply_to_scale(
         Scale(
             shape=op_data.Output.meta.getTaggedShape(),
             spacing=Spacing.from_vigra(op_data.Output.meta.axistags),
             unit=Unit(op_data.Output.meta.axis_units),
-        ).with_axes("tczyx"),
+        ).with_axes("tczyx")
     )
     for tag in reader.Output.meta.axistags:
         scaling = source_shape[tag.key] / target_shape_down[tag.key]

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -707,6 +707,7 @@ def test_read_ome_zarr_v0_3(graph):
 
 
 def test_read_ome_zarr_v0_4(graph):
+    # Resolution 0 for channel seems like something that might happen in the wild
     pyramid_scale = {"t": 0.1, "c": 0, "z": 1, "y": 1, "x": 1}
     dataset_scale = {"t": 1.0, "c": 0, "z": 2.0, "y": 0.3, "x": 4.0}
     units = {"t": "sec", "c": "", "z": "mm", "y": "beep", "x": "metres"}
@@ -769,6 +770,9 @@ def test_read_ome_zarr_v0_4_no_units(graph):
     }
     array_mock = mock.Mock()
     array_mock.shape = (3, 2, 11, 10, 9)
+    # 1.0 is the default scale in OME-Zarr. It will be mapped to the vigra default resolution 0.0
+    expected_resolution = dataset_scale.copy()
+    expected_resolution["t"] = 0
 
     reader = OpOMEZarrMultiscaleReader(graph=graph)
     with patch_ome_zarr(ome_spec_v0_4, "file:///noop", array_mock):
@@ -780,7 +784,7 @@ def test_read_ome_zarr_v0_4_no_units(graph):
     assert reader.Output.meta.axis_units == {a: "" for a in dataset_scale}
     assert reader.Output.meta.getAxisKeys() == list(dataset_scale.keys())
     for tag in reader.Output.meta.axistags:
-        assert tag.resolution == dataset_scale[tag.key]
+        assert tag.resolution == expected_resolution[tag.key]
 
 
 def test_write_ome_zarr_single_scale(graph, tmp_path):

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -27,7 +27,7 @@ from lazyflow.operators.ioOperators import (
     OpStreamingH5N5Reader,
 )
 from lazyflow.slot import Slot
-from lazyflow.utility.io_util.clearscale import Scale, BlueprintShapes, Spacing, Unit
+from lazyflow.utility.io_util.clearscale import Scale, BlueprintShapes, PixelSize, Unit
 from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
 from ..test_ioOperators.testOpStreamingH5N5Reader import h5n5_file, data
 
@@ -850,7 +850,7 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     assert reader.Output.meta.scales == BlueprintShapes(target_scales).apply_to_scale(
         Scale(
             shape=op_data.Output.meta.getTaggedShape(),
-            spacing=Spacing.from_vigra(op_data.Output.meta.axistags),
+            pixel_size=PixelSize.from_vigra(op_data.Output.meta.axistags),
             unit=Unit(op_data.Output.meta.axis_units),
         ).with_axes("tczyx")
     )

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple, Union
 from unittest import mock
 from unittest.mock import ANY
 
+from clearscale import Scale, BlueprintShapes, PixelSize, Unit
 import h5py
 import numpy as np
 import pytest
@@ -27,7 +28,6 @@ from lazyflow.operators.ioOperators import (
     OpStreamingH5N5Reader,
 )
 from lazyflow.slot import Slot
-from lazyflow.utility.io_util.clearscale import Scale, BlueprintShapes, PixelSize, Unit
 from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr
 from ..test_ioOperators.testOpStreamingH5N5Reader import h5n5_file, data
 

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -811,8 +811,7 @@ def test_write_ome_zarr_single_scale(graph, tmp_path):
     # Dataset scale is mandatory, but should be noop here. In single-scale export from a single-scale source,
     # pixel size should be written on multiscale-level. This isn't a spec requirement, but a generalisation of the
     # convention of writing scale for the t-axis into the multiscale-level transforms.
-    expected_multiscale_transform = [{"type": "scale", "scale": [0.4, 8.99991, 5.0, 0.3, 6.4]}]  # tczyx
-    expected_dataset_transform = [{"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}]
+    expected_dataset_transform = [{"type": "scale", "scale": [0.4, 8.99991, 5.0, 0.3, 6.4]}]  # tczyx
 
     write_ome_zarr(str(export_path), op_data.Output, progress, None)
 
@@ -821,8 +820,7 @@ def test_write_ome_zarr_single_scale(graph, tmp_path):
     m = group.attrs["multiscales"][0]
     assert "axes" in m
     assert m["axes"] == expected_axes
-    assert "coordinateTransformations" in m
-    assert m["coordinateTransformations"] == expected_multiscale_transform
+    assert "coordinateTransformations" not in m
     assert "datasets" in m and "path" in m["datasets"][0]
     assert len(m["datasets"]) == 1
     assert m["datasets"][0]["coordinateTransformations"] == expected_dataset_transform

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -27,6 +27,7 @@ from lazyflow.operators.ioOperators import (
     OpStreamingH5N5Reader,
 )
 from lazyflow.slot import Slot
+from lazyflow.utility.io_util.clearscale import Multiscale, Scale, BlueprintShapes, Spacing, Unit
 from lazyflow.utility.io_util.write_ome_zarr import write_ome_zarr, ShapesByScaleKey
 from ..test_ioOperators.testOpStreamingH5N5Reader import h5n5_file, data
 
@@ -846,7 +847,14 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     assert "axis_units" in reader.Output.meta
     assert reader.Output.meta.axis_units == dict(zip(axes, units))
     assert reader.Output.meta.getAxisKeys() == list("tczyx")
-    assert reader.Output.meta.scales == target_scales
+    assert reader.Output.meta.scales == Multiscale.from_shapes(
+        BlueprintShapes(target_scales),
+        Scale(
+            shape=op_data.Output.meta.getTaggedShape(),
+            spacing=Spacing.from_vigra(op_data.Output.meta.axistags),
+            unit=Unit(op_data.Output.meta.axis_units),
+        ).with_axes("tczyx"),
+    )
     for tag in reader.Output.meta.axistags:
         scaling = source_shape[tag.key] / target_shape_down[tag.key]
         expected_resolution = scaling * resolutions[tag.key]

--- a/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
+++ b/tests/test_lazyflow/test_operators/test_ioOperators/test_pixel_sizes.py
@@ -5,9 +5,8 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from typing import Dict, List, Tuple, Union
 from unittest import mock
-from unittest.mock import ANY
 
-from clearscale import Scale, BlueprintShapes, PixelSize, Unit
+import clearscale
 import h5py
 import numpy as np
 import pytest
@@ -837,7 +836,7 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     progress = mock.Mock()
     target_shape_up = OrderedDict(zip("tczyx", (6, 2, 16, 15, 13)))  # ome-zarr standard
     target_shape_down = OrderedDict(zip("tczyx", (6, 2, 3, 2, 3)))
-    target_scales = BlueprintShapes([("upscale", target_shape_up), ("downscale", target_shape_down)])
+    target_scales = clearscale.BlueprintShapes([("upscale", target_shape_up), ("downscale", target_shape_down)])
 
     write_ome_zarr(str(export_path), op_data.Output, progress, None, target_scales)
 
@@ -847,11 +846,11 @@ def test_write_read_roundtrip_ome_zarr(graph, tmp_path):
     assert "axis_units" in reader.Output.meta
     assert reader.Output.meta.axis_units == dict(zip(axes, units))
     assert reader.Output.meta.getAxisKeys() == list("tczyx")
-    assert reader.Output.meta.scales == BlueprintShapes(target_scales).apply_to_scale(
-        Scale(
+    assert reader.Output.meta.scales == clearscale.BlueprintShapes(target_scales).apply_to_scale(
+        clearscale.Scale(
             shape=op_data.Output.meta.getTaggedShape(),
-            pixel_size=PixelSize.from_vigra(op_data.Output.meta.axistags),
-            unit=Unit(op_data.Output.meta.axis_units),
+            pixel_size=clearscale.PixelSize.from_vigra(op_data.Output.meta.axistags),
+            unit=clearscale.Unit(op_data.Output.meta.axis_units),
         ).with_axes("tczyx")
     )
     for tag in reader.Output.meta.axistags:

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -9,9 +9,8 @@ import zarr
 
 from lazyflow.operators import OpArrayPiper
 from lazyflow.utility.data_semantics import ImageTypes
-from lazyflow.utility.io_util.clearscale import Multiscale, BlueprintShapes, Scale, Shape
+from lazyflow.utility.io_util.clearscale import Multiscale, BlueprintShapes
 from lazyflow.utility.io_util.write_ome_zarr import (
-    ShapesByScaleKey,
     write_ome_zarr,
     generate_default_target_scales,
     _match_target_scales_to_input,
@@ -34,7 +33,7 @@ def tagged_shape(axes: Union[str, List[str]], shape: Iterable[int]):
         (
             (21, 23, 3),
             "yxc",
-            OrderedDict(
+            BlueprintShapes(
                 [
                     ("raw", tagged_shape("tczyx", (1, 3, 1, 21, 23))),
                     ("scaled", tagged_shape("tczyx", (1, 3, 1, 10, 12))),
@@ -44,7 +43,7 @@ def tagged_shape(axes: Union[str, List[str]], shape: Iterable[int]):
         (
             (21, 23, 3),
             "yxc",
-            OrderedDict({"s0": tagged_shape("tczyx", (1, 3, 1, 10, 12))}),
+            BlueprintShapes({"s0": tagged_shape("tczyx", (1, 3, 1, 10, 12))}),
         ),
     ],
 )
@@ -238,8 +237,7 @@ def test_resized_single_scale_export(tmp_path, tiny_5d_vigra_array_piper):
                 ("raw_scale", tagged_shape(input_axes, (2, 15, 15, 15))),
                 ("downscale", tagged_shape(input_axes, (2, 5, 5, 5))),
             ]
-        ),
-        Scale(shape=Shape(zip(input_axes, (2, 15, 15, 15)))),
+        )
     )
     target_scales = BlueprintShapes({"resized_scale": tagged_shape("tczyx", (2, 2, 10, 10, 10))})
     source_op.Output.meta.scales = input_scales
@@ -274,8 +272,7 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
     source_op.Output.meta.scales = Multiscale.from_shapes(
-        BlueprintShapes({"source_scale": source_op.Output.meta.getTaggedShape()}),
-        Scale(shape=source_op.Output.meta.getTaggedShape()),
+        BlueprintShapes({"source_scale": source_op.Output.meta.getTaggedShape()})
     )
     source_op.Output.meta.active_scale = "source_scale"
     # Both Precomputed and OME-Zarr readers would read the pixel size of the source scale from the source metadata.
@@ -289,7 +286,7 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     # The export image is (2,2,5,5,5), (simulating a 0,_,3,3,3 crop of source_scale),
     # so downscale and upscale shapes here need to be relative to that shape.
     # Also make up-scaling factors anisotropic and non-integer for good measure.
-    target_scales: ShapesByScaleKey = OrderedDict(
+    target_scales = BlueprintShapes(
         [
             ("weird_upscale", tagged_shape("tczyx", (2, 2, 13, 12, 12))),
             ("downscale", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -382,7 +379,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
         },
         get_shape=lambda path: (2, 5, 5, 5),
     )
-    target_scales: ShapesByScaleKey = OrderedDict(
+    target_scales = BlueprintShapes(
         [
             ("weird_upscale", tagged_shape("tczyx", (2, 2, 13, 12, 12))),
             ("downscale", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -438,7 +435,7 @@ def test_respects_interpolation_order(tmp_path, tiny_5d_vigra_array_piper):
     export_path = tmp_path
     source_op = tiny_5d_vigra_array_piper
     progress = mock.Mock()
-    target_scales: ShapesByScaleKey = OrderedDict(
+    target_scales = BlueprintShapes(
         [
             ("0", tagged_shape("tczyx", (2, 2, 5, 5, 5))),
             ("1", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -520,7 +517,9 @@ def test_generate_default_target_scales(shape, expected_shapes):
     [
         (  # Simple: match input scales in OME-Zarr order
             tagged_shape("yx", (1, 1)),
-            OrderedDict([("s0", tagged_shape("yx", (2, 2))), ("source_scale", tagged_shape("yx", (1, 1)))]),
+            Multiscale.from_shapes(
+                BlueprintShapes([("s0", tagged_shape("yx", (2, 2))), ("source_scale", tagged_shape("yx", (1, 1)))])
+            ),
             OrderedDict(
                 [
                     ("s0", tagged_shape("tczyx", (1, 1, 1, 2, 2))),
@@ -530,7 +529,11 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Input no channels + default scaling would create different scales than input has
             tagged_shape("yxc", (500, 500, 3)),
-            OrderedDict([("s0", tagged_shape("yx", (1100, 1100))), ("source_scale", tagged_shape("yx", (500, 500)))]),
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [("s0", tagged_shape("yx", (1100, 1100))), ("source_scale", tagged_shape("yx", (500, 500)))]
+                ),
+            ),
             OrderedDict(
                 [
                     ("s0", tagged_shape("tczyx", (1, 3, 1, 1100, 1100))),
@@ -540,8 +543,10 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Different number of channels in in put and export; input downscale was ceil-rounded (i.e. not like ilastik does)
             tagged_shape("yxc", (500, 500, 3)),
-            OrderedDict(
-                [("s0", tagged_shape("cyx", (2, 999, 999))), ("source_scale", tagged_shape("cyx", (2, 500, 500)))]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [("s0", tagged_shape("cyx", (2, 999, 999))), ("source_scale", tagged_shape("cyx", (2, 500, 500)))]
+                )
             ),
             OrderedDict(
                 [
@@ -552,12 +557,14 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Default scaling would not scale the input + export is cropped + source is middle scale
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            OrderedDict(
-                [
-                    ("0", tagged_shape("czyx", (2, 75, 75, 75))),
-                    ("source_scale", tagged_shape("czyx", (2, 25, 25, 25))),
-                    ("2", tagged_shape("czyx", (2, 8, 8, 8))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("0", tagged_shape("czyx", (2, 75, 75, 75))),
+                        ("source_scale", tagged_shape("czyx", (2, 25, 25, 25))),
+                        ("2", tagged_shape("czyx", (2, 8, 8, 8))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -572,12 +579,14 @@ def test_generate_default_target_scales(shape, expected_shapes):
             # OpResize refuses to scale along t, so all output scales need to be identical.
             # Note that OME-Zarr allows identical shapes at different scales.
             tagged_shape("tyxc", (5, 25, 25, 2)),
-            OrderedDict(
-                [
-                    ("0", tagged_shape("cyxt", (3, 25, 25, 32))),
-                    ("source_scale", tagged_shape("cyxt", (3, 25, 25, 11))),
-                    ("2", tagged_shape("cyxt", (3, 25, 25, 3))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("0", tagged_shape("cyxt", (3, 25, 25, 32))),
+                        ("source_scale", tagged_shape("cyxt", (3, 25, 25, 11))),
+                        ("2", tagged_shape("cyxt", (3, 25, 25, 3))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -599,12 +608,14 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
     [
         (  # Simple: match input scales in original order, even if ilastik default would not downscale
             tagged_shape("yx", (4, 4)),
-            OrderedDict(
-                [
-                    ("source_scale", tagged_shape("yx", (4, 4))),
-                    ("s2", tagged_shape("yx", (2, 2))),
-                    ("s3", tagged_shape("yx", (1, 1))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("source_scale", tagged_shape("yx", (4, 4))),
+                        ("s2", tagged_shape("yx", (2, 2))),
+                        ("s3", tagged_shape("yx", (1, 1))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -616,13 +627,15 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Input had no channels + ilastik default _would_ downscale
             tagged_shape("yxc", (1000, 1000, 3)),
-            OrderedDict([("source_scale", tagged_shape("yx", (1000, 1000)))]),
+            Multiscale.from_shapes(BlueprintShapes([("source_scale", tagged_shape("yx", (1000, 1000)))])),
             OrderedDict([("source_scale", tagged_shape("tczyx", (1, 3, 1, 1000, 1000)))]),
         ),
         (  # Different number of channels in input and export; input downscale was ceil-rounded (i.e. not like ilastik does)
             tagged_shape("yxc", (531, 531, 3)),
-            OrderedDict(
-                [("source_scale", tagged_shape("cyx", (2, 531, 531))), ("s2", tagged_shape("cyx", (2, 266, 266)))]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [("source_scale", tagged_shape("cyx", (2, 531, 531))), ("s2", tagged_shape("cyx", (2, 266, 266)))]
+                )
             ),
             OrderedDict(
                 [
@@ -633,13 +646,15 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped + source is middle scale (upscales should be excluded)
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            OrderedDict(
-                [
-                    ("0", tagged_shape("czyx", (2, 225, 225, 225))),
-                    ("1", tagged_shape("czyx", (2, 75, 75, 75))),
-                    ("source_scale", tagged_shape("czyx", (2, 25, 25, 25))),
-                    ("4", tagged_shape("czyx", (2, 8, 8, 8))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("0", tagged_shape("czyx", (2, 225, 225, 225))),
+                        ("1", tagged_shape("czyx", (2, 75, 75, 75))),
+                        ("source_scale", tagged_shape("czyx", (2, 25, 25, 25))),
+                        ("4", tagged_shape("czyx", (2, 8, 8, 8))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -650,11 +665,13 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped + input has no channels
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            OrderedDict(
-                [
-                    ("source_scale", tagged_shape("zyx", (25, 25, 25))),
-                    ("4", tagged_shape("zyx", (8, 8, 8))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("source_scale", tagged_shape("zyx", (25, 25, 25))),
+                        ("4", tagged_shape("zyx", (8, 8, 8))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -665,14 +682,16 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped tiny (matching all downscales would lead to 0 shapes) + makes an axis singleton
             tagged_shape("zyxc", (19, 7, 1, 3)),
-            OrderedDict(
-                [
-                    ("0", tagged_shape("czyx", (2, 225, 225, 225))),
-                    ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
-                    ("2", tagged_shape("czyx", (2, 25, 25, 25))),
-                    ("3", tagged_shape("czyx", (2, 8, 8, 8))),
-                    ("4", tagged_shape("czyx", (2, 2, 2, 2))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("0", tagged_shape("czyx", (2, 225, 225, 225))),
+                        ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
+                        ("2", tagged_shape("czyx", (2, 25, 25, 25))),
+                        ("3", tagged_shape("czyx", (2, 8, 8, 8))),
+                        ("4", tagged_shape("czyx", (2, 2, 2, 2))),
+                    ]
+                )
             ),
             OrderedDict(
                 [
@@ -683,12 +702,14 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export cropped to 1px
             tagged_shape("zyxc", (1, 1, 1, 2)),
-            OrderedDict(
-                [
-                    ("0", tagged_shape("czyx", (2, 225, 225, 225))),
-                    ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
-                    ("2", tagged_shape("czyx", (2, 25, 25, 25))),
-                ]
+            Multiscale.from_shapes(
+                BlueprintShapes(
+                    [
+                        ("0", tagged_shape("czyx", (2, 225, 225, 225))),
+                        ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
+                        ("2", tagged_shape("czyx", (2, 25, 25, 25))),
+                    ]
+                )
             ),
             OrderedDict(
                 [

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -163,16 +163,13 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
     source_op.Output.meta.axistags.setResolution("y", resolution_xyz)
     source_op.Output.meta.axistags.setResolution("x", resolution_xyz)
     source_op.Output.meta.axis_units = units
-    expected_multiscale_transform = [
-        {"type": "scale", "scale": [resolution_t, 1.0, 1.0, 1.0, 1.0]},
+    # When no actual scaling is done by ilastik, input scale should be carried over unmodified even if imprecise.
+    expected_source_scale_transform = [
+        {"type": "scale", "scale": [resolution_t, 1.0, resolution_xyz, resolution_xyz, resolution_xyz]},
         {
             "type": "translation",
             "translation": [0.1, 0.0, 11.2, 9.0, 9.0],
         },  # offset * input scale + source scale translation
-    ]
-    # When no actual scaling is done by ilastik, input scale should be carried over unmodified even if imprecise.
-    expected_source_scale_transform = [
-        {"type": "scale", "scale": [1.0, 1.0, resolution_xyz, resolution_xyz, resolution_xyz]},
     ]
     source_op.Output.meta.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(
         {
@@ -225,7 +222,7 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
         {"name": "y", "type": "space", "unit": "micrometer"},
         {"name": "x", "type": "space", "unit": "micrometer"},
     ]  # Axis units should be carried over
-    assert m["coordinateTransformations"] == expected_multiscale_transform
+    assert "coordinateTransformations" not in m
     assert m["datasets"][0]["path"] == "source_scale"
     assert m["datasets"][0]["coordinateTransformations"] == expected_source_scale_transform
 
@@ -280,7 +277,7 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     progress = mock.Mock()
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
-    source_op.Output.meta.scales = OrderedDict({"noop": {"boop": "should be irrelevant"}})
+    source_op.Output.meta.scales = OrderedDict({"noop": {"should be irrelevant": 1}})
     source_op.Output.meta.active_scale = "source_scale"
     # Both Precomputed and OME-Zarr readers would read the pixel size of the source scale from the source metadata.
     # A hypothetical multiscale reader with no direct pixel size meta should still provide
@@ -336,7 +333,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
     progress = mock.Mock()
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
-    source_op.Output.meta.scales = OrderedDict({"noop": {"boop": "should be irrelevant"}})
+    source_op.Output.meta.scales = OrderedDict({"noop": {"should be irrelevant": 1}})
     source_op.Output.meta.active_scale = "source_scale"
     resolution_t = 0.1
     resolution_xyz = 2.0  # Writers might round scaling factors. We have to assume this is intentional and maintain it.

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -196,7 +196,7 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
                 },
             ],
         },
-        get_shape=lambda path: {
+        shape_source=lambda path: {
             "raw_scale": (2, 17, 17, 17),
             "source_scale": (2, 9, 9, 9),
             "downscale": (2, 5, 5, 5),
@@ -377,7 +377,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
                 },
             ],
         },
-        get_shape=lambda path: (2, 5, 5, 5),
+        shape_source=lambda path: (2, 5, 5, 5),
     )
     target_scales = BlueprintShapes(
         [

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -302,10 +302,7 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     # 2px would be the result of scaling 5px by 2.0.
     # The scaling implementation in OpResize is precise though, so metadata should not be rounded.
     expected_downscale = [1.0, 1.0, s * 5 / 2, s * 5 / 2, s * 5 / 2]
-    expected_multiscale_transforms = [
-        {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]},
-        {"type": "translation", "translation": [0.0, 0.0, s * 3, s * 3, s * 3]},  # scaled offset
-    ]
+    expected_translation = {"type": "translation", "translation": [0.0, 0.0, s * 3, s * 3, s * 3]}  # scaled offset
 
     write_ome_zarr(str(export_path), source_op.Output, progress, export_offset, target_scales)
 
@@ -315,13 +312,15 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     assert "datasets" in m and "path" in m["datasets"][0]
     assert len(m["datasets"]) == 2
     assert m["datasets"][0]["path"] == "weird_upscale"
-    assert m["coordinateTransformations"] == expected_multiscale_transforms
+    assert "coordinateTransformations" not in m
     # The factor calculations come out unequal at 1e-16
     upscale_transforms = m["datasets"][0]["coordinateTransformations"]
     numpy.testing.assert_allclose(upscale_transforms[0]["scale"], expected_upscale, atol=1e-15)
+    assert upscale_transforms[1] == expected_translation
     assert m["datasets"][1]["path"] == "downscale"
     downscale_transforms = m["datasets"][1]["coordinateTransformations"]
     numpy.testing.assert_allclose(downscale_transforms[0]["scale"], expected_downscale, atol=1e-15)
+    assert downscale_transforms[1] == expected_translation
 
 
 def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper):
@@ -392,18 +391,23 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
             ("downscale", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
         ]
     )
-    expected_multiscale_transform = [
-        {"type": "scale", "scale": [0.1, 1.0, 1.0, 1.0, 1.0]},
+    s_abs = 2.0  # Even if OpResize scales precisely, output should be computed based on the input's metadata.
+    upscale = [0.1, 1.0, s_abs * 5 / 13, s_abs * 5 / 12, s_abs * 5 / 12]
+    downscale = [0.1, 1.0, s_abs * 5 / 2, s_abs * 5 / 2, s_abs * 5 / 2]
+    expected_upscale_transform = [
+        {"type": "scale", "scale": upscale},
         {
             "type": "translation",
             "translation": [3.1, 0.0, 9.2, 8.1, 7.0],
         },  # offset * input scale + source scale translation
     ]
-    s_abs = 2.0  # Even if OpResize scales precisely, output should be computed based on the input's metadata.
-    upscale = [1.0, 1.0, s_abs * 5 / 13, s_abs * 5 / 12, s_abs * 5 / 12]
-    downscale = [1.0, 1.0, s_abs * 5 / 2, s_abs * 5 / 2, s_abs * 5 / 2]
-    expected_upscale_transform = [{"type": "scale", "scale": upscale}]
-    expected_downscale_transform = [{"type": "scale", "scale": downscale}]
+    expected_downscale_transform = [
+        {"type": "scale", "scale": downscale},
+        {
+            "type": "translation",
+            "translation": [3.1, 0.0, 9.2, 8.1, 7.0],
+        },  # offset * input scale + source scale translation
+    ]
 
     write_ome_zarr(str(export_path), source_op.Output, progress, export_offset, target_scales)
 
@@ -420,7 +424,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
         {"name": "y", "type": "space", "unit": "micrometer"},
         {"name": "x", "type": "space", "unit": "micrometer"},
     ]  # Axis units should be carried over
-    assert m["coordinateTransformations"] == expected_multiscale_transform
+    assert "coordinateTransformations" not in m
     assert m["datasets"][0]["path"] == "weird_upscale"
     assert m["datasets"][0]["coordinateTransformations"] == expected_upscale_transform
     assert m["datasets"][1]["path"] == "downscale"

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -567,6 +567,26 @@ def test_generate_default_target_scales(shape, expected_shapes):
                 ]
             ),
         ),
+        (
+            # Weird case: input is a framerate multiscale, export crops t.
+            # OpResize refuses to scale along t, so all output scales need to be identical.
+            # Note that OME-Zarr allows identical shapes at different scales.
+            tagged_shape("tyxc", (5, 25, 25, 2)),
+            OrderedDict(
+                [
+                    ("0", tagged_shape("cyxt", (3, 25, 25, 32))),
+                    ("source_scale", tagged_shape("cyxt", (3, 25, 25, 11))),
+                    ("2", tagged_shape("cyxt", (3, 25, 25, 3))),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("0", tagged_shape("tczyx", (5, 2, 1, 25, 25))),
+                    ("source_scale", tagged_shape("tczyx", (5, 2, 1, 25, 25))),
+                    ("2", tagged_shape("tczyx", (5, 2, 1, 25, 25))),
+                ]
+            ),
+        ),
     ],
 )
 def test_match_target_scales_to_input(shape, input_scales, expected_shapes):

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from typing import List, Union, Iterable
 from unittest import mock
 
+from clearscale import Multiscale, BlueprintShapes
 import numpy
 import pytest
 import vigra
@@ -9,7 +10,6 @@ import zarr
 
 from lazyflow.operators import OpArrayPiper
 from lazyflow.utility.data_semantics import ImageTypes
-from lazyflow.utility.io_util.clearscale import Multiscale, BlueprintShapes
 from lazyflow.utility.io_util.write_ome_zarr import (
     write_ome_zarr,
     generate_default_target_scales,

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -204,7 +204,8 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
                     ],
                 },
             ],
-        }
+        },
+        axes="tzyx",
     )
 
     write_ome_zarr(str(export_path), source_op.Output, progress, export_offset)
@@ -382,7 +383,8 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
                     ],
                 },
             ],
-        }
+        },
+        axes="tzyx",
     )
     target_scales: ShapesByScaleKey = OrderedDict(
         [

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -9,7 +9,7 @@ import zarr
 
 from lazyflow.operators import OpArrayPiper
 from lazyflow.utility.data_semantics import ImageTypes
-from lazyflow.utility.io_util.OMEZarrStore import OMEZarrTranslations
+from lazyflow.utility.io_util.clearscale import Multiscale, BlueprintShapes, Scale, Shape
 from lazyflow.utility.io_util.write_ome_zarr import (
     ShapesByScaleKey,
     write_ome_zarr,
@@ -143,17 +143,8 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
     export_path = tmp_path / "test_multi_to_single.zarr"
     source_op = tiny_5d_vigra_array_piper
     progress = mock.Mock()
-    # Input scales are only relevant here for the export to determine that xyz are scaling axes
-    multiscale: ShapesByScaleKey = OrderedDict(
-        [
-            ("raw_scale", tagged_shape("tzyx", (2, 17, 17, 17))),
-            ("source_scale", tagged_shape("tzyx", (2, 9, 9, 9))),
-            ("downscale", tagged_shape("tzyx", (2, 5, 5, 5))),
-        ]
-    )
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source source_scale after a 4/4/4 offset
     export_offset = (0, 0, 4, 4, 4)
-    source_op.Output.meta.scales = multiscale
     source_op.Output.meta.active_scale = "source_scale"
     resolution_t = 0.1
     resolution_xyz = 2.0  # Writers might round scaling factors. We have to assume this is intentional and maintain it.
@@ -171,7 +162,7 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
             "translation": [0.1, 0.0, 11.2, 9.0, 9.0],
         },  # offset * input scale + source scale translation
     ]
-    source_op.Output.meta.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(
+    source_op.Output.meta.scales = Multiscale.from_ome_zarr(
         {
             "name": "wonderful_pyramid",
             "axes": [
@@ -192,7 +183,8 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
                 {
                     "path": "source_scale",
                     "coordinateTransformations": [
-                        {"type": "scale", "scale": "should not be accessed"},
+                        # Bad metadata: Ensure it's not copied
+                        {"type": "scale", "scale": [2.4, 1.3, 3.7, 6.9]},
                         {"type": "translation", "translation": [0.1, 3.2, 1.0, 1.0]},
                     ],
                 },
@@ -205,7 +197,11 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
                 },
             ],
         },
-        axes="tzyx",
+        get_shape=lambda path: {
+            "raw_scale": (2, 17, 17, 17),
+            "source_scale": (2, 9, 9, 9),
+            "downscale": (2, 5, 5, 5),
+        }[path],
     )
 
     write_ome_zarr(str(export_path), source_op.Output, progress, export_offset)
@@ -236,17 +232,16 @@ def test_resized_single_scale_export(tmp_path, tiny_5d_vigra_array_piper):
     progress = mock.Mock()
     input_axes = ["c", "z", "y", "x"]  # Neuroglancer Precomputed axes for a change
     # Input scales are only relevant here for the export to determine that xyz are scaling axes
-    input_scales: ShapesByScaleKey = OrderedDict(
-        [
-            ("raw_scale", tagged_shape(input_axes, (2, 15, 15, 15))),
-            ("downscale", tagged_shape(input_axes, (2, 5, 5, 5))),
-        ]
+    input_scales = Multiscale.from_shapes(
+        BlueprintShapes(
+            [
+                ("raw_scale", tagged_shape(input_axes, (2, 15, 15, 15))),
+                ("downscale", tagged_shape(input_axes, (2, 5, 5, 5))),
+            ]
+        ),
+        Scale(shape=Shape(zip(input_axes, (2, 15, 15, 15)))),
     )
-    target_scales: ShapesByScaleKey = OrderedDict(
-        [
-            ("resized_scale", tagged_shape("tczyx", (2, 2, 10, 10, 10))),
-        ]
-    )
+    target_scales = BlueprintShapes({"resized_scale": tagged_shape("tczyx", (2, 2, 10, 10, 10))})
     source_op.Output.meta.scales = input_scales
     source_op.Output.meta.active_scale = "downscale"
     source_op.Output.meta.axistags.setResolution("t", 1.0)
@@ -278,7 +273,10 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     progress = mock.Mock()
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
-    source_op.Output.meta.scales = OrderedDict({"noop": {"should be irrelevant": 1}})
+    source_op.Output.meta.scales = Multiscale.from_shapes(
+        BlueprintShapes({"source_scale": source_op.Output.meta.getTaggedShape()}),
+        Scale(shape=source_op.Output.meta.getTaggedShape()),
+    )
     source_op.Output.meta.active_scale = "source_scale"
     # Both Precomputed and OME-Zarr readers would read the pixel size of the source scale from the source metadata.
     # A hypothetical multiscale reader with no direct pixel size meta should still provide
@@ -333,7 +331,6 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
     progress = mock.Mock()
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
-    source_op.Output.meta.scales = OrderedDict({"noop": {"should be irrelevant": 1}})
     source_op.Output.meta.active_scale = "source_scale"
     resolution_t = 0.1
     resolution_xyz = 2.0  # Writers might round scaling factors. We have to assume this is intentional and maintain it.
@@ -343,7 +340,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
     source_op.Output.meta.axistags.setResolution("y", resolution_xyz)
     source_op.Output.meta.axistags.setResolution("x", resolution_xyz)
     source_op.Output.meta.axis_units = units
-    source_op.Output.meta.ome_zarr_translations = OMEZarrTranslations.from_multiscale_spec(
+    source_op.Output.meta.scales = Multiscale.from_ome_zarr(
         {
             "name": "wonderful_pyramid",
             "axes": [
@@ -383,7 +380,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
                 },
             ],
         },
-        axes="tzyx",
+        get_shape=lambda path: (2, 5, 5, 5),
     )
     target_scales: ShapesByScaleKey = OrderedDict(
         [

--- a/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
+++ b/tests/test_lazyflow/test_utility/test_io_util/test_write_ome_zarr.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from typing import List, Union, Iterable
 from unittest import mock
 
-from clearscale import Multiscale, BlueprintShapes
+import clearscale
 import numpy
 import pytest
 import vigra
@@ -33,7 +33,7 @@ def tagged_shape(axes: Union[str, List[str]], shape: Iterable[int]):
         (
             (21, 23, 3),
             "yxc",
-            BlueprintShapes(
+            clearscale.BlueprintShapes(
                 [
                     ("raw", tagged_shape("tczyx", (1, 3, 1, 21, 23))),
                     ("scaled", tagged_shape("tczyx", (1, 3, 1, 10, 12))),
@@ -43,7 +43,7 @@ def tagged_shape(axes: Union[str, List[str]], shape: Iterable[int]):
         (
             (21, 23, 3),
             "yxc",
-            BlueprintShapes({"s0": tagged_shape("tczyx", (1, 3, 1, 10, 12))}),
+            clearscale.BlueprintShapes({"s0": tagged_shape("tczyx", (1, 3, 1, 10, 12))}),
         ),
     ],
 )
@@ -161,7 +161,7 @@ def test_port_ome_zarr_metadata_single_scale_export(tmp_path, tiny_5d_vigra_arra
             "translation": [0.1, 0.0, 11.2, 9.0, 9.0],
         },  # offset * input scale + source scale translation
     ]
-    source_op.Output.meta.scales = Multiscale.from_ome_zarr(
+    source_op.Output.meta.scales = clearscale.Multiscale.from_ome_zarr(
         {
             "name": "wonderful_pyramid",
             "axes": [
@@ -231,15 +231,15 @@ def test_resized_single_scale_export(tmp_path, tiny_5d_vigra_array_piper):
     progress = mock.Mock()
     input_axes = ["c", "z", "y", "x"]  # Neuroglancer Precomputed axes for a change
     # Input scales are only relevant here for the export to determine that xyz are scaling axes
-    input_scales = Multiscale.from_shapes(
-        BlueprintShapes(
+    input_scales = clearscale.Multiscale.from_shapes(
+        dict(
             [
                 ("raw_scale", tagged_shape(input_axes, (2, 15, 15, 15))),
                 ("downscale", tagged_shape(input_axes, (2, 5, 5, 5))),
             ]
         )
     )
-    target_scales = BlueprintShapes({"resized_scale": tagged_shape("tczyx", (2, 2, 10, 10, 10))})
+    target_scales = clearscale.BlueprintShapes({"resized_scale": tagged_shape("tczyx", (2, 2, 10, 10, 10))})
     source_op.Output.meta.scales = input_scales
     source_op.Output.meta.active_scale = "downscale"
     source_op.Output.meta.axistags.setResolution("t", 1.0)
@@ -271,8 +271,8 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     progress = mock.Mock()
     # The tiny_5d_array is 5x5x5; in this test it represents a subregion of source_scale after a 3/3/3 offset
     export_offset = (0, 0, 3, 3, 3)
-    source_op.Output.meta.scales = Multiscale.from_shapes(
-        BlueprintShapes({"source_scale": source_op.Output.meta.getTaggedShape()})
+    source_op.Output.meta.scales = clearscale.Multiscale.from_shapes(
+        clearscale.BlueprintShapes({"source_scale": source_op.Output.meta.getTaggedShape()})
     )
     source_op.Output.meta.active_scale = "source_scale"
     # Both Precomputed and OME-Zarr readers would read the pixel size of the source scale from the source metadata.
@@ -286,7 +286,7 @@ def test_transformations_multi_scale_export(tmp_path, tiny_5d_vigra_array_piper)
     # The export image is (2,2,5,5,5), (simulating a 0,_,3,3,3 crop of source_scale),
     # so downscale and upscale shapes here need to be relative to that shape.
     # Also make up-scaling factors anisotropic and non-integer for good measure.
-    target_scales = BlueprintShapes(
+    target_scales = clearscale.BlueprintShapes(
         [
             ("weird_upscale", tagged_shape("tczyx", (2, 2, 13, 12, 12))),
             ("downscale", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -337,7 +337,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
     source_op.Output.meta.axistags.setResolution("y", resolution_xyz)
     source_op.Output.meta.axistags.setResolution("x", resolution_xyz)
     source_op.Output.meta.axis_units = units
-    source_op.Output.meta.scales = Multiscale.from_ome_zarr(
+    source_op.Output.meta.scales = clearscale.Multiscale.from_ome_zarr(
         {
             "name": "wonderful_pyramid",
             "axes": [
@@ -379,7 +379,7 @@ def test_port_ome_zarr_metadata_multi_scale_export(tmp_path, tiny_5d_vigra_array
         },
         shape_source=lambda path: (2, 5, 5, 5),
     )
-    target_scales = BlueprintShapes(
+    target_scales = clearscale.BlueprintShapes(
         [
             ("weird_upscale", tagged_shape("tczyx", (2, 2, 13, 12, 12))),
             ("downscale", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -435,7 +435,7 @@ def test_respects_interpolation_order(tmp_path, tiny_5d_vigra_array_piper):
     export_path = tmp_path
     source_op = tiny_5d_vigra_array_piper
     progress = mock.Mock()
-    target_scales = BlueprintShapes(
+    target_scales = clearscale.BlueprintShapes(
         [
             ("0", tagged_shape("tczyx", (2, 2, 5, 5, 5))),
             ("1", tagged_shape("tczyx", (2, 2, 2, 2, 2))),
@@ -517,8 +517,8 @@ def test_generate_default_target_scales(shape, expected_shapes):
     [
         (  # Simple: match input scales in OME-Zarr order
             tagged_shape("yx", (1, 1)),
-            Multiscale.from_shapes(
-                BlueprintShapes([("s0", tagged_shape("yx", (2, 2))), ("source_scale", tagged_shape("yx", (1, 1)))])
+            clearscale.Multiscale.from_shapes(
+                dict([("s0", tagged_shape("yx", (2, 2))), ("source_scale", tagged_shape("yx", (1, 1)))])
             ),
             OrderedDict(
                 [
@@ -529,10 +529,8 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Input no channels + default scaling would create different scales than input has
             tagged_shape("yxc", (500, 500, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
-                    [("s0", tagged_shape("yx", (1100, 1100))), ("source_scale", tagged_shape("yx", (500, 500)))]
-                ),
+            clearscale.Multiscale.from_shapes(
+                dict([("s0", tagged_shape("yx", (1100, 1100))), ("source_scale", tagged_shape("yx", (500, 500)))]),
             ),
             OrderedDict(
                 [
@@ -543,10 +541,8 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Different number of channels in in put and export; input downscale was ceil-rounded (i.e. not like ilastik does)
             tagged_shape("yxc", (500, 500, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
-                    [("s0", tagged_shape("cyx", (2, 999, 999))), ("source_scale", tagged_shape("cyx", (2, 500, 500)))]
-                )
+            clearscale.Multiscale.from_shapes(
+                dict([("s0", tagged_shape("cyx", (2, 999, 999))), ("source_scale", tagged_shape("cyx", (2, 500, 500)))])
             ),
             OrderedDict(
                 [
@@ -557,8 +553,8 @@ def test_generate_default_target_scales(shape, expected_shapes):
         ),
         (  # Default scaling would not scale the input + export is cropped + source is middle scale
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("0", tagged_shape("czyx", (2, 75, 75, 75))),
                         ("source_scale", tagged_shape("czyx", (2, 25, 25, 25))),
@@ -579,8 +575,8 @@ def test_generate_default_target_scales(shape, expected_shapes):
             # OpResize refuses to scale along t, so all output scales need to be identical.
             # Note that OME-Zarr allows identical shapes at different scales.
             tagged_shape("tyxc", (5, 25, 25, 2)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("0", tagged_shape("cyxt", (3, 25, 25, 32))),
                         ("source_scale", tagged_shape("cyxt", (3, 25, 25, 11))),
@@ -608,8 +604,8 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
     [
         (  # Simple: match input scales in original order, even if ilastik default would not downscale
             tagged_shape("yx", (4, 4)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("source_scale", tagged_shape("yx", (4, 4))),
                         ("s2", tagged_shape("yx", (2, 2))),
@@ -627,15 +623,13 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Input had no channels + ilastik default _would_ downscale
             tagged_shape("yxc", (1000, 1000, 3)),
-            Multiscale.from_shapes(BlueprintShapes([("source_scale", tagged_shape("yx", (1000, 1000)))])),
+            clearscale.Multiscale.from_shapes(dict([("source_scale", tagged_shape("yx", (1000, 1000)))])),
             OrderedDict([("source_scale", tagged_shape("tczyx", (1, 3, 1, 1000, 1000)))]),
         ),
         (  # Different number of channels in input and export; input downscale was ceil-rounded (i.e. not like ilastik does)
             tagged_shape("yxc", (531, 531, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
-                    [("source_scale", tagged_shape("cyx", (2, 531, 531))), ("s2", tagged_shape("cyx", (2, 266, 266)))]
-                )
+            clearscale.Multiscale.from_shapes(
+                dict([("source_scale", tagged_shape("cyx", (2, 531, 531))), ("s2", tagged_shape("cyx", (2, 266, 266)))])
             ),
             OrderedDict(
                 [
@@ -646,8 +640,8 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped + source is middle scale (upscales should be excluded)
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("0", tagged_shape("czyx", (2, 225, 225, 225))),
                         ("1", tagged_shape("czyx", (2, 75, 75, 75))),
@@ -665,8 +659,8 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped + input has no channels
             tagged_shape("zyxc", (16, 16, 16, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("source_scale", tagged_shape("zyx", (25, 25, 25))),
                         ("4", tagged_shape("zyx", (8, 8, 8))),
@@ -682,8 +676,8 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export is cropped tiny (matching all downscales would lead to 0 shapes) + makes an axis singleton
             tagged_shape("zyxc", (19, 7, 1, 3)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("0", tagged_shape("czyx", (2, 225, 225, 225))),
                         ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),
@@ -702,8 +696,8 @@ def test_match_target_scales_to_input(shape, input_scales, expected_shapes):
         ),
         (  # Export cropped to 1px
             tagged_shape("zyxc", (1, 1, 1, 2)),
-            Multiscale.from_shapes(
-                BlueprintShapes(
+            clearscale.Multiscale.from_shapes(
+                dict(
                     [
                         ("0", tagged_shape("czyx", (2, 225, 225, 225))),
                         ("source_scale", tagged_shape("czyx", (2, 75, 75, 75))),


### PR DESCRIPTION
This PR simplifies ilastik's OME-Zarr metadata handling using the new [`clearscale`](https://github.com/ilastik/clearscale) package.

This isn't a pure refactor though, there are some subtle changes in written OME-Zarr metadata (reflected in the test changes on this PR).

Requires:

```
pip install git+https://github.com/ilastik/clearscale.git@ilastik-review2
```

## Production changes

For those who like to read, and for my own record if necessary...

### `slot.meta.scales` is now `clearscale.Multiscale`

The most significant functional change across ilastik is this, `slow.meta.scales` throughout workflows before was
`{scale_key : TaggedShape}` .
Now it's a `clearscale.Multiscale` object, which works like
`{scale_key : Scale(shape=Shape(), pixel_size=PixelSize(), unit=Unit(), translation=Translation()) }`

clearscale's `Shape`, `PixelSize` etc. are all basically flavours of `TaggedShape` (axis -> value mappings).

All of the test changes besides the ones specified below are to accommodate this change.

### `1.0` scale (pixel size) metadata is normalised to `0.0` on vigra axistags

This is cleaner in the sense that vigra axistag resolution is `0.0` by default. Currently, reading `1.0` out of scale metadata puts that 1.0 into axistag resolution. `1.0` is effectively noop, but the vigra axistag is then technically non-default.

I've implemented the normalisation in clearscale: vigra default `0.0` maps to clearscale default `1.0` in `PixelSize.from_vigra` and backwards in `PixelSize.to_vigra`. This lets the axistag genuinely be default when the received value is the default.

This changes the assertion in `test_pixel_sizes::test_read_ome_zarr_v0_4`

### OME-Zarr `scale` metadata is now more consistent with 0.4 spec

* "multiscale-transforms" refers to meta under `multiscale["coordinateTransformations"]`
* "dataset-transforms" refers to meta under `multiscale["datasets"][]["coordinateTransformations"]`

(Each of which can have one `scale` and optionally one `translation`)

Older OME-Zarr versions had a documented convention where `scale` along *unscaled* axes like `t` is recorded on multiscale-transforms, while `scale` along *scaled* axes (typically `xyz`) is recorded on dataset-transforms. The respective other axes get the default `1.0` scale. The examples in the spec only show this for `t`, because the `xyz` are scaled axes:
```
// ...
"datasets": [
    {
        "path": "0",
        "coordinateTransformations": [{ // the voxel size for the first scale level (0.5 micrometer)
            "type": "scale", "scale": [1.0, 1.0, 0.5, 0.5, 0.5]
        }]
    },
    // ...
]
"coordinateTransformations": [{ // the time unit (0.1 milliseconds), which is the same for each scale level
    "type": "scale",   "scale": [0.1, 1.0, 1.0, 1.0, 1.0]
}],
// ...
```

Despite being a prominent convention, and shown in the spec's own examples, this directly contradict's the spec's own phrasing:

> Each dictionary in “datasets” MUST contain the field “coordinateTransformations” [...]. They MUST contain exactly one scale transformation that specifies the pixel size in physical units or time duration.

Very explicitly, pixel size = dataset-transforms, not multiscale-transforms, including time.

ilastik's writer took the contradictory convention all the way, applying the general rule "scale for unscaled axes -> multiscale-transforms. rest -> dataset-transforms". For the `single-scale OME-Zarr` export format, none of the axes are scaled, which means all `scale` values (pixel size) were written to multiscale-transforms, and `scale` values in dataset-transforms were all `1.0`. Example exerpt from a test:

```
    expected_multiscale_transform = [{"type": "scale", "scale": [0.4, 8.99991, 5.0, 0.3, 6.4]}]  # tczyx
    expected_dataset_transform = [{"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0, 1.0]}]
```

The convention would have these split as `multiscale = [0.4, 1.0, 1.0, 1.0, 1.0]; dataset = [1.0, 8.99991, 5.0, 0.3, 6.4]` instead.
In other words, the current output for single-scale OME-Zarr agrees with neither the spec, nor the convention.

Not good. We should follow the spec's phrasing (pixel size -> dataset-scale), not its examples (t-scale -> multiscale-transforms), and we definitely shouldn't do something supported by neither.

clearscale does detect specifically the t-scale convention, and roundtrips it when found. Outside of that convention, we now always write the pixel size for all axes to dataset-transforms.

This changes the assertion in:
* `test_pixel_sizes::test_write_ome_zarr_single_scale`  -- pixel size goes in dataset-transforms now
* (The diff in `testOpExportSlot::test_ome_zarr_single_scale` just adds an assert on the unchanged dataset-scale.)
* `testOpExportSlot::test_ome_zarr_roundtrip_multiscale` (new test added specifically to ensure the t-scale split roundtrips)
*  `test_write_ome_zarr`
   * `test_port_ome_zarr_metadata_single_scale_export` -- this test was obsolete ever since the pixel size PR, since the metadata now "roundtrips" by becoming pixel size slot meta, and the export using the slot meta as its source. Replaced with the next two.
   * `test_unscaled_single_scale_export_writes_crop_to_multiscale_transforms` -- pixel size goes in dataset-transforms now,...
   * `test_unscaled_single_scale_export_round_trips_t_convention` -- ...unless the input multiscale had t-scale in multiscale-transforms, then roundtrip
   * `test_resized_single_scale_export` -- similarly sort of obsolete since the pixel size PR. Pixel size is now written in dataset-transforms.
   * `test_port_ome_zarr_metadata_multi_scale_export` -- t-scale now also in dataset-transforms (just like the test's input meta)

### OME-Zarr `translation` metadata now maintains a clean separation between roundtripped translation and added crop-translation

As above, this concerns the semantics of dataset-transformations vs. multiscale-transformations.

When the user exports a subregion, the `translation` of the multiscale-transforms is a good place to express the exported dataset's shift relative to its parent dataset.
This is already status-quo and isn't changed in this PR.

If the input already had its own translation, previously this would be added to the translation of the multiscale-transforms. Dataset translation was always 0. (And the summing into multiscale-transforms could be numerically wrong if the same axis also had a non-1.0 scale transform...)

This now round-trips more exactly: translation in dataset-transforms stays in dataset-transforms, translation in multiscale-transforms stays in multiscale-transforms. Even if multiscale-transforms are identity (which previously would be dropped in the export), that is now round-tripped.

`testOpExportSlot::test_ome_zarr_roundtrip_multiscale`, the new test for the t-scale split roundtrip, also demonstrates how translations roundtrip. dataset-translation -> dataset-translation (identity in the test), multiscale-translation -> multiscale-translation.

Where this gets complicated is when an OME-Zarr input was using the t-scale split convention. Having a translation next to the scale on the multiscale-transforms is not expected in this convention, and is semantically poorly defined. When a dataset follows this convention, it implies that the multiscale-transforms are part of the multiscale's own coordinate system (because the dataset-transforms alone would leave the t-axis scaled to 1.0 units, seconds or whatever, which is almost certainly wrong). There is no room for an additional transform to some external reference space in this case, so we have to choose between (1) maintaining the convention in our export and discarding a crop-translation if there was one; or (2) writing our crop-translation and composing the global t-scale into each dataset-transform, thereby breaking the written export out of the convention. I think this is a niche enough edge case that what exactly we choose is unlikely to matter in practice. I've figured that if a user is working with datasets that use this convention, they might be in a workflow with other tools that rely on this convention. Then it would be more important that the outputs conform to the convention, than adding metadata that express "this dataset is shifted relative to some unknown external reference".

* `testOpExportSlot`
   * `test_ome_zarr_multi_scale` -- dataset-translation stays dataset-translation now, identity multiscale-transforms stay identity multiscale-transforms
   * `test_ome_zarr_roundtrip_multiscale` (new test added for the t-scale split roundtrip also checks translation roundtrip)
*  `test_write_ome_zarr`
   * `test_port_ome_zarr_metadata_single_scale_export` -- obsolete, replaced with the next two.
   * `test_unscaled_single_scale_export_writes_crop_to_multiscale_transforms` -- crop offset becomes translation inside multiscale-transforms; dataset-transforms now maintain the source dataset's translation instead of adding that onto the crop-translation
   * `test_unscaled_single_scale_export_t_scale_convention_overrides_storing_crop` -- ...unless the input multiscale had t-scale in multiscale-transforms, then we do not write the crop translation at all
   * `test_port_ome_zarr_metadata_multi_scale_export` -- source dataset translation goes into every output dataset, crop translation goes into multiscale-transforms

## Checklist

- [X] Format code and imports.
- [X] Add docstrings and comments.
- [X] Add tests.
- [X] Reference relevant issues and other pull requests.
- [X] Rebase commits into a logical sequence.
- (-) Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- (-) Add screenshots / screen recordings.
- [ ] After review: Publish clearscale to PyPI and conda-forge and update `dev/environment-dev.yml` and `meta.yaml`
