### PR TITLE
AWS creds dialog: Add note to restart ilastik

### DIFF
--- a/ilastik/shell/gui/awsCredentialsDialog.py
+++ b/ilastik/shell/gui/awsCredentialsDialog.py
@@ -54,6 +54,7 @@ class AwsCredentialsDialog(QDialog):
 
         self._fields = []
 
+        self.creds_path = _get_creds_path()
         self.setup_ui()
         self.load_existing_credentials()
         self.connect_validation()
@@ -63,16 +64,6 @@ class AwsCredentialsDialog(QDialog):
 
     def setup_ui(self):
         layout = QVBoxLayout(self)
-
-        if _get_creds_path().exists():
-            warning_label = QLabel(
-                "<p>Warning: This modifies your user-wide AWS credentials file at <br>"
-                f"<b>{_get_creds_path()}</b>"
-                "</p><p>If something goes wrong, look for .bak files in the same folder.</p>"
-            )
-            warning_label.setWordWrap(True)
-            layout.addWidget(warning_label)
-
         form = QFormLayout()
 
         profile_label = QLabel("Profile")
@@ -93,6 +84,17 @@ class AwsCredentialsDialog(QDialog):
         form.addRow(secret_key_label, secret_layout)
 
         layout.addLayout(form)
+
+        if self.creds_path.exists():
+            file_label = QLabel(
+                "<p>Warning: Clicking Ok will modify your user-wide AWS credentials file at <br>"
+                f"<b>{self.creds_path}</b>"
+                "</p><p>If something goes wrong, look for backup copies (.bak) in the same folder.</p>"
+            )
+        else:
+            file_label = QLabel(f"<p>Clicking Ok will create the credentials file at <b>{self.creds_path}</b></p>")
+        layout.addWidget(file_label)
+        layout.addWidget(QLabel("<p>Note: You must <b>restart ilastik</b> for changes to take effect.</p>"))
 
         self._fields = [self.profile_input, self.access_key_input, self.secret_key_input]
 
@@ -124,13 +126,12 @@ class AwsCredentialsDialog(QDialog):
         self.ok_button.setEnabled(all_valid)
 
     def load_existing_credentials(self):
-        creds_path = _get_creds_path()
-        if not creds_path.exists():
+        if not self.creds_path.exists():
             self.profile_input.setText("default")
             return
 
         config = configparser.ConfigParser()
-        config.read(creds_path)
+        config.read(self.creds_path)
 
         if "default" in config:
             profile = "default"
@@ -146,7 +147,7 @@ class AwsCredentialsDialog(QDialog):
         access_key = self.access_key_input.text().strip()
         secret_key = self.secret_key_input.text().strip()
 
-        creds_path = _get_creds_path()
+        creds_path = self.creds_path
         backup_path = creds_path.parent / "credentials.bak"
         i = 1
         while backup_path.exists():

--- a/tests/test_ilastik/test_shell/test_aws_credentials_dialog.py
+++ b/tests/test_ilastik/test_shell/test_aws_credentials_dialog.py
@@ -8,8 +8,9 @@ from ilastik.shell.gui.awsCredentialsDialog import AwsCredentialsDialog
 
 
 @pytest.fixture
-def dialog(qtbot):
-    dlg = AwsCredentialsDialog()
+def dialog(qtbot, tmp_path):
+    with patch("pathlib.Path.home", return_value=tmp_path):
+        dlg = AwsCredentialsDialog()
     qtbot.addWidget(dlg)
     qtbot.waitExposed(dlg)
     return dlg
@@ -39,11 +40,10 @@ def test_loads_existing_credentials(dialog, tmp_path, aws_dir):
     with open(creds_path, "w") as f:
         config.write(f)
 
-    with patch("pathlib.Path.home", return_value=tmp_path):
-        dialog.load_existing_credentials()
-        assert dialog.profile_input.text() == "default"
-        assert dialog.access_key_input.text() == "test_key"
-        assert dialog.secret_key_input.text() == "test_secret"
+    dialog.load_existing_credentials()
+    assert dialog.profile_input.text() == "default"
+    assert dialog.access_key_input.text() == "test_key"
+    assert dialog.secret_key_input.text() == "test_secret"
 
 
 def test_on_ok_creates_backup_and_writes_credentials(dialog, qtbot, tmp_path, aws_dir):
