### PR TITLE
Fix watershed applet after deserialization (regression from numpy 2.x update)

### DIFF
--- a/ilastik/applets/wsdt/opWsdt.py
+++ b/ilastik/applets/wsdt/opWsdt.py
@@ -192,7 +192,7 @@ class OpWsdt(Operator):
             self.debug_results.clear()
 
         # distance_transform_watershed expects a default value of None for pixel_pitch.
-        if self.PixelPitch.value == []:
+        if len(self.PixelPitch.value) == 0:
             pixel_pitch_to_pass = None
         else:
             pixel_pitch_to_pass = self.PixelPitch.value


### PR DESCRIPTION
Make sure code path succeeds for both lists (which is the default) and numpy.ndarrays - after deserialization this slot will be an ndarray.

This broke multicut. I checked the repo for similar instances but have high hopes that his was the only point that list/ndarray mattered.

- [x] Format code and imports.
- [-] Add docstrings and comments.
- [-] Add tests.
- [-] Reference relevant issues and other pull requests.
- [x] Rebase commits into a logical sequence.
- [-] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [-] Add screenshots / screen recordings.
