### PR TITLE
Multiscale: Ensure scale select works when loading via Add New

### DIFF
--- a/ilastik/applets/dataSelection/dataSelectionApplet.py
+++ b/ilastik/applets/dataSelection/dataSelectionApplet.py
@@ -245,7 +245,7 @@ class DataSelectionApplet(Applet):
         if isUrl(url):
             return MultiscaleUrlDatasetInfo(url=url, axistags=axistags, project_file=self.project_file)
         else:
-            return RelativeFilesystemDatasetInfo.create_or_fallback_to_absolute(
+            return RelativeFilesystemDatasetInfo.create_or_dispatch(
                 filePath=str(Path(url).absolute()),
                 axistags=axistags,
                 sequence_axis=sequence_axis,

--- a/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
+++ b/ilastik/applets/dataSelection/datasetInfoEditorWidget.py
@@ -252,7 +252,7 @@ class DatasetInfoEditorWidget(QDialog):
                     filePath = info.effective_path
 
                 if new_internal_path and {new_internal_path} != set(info.internal_paths):
-                    edited_info = RelativeFilesystemDatasetInfo.create_or_fallback_to_absolute(
+                    edited_info = RelativeFilesystemDatasetInfo.create_or_dispatch(
                         filePath=filePath, project_file=self.serializer.topLevelOperator.ProjectFile.value
                     )
                     self.edited_infos.append(edited_info)

--- a/ilastik/applets/dataSelection/opDataSelection.py
+++ b/ilastik/applets/dataSelection/opDataSelection.py
@@ -66,6 +66,11 @@ class CantSaveAsRelativePathsException(Exception):
         super().__init__(f"Can't represent {file_path} relative to {base_dir}")
 
 
+class IsMultiscaleException(Exception):
+    def __init__(self):
+        super().__init__("File must be handled as multiscale URL")
+
+
 class InconsistentAxisMetaException(Exception):
     def __init__(self, axistags: AxisTags, shape):
         if len(axistags) > len(shape):
@@ -708,6 +713,8 @@ class FilesystemDatasetInfo(DatasetInfo):
         )
         meta = op_reader.Output.meta.copy()
         op_reader.cleanUp()
+        if meta.scales:
+            raise IsMultiscaleException()
         super().__init__(
             default_tags=meta.axistags,
             nickname=nickname or self.create_nickname(self.expanded_paths),
@@ -807,11 +814,19 @@ class RelativeFilesystemDatasetInfo(FilesystemDatasetInfo):
             raise CantSaveAsRelativePathsException(self.filePath, self.base_dir)
 
     @classmethod
-    def create_or_fallback_to_absolute(cls, *args, **kwargs):
+    def create_or_dispatch(cls, *args, **kwargs):
         try:
             return cls(*args, **kwargs)
         except CantSaveAsRelativePathsException:
             return FilesystemDatasetInfo(*args, **kwargs)
+        except IsMultiscaleException as e:
+            if "filePath" not in kwargs:
+                raise e
+            # DatasetInfo.__init__ doesn't like "filePath" and "sequence_axis"
+            acceptable_multiscale_kwargs = ("axistags", "project_file", "axistags")
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k in acceptable_multiscale_kwargs}
+            url = Path(kwargs["filePath"]).as_uri()
+            return MultiscaleUrlDatasetInfo(url=url, **filtered_kwargs)
 
     @property
     def display_string(self):

--- a/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
+++ b/tests/test_ilastik/test_applets/dataSelection/testDataSelectionGui.py
@@ -6,12 +6,18 @@ import platform
 from typing import Tuple, List
 from unittest import mock
 
+import numpy
 import pytest
+import vigra
 from qtpy.QtGui import QStandardItemModel, QStandardItem
 from qtpy.QtWidgets import QComboBox, QMessageBox
 
+from ilastik.applets.dataSelection import DataSelectionApplet
 from ilastik.applets.dataSelection.datasetDetailedInfoTableModel import DatasetColumn
 from ilastik.applets.dataSelection.datasetDetailedInfoTableView import DatasetDetailedInfoTableView
+from ilastik.applets.dataSelection.opDataSelection import MultiscaleUrlDatasetInfo
+from lazyflow.operator import Operator
+from lazyflow.operators.opArrayPiper import OpArrayPiper
 
 CI = os.environ.get("GITHUB_ACTIONS") or os.environ.get("APPVEYOR") or os.environ.get("ON_CIRCLE_CI")
 MAC = platform.system().lower() == "darwin"
@@ -209,3 +215,45 @@ def test_scale_select_disables_scale_options_not_available_in_other_roles(
                 lane,
                 str(enabled),
             ), f"scale option index {enabled} was supposed to be available"
+
+
+@pytest.fixture
+def data_selection_applet(tmp_path, graph):
+    workflow = Operator(graph=graph)
+    workflow.shell = mock.Mock()
+    workflow.handleNewLanesAdded = mock.Mock()
+
+    applet = DataSelectionApplet(workflow, "Input Data", "Input Data")
+    applet.topLevelOperator.DatasetRoles.setValue(["Raw Data"])
+    applet.topLevelOperator.WorkingDirectory.setValue(tmp_path)
+    return applet
+
+
+def test_add_files_adds_ome_zarr_as_multiscale_dataset(monkeypatch, graph, tmp_path, data_selection_applet):
+    ome_zarr_path = tmp_path / "test.ome.zarr"
+    ome_zarr_path.mkdir()
+    truthy_mock_scales = {"scale_key": object()}
+
+    def make_piper(*_args, parent=None, local_graph=graph, **_kwargs):
+        reader = OpArrayPiper(parent=parent, graph=local_graph)
+        reader.Input.setValue(numpy.zeros((3, 25, 25)))
+        reader.Output.meta.axistags = vigra.defaultAxistags("zyx")
+        reader.Output.meta.scales = truthy_mock_scales
+        return reader
+
+    monkeypatch.setattr("ilastik.applets.dataSelection.opDataSelection.OpInputDataReader", make_piper)
+    monkeypatch.setattr(QMessageBox, "critical", lambda *args: None)
+
+    monkeypatch.setattr(
+        "ilastik.applets.dataSelection.dataSelectionGui.ImageFileDialog.getSelectedPaths",
+        mock.Mock(return_value=[ome_zarr_path]),
+    )
+
+    gui = data_selection_applet.getMultiLaneGui()
+    gui.addFiles(roleIndex=0)
+    assert data_selection_applet.num_lanes == 1, "test setup failed - did not load dataset"
+
+    dataset_info = data_selection_applet.get_lane(0).get_dataset_info("Raw Data")
+
+    assert isinstance(dataset_info, MultiscaleUrlDatasetInfo), "datasets that load .scales should reroute to multiscale"
+    assert dataset_info.scales == truthy_mock_scales


### PR DESCRIPTION
Fixes #3236

Call chain:
```
DataSelectionGui.addFiles -> 
addFileNames -> 
instantiate_dataset_info -> 

DataSelectionApplet.create_dataset_info ->

if isUrl(path):
    MultiscaleUrlDatasetInfo(url=path, ...)
else:
    RelativeFilesystemDatasetInfo.create_or_fallback_to_absolute(filePath=path, ...)
```

`path` is not a URL via Add New, but due to #3162, the backend `OpInputDataReader` now recognises OME-Zarr even when RelativeFilesystemDatasetInfo gives it a regular file path. (Prior to that PR, Add New / drag-and-drop simply errored out.)

To make multiscale features work properly in this case, we make the else branch drop over into the MultiscaleUrl branch when the backend has detected that the dataset at the path actually is multiscale.

More costly in terms of number of requests, but when loading from the file system that seems pretty irrelevant for UX. Even when drag-and-dropping multiple scale levels together it's still fine:

https://github.com/user-attachments/assets/c870c4fb-ef94-48a2-8d8d-0fc214292685

**Genuine drawback to consider**: Since ilastik serializes the DatasetInfo, this fix approach does not fix the issue for existing project files that have been saved with the `FilesystemDatasetInfo`. It only makes sure new project files reroute to adding all ome-zarrs as `MultiscaleUrlDatasetInfo`. We can alternatively move the multiscale props and methods to the base `DatasetInfo`, but I feel that would muddle things up even more than they already are. If anyone loaded multiscale datasets this way and accepted the bug by saving the project file... then I guess they were ok with it?

## Checklist

- [X] Format code and imports.
- [X] Add docstrings and comments.
- [x] Add tests.
- [X] Reference relevant issues and other pull requests.
- [X] Rebase commits into a logical sequence.
- [X] Update [user documentation](https://github.com/ilastik/ilastik.github.io) -> https://github.com/ilastik/ilastik.github.io/pull/351
- [X] Add screenshots / screen recordings.