@@ -56,20 +56,19 @@ def test_on_ok_creates_backup_and_writes_credentials(dialog, qtbot, tmp_path, aw
     with open(creds_path, "w") as f:
         config.write(f)
 
-    with patch("pathlib.Path.home", return_value=tmp_path):
-        dialog.profile_input.setText("test_profile")
-        dialog.access_key_input.setText("new_key")
-        dialog.secret_key_input.setText("new_secret")
+    dialog.profile_input.setText("test_profile")
+    dialog.access_key_input.setText("new_key")
+    dialog.secret_key_input.setText("new_secret")
 
-        qtbot.mouseClick(dialog.ok_button, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(dialog.ok_button, Qt.MouseButton.LeftButton)
 
-        backup_files = list(aws_dir.glob("credentials.bak*"))
-        assert len(backup_files) == 1
+    backup_files = list(aws_dir.glob("credentials.bak*"))
+    assert len(backup_files) == 1
 
-        new_config = configparser.ConfigParser()
-        new_config.read(creds_path)
-        assert new_config["test_profile"]["aws_access_key_id"] == "new_key"
-        assert new_config["test_profile"]["aws_secret_access_key"] == "new_secret"
+    new_config = configparser.ConfigParser()
+    new_config.read(creds_path)
+    assert new_config["test_profile"]["aws_access_key_id"] == "new_key"
+    assert new_config["test_profile"]["aws_secret_access_key"] == "new_secret"
 
 
 def test_modify_alternative_profile(dialog, qtbot, tmp_path, aws_dir):
@@ -87,19 +86,18 @@ def test_modify_alternative_profile(dialog, qtbot, tmp_path, aws_dir):
     with open(creds_path, "w") as f:
         config.write(f)
 
-    with patch("pathlib.Path.home", return_value=tmp_path):
-        dialog.load_existing_credentials()
-        dialog.profile_input.setText("alt_profile")
-        dialog.access_key_input.setText("new_alt_key")
-        dialog.secret_key_input.setText("new_alt_secret")
+    dialog.load_existing_credentials()
+    dialog.profile_input.setText("alt_profile")
+    dialog.access_key_input.setText("new_alt_key")
+    dialog.secret_key_input.setText("new_alt_secret")
 
-        qtbot.mouseClick(dialog.ok_button, Qt.MouseButton.LeftButton)
+    qtbot.mouseClick(dialog.ok_button, Qt.MouseButton.LeftButton)
 
-        new_config = configparser.ConfigParser()
-        new_config.read(creds_path)
-        assert new_config["default"] == default_config
-        assert new_config["alt_profile"]["aws_access_key_id"] == "new_alt_key"
-        assert new_config["alt_profile"]["aws_secret_access_key"] == "new_alt_secret"
+    new_config = configparser.ConfigParser()
+    new_config.read(creds_path)
+    assert new_config["default"] == default_config
+    assert new_config["alt_profile"]["aws_access_key_id"] == "new_alt_key"
+    assert new_config["alt_profile"]["aws_secret_access_key"] == "new_alt_secret"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Just a tiny text change in the AWS credentials dialog. While updating docs, I realised we should probably inform users they need to restart ilastik in the dialog, not just in the docs.

Dialog when no creds file exists:
<img width="315" height="160" alt="image" src="https://github.com/user-attachments/assets/b1dc8462-ce7a-4ed0-9a26-a2e55087b267" />

Dialog when file exists:
<img width="305" height="195" alt="image" src="https://github.com/user-attachments/assets/4b3e5e73-43b0-4b8e-933e-d92cc79cb237" />


## Checklist

- [X] Format code and imports.
- ( )Add docstrings and comments.
- ( ) Add tests.
- ( ) Reference relevant issues and other pull requests.
- ( ) Rebase commits into a logical sequence.
- ( ) Update [user documentation](https://github.com/ilastik/ilastik.github.io)
- [X] Add screenshots / screen recordings.
