### PR TITLE
Fix overlooked passing of numpy types to qt

### DIFF
--- a/ilastik/applets/neuralNetwork/nnClassGui.py
+++ b/ilastik/applets/neuralNetwork/nnClassGui.py
@@ -58,6 +58,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from ilastik.utility.gui.qtcompat import ensure_bool
 from tiktorch.configkeys import NUM_ITERATIONS_DONE, NUM_ITERATIONS_MAX, TRAINING
 from tiktorch.types import ModelState
 from volumina.api import AlphaModulatedLayer, LazyflowSource
@@ -833,7 +834,7 @@ class NNClassGui(LabelingGui):
             self._viewerControlUi.checkShowPredictions.setChecked(False)
             self.handleShowPredictionsClicked()
 
-        self._viewerControlUi.checkShowPredictions.setEnabled(enabled)
+        self._viewerControlUi.checkShowPredictions.setEnabled(ensure_bool(enabled))
 
     def _getNext(self, slot, parentFun, transform=None):
         numLabels = self.labelListData.rowCount()


### PR DESCRIPTION
related to: 70167e8403f34c3fb46780e26d79814041e6a120

<!-- Thank you very much for opening a PR!

     Please read CONTRIBUTING.md, and ask if you're not sure about anything :)

     Your PR description should include what *behavior* you changed, and how this improves ilastik.
     If your PR addresses a GitHub issue, a clear title and a link to the issue can be sufficient.
     Don't describe what *code* you changed - we can see your code changes.
     Do explain *why* you chose to go about it as you did.-->

## Checklist

<!-- Check off the items in this list to show your PR meets our guidelines.
     Some items might not be applicable.
     Leave these unchecked and add a few words to explain why.
-->

- [ ] Format code and imports.
- [ ] Add docstrings and comments.
- [ ] Add tests.
- [ ] Reference relevant issues and other pull requests.
- [ ] Rebase commits into a logical sequence.
- [ ] Update [user documentation](https://github.com/ilastik/ilastik.github.io).
- [ ] Add screenshots / screen recordings.

followup to #3230 
