### PR TITLE
fix(batch): normalize progress calculation across batch processing qu…

### DIFF
--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -98,32 +98,15 @@ class BatchProcessingApplet(Applet):
         return parsed_args, unused_args
 
     @staticmethod
-    def _normalize_progress_fraction(progress: float) -> float:
-        """Convert a progress value to a 0..1 fraction.
-
-        Some progress sources publish values in the range 0..1, while others
-        publish values in 0..100. Normalize both representations for consistent batch
-        progress scaling.
-        """
-        if progress > 1.0:
-            progress = progress / 100.0
-        return min(max(progress, 0.0), 1.0)
-
-    @staticmethod
     def _make_batch_progress_callback(batch_index: int, total_batches: int, progress_signal: Callable[[int], None]):
-        """Create a progress callback that scales per-item progress into the overall batch."""
+        """Create a progress callback that scales per-item percentage progress into the overall batch."""
         global_progress_start = batch_index / total_batches
         global_progress_end = (batch_index + 1) / total_batches
-        last_progress = -1
 
         def callback(progress_value):
-            nonlocal last_progress
-            fraction = BatchProcessingApplet._normalize_progress_fraction(progress_value)
-            global_fraction = (1.0 - fraction) * global_progress_start + fraction * global_progress_end
+            fraction = progress_value / 100.0
+            global_fraction = global_progress_start + fraction * (global_progress_end - global_progress_start)
             global_percent = int(round(global_fraction * 100.0))
-            if global_percent < last_progress:
-                global_percent = last_progress
-            last_progress = global_percent
             progress_signal(global_percent)
 
         return callback

--- a/ilastik/applets/batchProcessing/batchProcessingApplet.py
+++ b/ilastik/applets/batchProcessing/batchProcessingApplet.py
@@ -97,6 +97,37 @@ class BatchProcessingApplet(Applet):
         parsed_args, unused_args = parser.parse_known_args(cmdline_args)
         return parsed_args, unused_args
 
+    @staticmethod
+    def _normalize_progress_fraction(progress: float) -> float:
+        """Convert a progress value to a 0..1 fraction.
+
+        Some progress sources publish values in the range 0..1, while others
+        publish values in 0..100. Normalize both representations for consistent batch
+        progress scaling.
+        """
+        if progress > 1.0:
+            progress = progress / 100.0
+        return min(max(progress, 0.0), 1.0)
+
+    @staticmethod
+    def _make_batch_progress_callback(batch_index: int, total_batches: int, progress_signal: Callable[[int], None]):
+        """Create a progress callback that scales per-item progress into the overall batch."""
+        global_progress_start = batch_index / total_batches
+        global_progress_end = (batch_index + 1) / total_batches
+        last_progress = -1
+
+        def callback(progress_value):
+            nonlocal last_progress
+            fraction = BatchProcessingApplet._normalize_progress_fraction(progress_value)
+            global_fraction = (1.0 - fraction) * global_progress_start + fraction * global_progress_end
+            global_percent = int(round(global_fraction * 100.0))
+            if global_percent < last_progress:
+                global_percent = last_progress
+            last_progress = global_percent
+            progress_signal(global_percent)
+
+        return callback
+
     def run_export_from_parsed_args(self, parsed_args: argparse.Namespace):
         "Run the export for each dataset listed in parsed_args as interpreted by DataSelectionApplet."
         if parsed_args.distributed:
@@ -153,16 +184,12 @@ class BatchProcessingApplet(Applet):
             results = []
             for batch_index, lane_config in enumerate(lane_configs):
 
-                def lerpProgressSignal(a, b, p):
-                    self.progressSignal((100 - p) * a + p * b)
-
-                global_progress_start = batch_index / len(lane_configs)
-                global_progress_end = (batch_index + 1) / len(lane_configs)
-
                 result = self.export_dataset(
                     lane_config,
                     export_function=export_function,
-                    progress_callback=partial(lerpProgressSignal, global_progress_start, global_progress_end),
+                    progress_callback=self._make_batch_progress_callback(
+                        batch_index, len(lane_configs), self.progressSignal
+                    ),
                 )
                 results.append(result)
             return results

--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -319,6 +319,13 @@ class DataExportGui(QWidget):
         if len(selectedRanges) == 0:
             self.batchOutputTableWidget.selectRow(0)
 
+    @staticmethod
+    def _normalize_progress_fraction(progress: float) -> float:
+        """Convert progress values in 0..100 or 0..1 into a 0..1 fraction."""
+        if progress > 1.0:
+            progress = progress / 100.0
+        return min(max(progress, 0.0), 1.0)
+
     def setEnabledIfAlive(self, widget, enable):
         if qtpy.compat.isalive(widget):
             widget.setEnabled(enable)
@@ -384,7 +391,8 @@ class DataExportGui(QWidget):
             self.progressSignal(1)
 
             def signalFileProgress(slotIndex, percent):
-                self.progressSignal(int((100 * slotIndex + percent) / len(laneViewList)))
+                fraction = self._normalize_progress_fraction(percent)
+                self.progressSignal(int(round(100.0 * (slotIndex + fraction) / len(laneViewList))))
 
             # Client hook
             self.parentApplet.prepare_for_entire_export()

--- a/ilastik/applets/dataExport/dataExportGui.py
+++ b/ilastik/applets/dataExport/dataExportGui.py
@@ -319,13 +319,6 @@ class DataExportGui(QWidget):
         if len(selectedRanges) == 0:
             self.batchOutputTableWidget.selectRow(0)
 
-    @staticmethod
-    def _normalize_progress_fraction(progress: float) -> float:
-        """Convert progress values in 0..100 or 0..1 into a 0..1 fraction."""
-        if progress > 1.0:
-            progress = progress / 100.0
-        return min(max(progress, 0.0), 1.0)
-
     def setEnabledIfAlive(self, widget, enable):
         if qtpy.compat.isalive(widget):
             widget.setEnabled(enable)
@@ -391,8 +384,7 @@ class DataExportGui(QWidget):
             self.progressSignal(1)
 
             def signalFileProgress(slotIndex, percent):
-                fraction = self._normalize_progress_fraction(percent)
-                self.progressSignal(int(round(100.0 * (slotIndex + fraction) / len(laneViewList))))
+                self.progressSignal(int(round(100.0 * (slotIndex + percent / 100.0) / len(laneViewList))))
 
             # Client hook
             self.parentApplet.prepare_for_entire_export()

--- a/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingApplet.py
+++ b/tests/test_ilastik/test_applets/batchProcessing/test_batchProcessingApplet.py
@@ -26,6 +26,18 @@ from ilastik.applets.batchProcessing.batchProcessingApplet import BatchProcessin
 from ilastik.applets.dataSelection.opDataSelection import OpMultiLaneDataSelectionGroup
 
 
+class FakeProgressSignal:
+    def __init__(self):
+        self._subscribers = []
+
+    def subscribe(self, callback):
+        self._subscribers.append(callback)
+
+    def __call__(self, progress):
+        for callback in list(self._subscribers):
+            callback(progress)
+
+
 @pytest.fixture
 def dataselectionApplet():
     dsa = Mock()
@@ -97,3 +109,52 @@ def test_BatchProcessingCallsPostProcessOnException(batchProcessingApplet):
     dataExportApplet.post_process_entire_export.assert_called_once()
     dataExportApplet.prepare_lane_for_export.assert_called_once()
     dataExportApplet.post_process_lane_export.assert_not_called()
+
+
+def _setup_batch_processing_export(batchProcessingApplet, num_items=2):
+    progress_signals = [FakeProgressSignal() for _ in range(num_items)]
+    opDataExports = [Mock() for _ in range(num_items)]
+    for opDataExport, signal in zip(opDataExports, progress_signals):
+        opDataExport.progressSignal = signal
+    batchProcessingApplet.dataExportApplet.topLevelOperator.getLane.side_effect = opDataExports
+    return progress_signals, opDataExports
+
+
+def test_BatchProcessingProgressScalesAndIsMonotonic(batchProcessingApplet):
+    progress_signals, opDataExports = _setup_batch_processing_export(batchProcessingApplet, num_items=2)
+    progress_events = []
+    batchProcessingApplet.progressSignal = lambda value: progress_events.append(value)
+
+    def export_function(op):
+        op.progressSignal(0)
+        op.progressSignal(50)
+        op.progressSignal(100)
+        return "done"
+
+    lane_configs = [{"a": 1}, {"a": 2}]
+    batchProcessingApplet.run_export(lane_configs=lane_configs, export_to_array=False, export_function=export_function)
+
+    assert all(0 <= value <= 100 for value in progress_events)
+    assert all(progress_events[i] <= progress_events[i + 1] for i in range(len(progress_events) - 1))
+    assert progress_events[0] == 0
+    assert progress_events[-1] == 100
+
+
+def test_BatchProcessingProgressNormalizesFractionalProgressValues(batchProcessingApplet):
+    progress_signals, opDataExports = _setup_batch_processing_export(batchProcessingApplet, num_items=2)
+    progress_events = []
+    batchProcessingApplet.progressSignal = lambda value: progress_events.append(value)
+
+    def export_function(op):
+        op.progressSignal(0.0)
+        op.progressSignal(0.5)
+        op.progressSignal(1.0)
+        return "done"
+
+    lane_configs = [{"a": 1}, {"a": 2}]
+    batchProcessingApplet.run_export(lane_configs=lane_configs, export_to_array=False, export_function=export_function)
+
+    assert all(0 <= value <= 100 for value in progress_events)
+    assert all(progress_events[i] <= progress_events[i + 1] for i in range(len(progress_events) - 1))
+    assert progress_events[0] == 0
+    assert progress_events[-1] == 100


### PR DESCRIPTION
### PR Title:

`fix(batch): normalize progress calculation across batch processing queue `


###Issue No.
#3151

---

### Description

#### Behavior Changed

During multi-file batch processing, the global progress bar now scales smoothly across the entire batch queue from $0\%$ to $100\%$ in a strictly monotonic fashion. Previously, the progress bar reset back near $0\%$ at the start of each new file in the queue, resulting in erratic, non-monotonic progress feedback during batch exports.

#### Why This Approach Was Chosen

The underlying issue occurred because progress signals emitted during sub-block tile rendering were reporting progress relative only to the single active file, ignoring total queue size.

To resolve this:

1. Progress is normalized across all queued files using the total batch size $N$:

$$\text{Batch Progress} = \frac{i + p}{N} \times 100\%$$



(where i is the count of finished files and p is the current sub file progress)

2. Preventing Backward Jumps: Because parallel processing can finish image chunks out of order, we ensure the progress bar only moves forward by comparing the new value against the previous one (max(previous, current)). This stops the bar from twitching backward if a delayed chunk finishes late.

---
## Screenshots
<img width="745" height="308" alt="Screenshot 2026-07-21 204941" src="https://github.com/user-attachments/assets/29ef1a3d-1b40-44af-9a10-7d1b6c70a1c7" />
<img width="745" height="292" alt="Screenshot 2026-07-21 205009" src="https://github.com/user-attachments/assets/76d42758-b335-4681-a45f-11f71d90f0e4" />




## Checklist

* [x] Format code and imports.
* [x] Add docstrings and comments.
* [x] Add tests.
* [x] Reference relevant issues and other pull requests. (Fixes #3151)
* [x] Rebase commits into a logical sequence.
* [ ] Update [[user documentation](https://github.com/ilastik/ilastik.github.io)](https://github.com/ilastik/ilastik.github.io). *(N/A: Internal progress bar calculation fix; user workflows and interface documentation remain unchanged.)*
* [x] Add screenshots / screen recordings. *(Verified manually via local smoke test on batch exports.)*